### PR TITLE
3.1.0 - Dev

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -24,7 +24,7 @@
 
 <!-- How did you verify the change works? -->
 
-- [ ] Ran `python -m pytest tests/unit/ tests/integration/` — all pass
+- [ ] Ran `MOLEDITPY_HEADLESS=1 QT_QPA_PLATFORM=offscreen python tests/run_all_tests.py --no-cov --no-report --unit --integration` — all pass
 - [ ] Manually tested in the GUI (describe what you tested below)
 - [ ] Added new unit tests
 

--- a/moleditpy-linux/pyproject.toml
+++ b/moleditpy-linux/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "MoleditPy-linux"
 
-version = "3.0.6"
+version = "3.1.0"
 
 license = {file = "LICENSE"}
 

--- a/moleditpy-linux/src/moleditpy_linux/ui/app_state.py
+++ b/moleditpy-linux/src/moleditpy_linux/ui/app_state.py
@@ -364,9 +364,9 @@ class StateManager:
             # 'Save As' if not PMEPRJ
             file_path = self.host.init_manager.current_file_path
             if not file_path or not file_path.lower().endswith(".pmeprj"):
-                self.save_project_as()
+                self.host.io_manager.save_project_as()
             else:
-                self.save_project()
+                self.host.io_manager.save_project()
             return (
                 not self.host.state_manager.has_unsaved_changes
             )  # Return True only if save was successful

--- a/moleditpy-linux/src/moleditpy_linux/ui/dialog_logic.py
+++ b/moleditpy-linux/src/moleditpy_linux/ui/dialog_logic.py
@@ -200,10 +200,6 @@ class DialogManager:
             with open(filepath, "w", encoding="utf-8") as f:
                 json.dump(template_data, f, indent=2, ensure_ascii=False)
 
-            # Mark as saved (no unsaved changes for this operation)
-            self.host.state_manager.has_unsaved_changes = False
-            self.host.state_manager.update_window_title()
-
             QMessageBox.information(
                 self.host, "Success", f"Template '{name}' saved successfully."
             )

--- a/moleditpy-linux/src/moleditpy_linux/ui/io_logic.py
+++ b/moleditpy-linux/src/moleditpy_linux/ui/io_logic.py
@@ -564,10 +564,7 @@ class IOManager:
             self.host.statusBar().showMessage(f"Export error: {e}")
 
     def load_mol_file(self, file_path: Optional[str] = None) -> None:
-        """Regular 2D MOL file loading logic."""
-        if not self.host.state_manager.check_unsaved_changes():
-            return
-
+        """Import a MOL/SDF file and add its contents to the 2D editor."""
         if not file_path:
             default_dir = (
                 os.path.dirname(self.host.init_manager.current_file_path)
@@ -601,11 +598,6 @@ class IOManager:
                 raise ValueError("Failed to read molecule from file.")
 
             Chem.Kekulize(mol)
-            self.host.ui_manager.restore_ui_for_editing()
-            self.host.edit_actions_manager.clear_2d_editor(push_to_undo=False)
-            self.host.view_3d_manager.current_mol = None
-            self.host.view_3d_manager.plotter.clear()
-            self.host.init_manager.analysis_action.setEnabled(False)
 
             if mol.GetNumConformers() == 0:
                 AllChem.Compute2DCoords(mol)
@@ -615,9 +607,22 @@ class IOManager:
             AllChem.WedgeMolBonds(mol, conf)
 
             SCALE_FACTOR = 50.0
-            view_center = self.host.init_manager.view_2d.mapToScene(
-                self.host.init_manager.view_2d.viewport().rect().center()
-            )
+            existing_atoms = self.host.state_manager.data.atoms
+            if existing_atoms:
+                max_x = max(
+                    v["pos"].x() if hasattr(v["pos"], "x") else v["pos"][0]
+                    for v in existing_atoms.values()
+                )
+                avg_y = sum(
+                    v["pos"].y() if hasattr(v["pos"], "y") else v["pos"][1]
+                    for v in existing_atoms.values()
+                ) / len(existing_atoms)
+                place_center = QPointF(max_x + 80.0, avg_y)
+            else:
+                place_center = self.host.init_manager.view_2d.mapToScene(
+                    self.host.init_manager.view_2d.viewport().rect().center()
+                )
+
             positions = [conf.GetAtomPosition(i) for i in range(mol.GetNumAtoms())]
             mol_center_x = (
                 sum(p.x for p in positions) / len(positions) if positions else 0.0
@@ -630,8 +635,8 @@ class IOManager:
             for i in range(mol.GetNumAtoms()):
                 atom = mol.GetAtomWithIdx(i)
                 pos = conf.GetAtomPosition(i)
-                scene_x = ((pos.x - mol_center_x) * SCALE_FACTOR) + view_center.x()
-                scene_y = (-(pos.y - mol_center_y) * SCALE_FACTOR) + view_center.y()
+                scene_x = ((pos.x - mol_center_x) * SCALE_FACTOR) + place_center.x()
+                scene_y = (-(pos.y - mol_center_y) * SCALE_FACTOR) + place_center.y()
                 atom_id = self.host.init_manager.scene.create_atom(
                     atom.GetSymbol(),
                     QPointF(scene_x, scene_y),
@@ -662,18 +667,9 @@ class IOManager:
                     bond_stereo=stereo,
                 )
 
-            self.host.statusBar().showMessage(f"Successfully loaded {file_path}")
-            self.host.state_manager.reset_undo_stack()
-            self.host.init_manager.current_file_path = file_path
-            self.host.state_manager.has_unsaved_changes = False
-            self.host.state_manager.update_window_title()
+            self.host.statusBar().showMessage(f"Successfully imported {file_path}")
             self.host.init_manager.scene.update_all_items()
-
-            # Reset camera/zoom after drawing
-            QTimer.singleShot(
-                50, lambda: self.host.view_3d_manager.plotter.view_isometric()
-            )
-            QTimer.singleShot(100, lambda: self.host.view_3d_manager.plotter.render())
+            self.host.edit_actions_manager.push_undo_state()
             QTimer.singleShot(100, self.host.view_3d_manager.fit_to_view)
         except Exception as e:
             self.host.statusBar().showMessage(f"Error loading file: {e}")

--- a/moleditpy-linux/src/moleditpy_linux/ui/string_importers.py
+++ b/moleditpy-linux/src/moleditpy_linux/ui/string_importers.py
@@ -52,11 +52,83 @@ class StringImporterManager:
         if ok and inchi:
             self.load_from_inchi(inchi)
 
-    def load_from_smiles(self, smiles_string: str) -> None:
-        """Load molecule from SMILES string to 2D editor."""
-        if not self.host.state_manager.check_unsaved_changes():
-            return  # User cancelled
+    def _placement_center(self) -> QPointF:
+        """Return the scene point where the next imported molecule should be centered.
 
+        If the editor already contains atoms, offset to the right of the
+        rightmost atom so the new fragment does not overlap.  Otherwise use
+        the current viewport center.
+        """
+        existing = self.host.state_manager.data.atoms
+        if existing:
+
+            def _x(v):
+                return v["pos"].x() if hasattr(v["pos"], "x") else v["pos"][0]
+
+            def _y(v):
+                return v["pos"].y() if hasattr(v["pos"], "y") else v["pos"][1]
+
+            max_x = max(_x(v) for v in existing.values())
+            avg_y = sum(_y(v) for v in existing.values()) / len(existing)
+            return QPointF(max_x + 80.0, avg_y)
+
+        return self.host.init_manager.view_2d.mapToScene(
+            self.host.init_manager.view_2d.viewport().rect().center()
+        )
+
+    def _place_mol_bonds(self, mol, rdkit_idx_to_my_id: dict) -> None:
+        """Create bonds in the 2D scene from an RDKit molecule."""
+        for bond in mol.GetBonds():
+            b_idx, e_idx = bond.GetBeginAtomIdx(), bond.GetEndAtomIdx()
+            b_type = bond.GetBondTypeAsDouble()
+            b_dir = bond.GetBondDir()
+            stereo = 0
+            if b_dir == Chem.BondDir.BEGINWEDGE:
+                stereo = 1
+            elif b_dir == Chem.BondDir.BEGINDASH:
+                stereo = 2
+            if bond.GetBondType() == Chem.BondType.DOUBLE:
+                if bond.GetStereo() == Chem.BondStereo.STEREOZ:
+                    stereo = 3
+                elif bond.GetStereo() == Chem.BondStereo.STEREOE:
+                    stereo = 4
+
+            if b_idx in rdkit_idx_to_my_id and e_idx in rdkit_idx_to_my_id:
+                a1_id = rdkit_idx_to_my_id[b_idx]
+                a2_id = rdkit_idx_to_my_id[e_idx]
+                a1_item = self.host.state_manager.data.atoms[a1_id]["item"]
+                a2_item = self.host.state_manager.data.atoms[a2_id]["item"]
+                self.host.init_manager.scene.create_bond(
+                    a1_item, a2_item, bond_order=int(b_type), bond_stereo=stereo
+                )
+
+    def _place_mol_atoms(self, mol, conf, place_center: QPointF) -> dict:
+        """Create atoms in the 2D scene and return rdkit_idx → atom_id mapping."""
+        SCALE_FACTOR = 50.0
+        positions = [conf.GetAtomPosition(i) for i in range(mol.GetNumAtoms())]
+        mol_center_x = (
+            sum(p.x for p in positions) / len(positions) if positions else 0.0
+        )
+        mol_center_y = (
+            sum(p.y for p in positions) / len(positions) if positions else 0.0
+        )
+
+        rdkit_idx_to_my_id = {}
+        for i in range(mol.GetNumAtoms()):
+            atom = mol.GetAtomWithIdx(i)
+            pos = conf.GetAtomPosition(i)
+            scene_x = ((pos.x - mol_center_x) * SCALE_FACTOR) + place_center.x()
+            scene_y = (-(pos.y - mol_center_y) * SCALE_FACTOR) + place_center.y()
+            atom_id = self.host.init_manager.scene.create_atom(
+                atom.GetSymbol(),
+                QPointF(scene_x, scene_y),
+                charge=atom.GetFormalCharge(),
+            )
+            rdkit_idx_to_my_id[i] = atom_id
+        return rdkit_idx_to_my_id
+
+    def load_from_smiles(self, smiles_string: str) -> None:
+        """Add a molecule from a SMILES string to the 2D editor."""
         cleaned_smiles = smiles_string.strip()
 
         try:
@@ -68,7 +140,6 @@ class StringImporterManager:
 
             AllChem.Compute2DCoords(mol)
             Chem.Kekulize(mol)
-
             AllChem.AssignStereochemistry(mol, cleanIt=True, force=True)
             conf = mol.GetConformer()
             AllChem.WedgeMolBonds(mol, conf)
@@ -80,83 +151,22 @@ class StringImporterManager:
             return
 
         try:
-            self.host.ui_manager.restore_ui_for_editing()
-            self.host.edit_actions_manager.clear_2d_editor(push_to_undo=False)
-            self.host.view_3d_manager.current_mol = None
-            self.host.view_3d_manager.plotter.clear()
-            self.host.init_manager.analysis_action.setEnabled(False)
-
-            conf = mol.GetConformer()
-            SCALE_FACTOR = 50.0
-
-            view_center = self.host.init_manager.view_2d.mapToScene(
-                self.host.init_manager.view_2d.viewport().rect().center()
+            place_center = self._placement_center()
+            rdkit_idx_to_my_id = self._place_mol_atoms(
+                mol, mol.GetConformer(), place_center
             )
-            positions = [conf.GetAtomPosition(i) for i in range(mol.GetNumAtoms())]
-            mol_center_x = (
-                sum(p.x for p in positions) / len(positions) if positions else 0.0
-            )
-            mol_center_y = (
-                sum(p.y for p in positions) / len(positions) if positions else 0.0
-            )
-
-            rdkit_idx_to_my_id = {}
-            for i in range(mol.GetNumAtoms()):
-                atom = mol.GetAtomWithIdx(i)
-                pos = conf.GetAtomPosition(i)
-                charge = atom.GetFormalCharge()
-
-                relative_x = pos.x - mol_center_x
-                relative_y = pos.y - mol_center_y
-
-                scene_x = (relative_x * SCALE_FACTOR) + view_center.x()
-                scene_y = (-relative_y * SCALE_FACTOR) + view_center.y()
-
-                atom_id = self.host.init_manager.scene.create_atom(
-                    atom.GetSymbol(), QPointF(scene_x, scene_y), charge=charge
-                )
-                rdkit_idx_to_my_id[i] = atom_id
-
-            for bond in mol.GetBonds():
-                b_idx, e_idx = bond.GetBeginAtomIdx(), bond.GetEndAtomIdx()
-                b_type = bond.GetBondTypeAsDouble()
-                b_dir = bond.GetBondDir()
-                stereo = 0
-                # Single bond stereo
-                if b_dir == Chem.BondDir.BEGINWEDGE:
-                    stereo = 1  # Wedge
-                elif b_dir == Chem.BondDir.BEGINDASH:
-                    stereo = 2  # Dash
-                # Double bond E/Z
-                if bond.GetBondType() == Chem.BondType.DOUBLE:
-                    if bond.GetStereo() == Chem.BondStereo.STEREOZ:
-                        stereo = 3  # Z
-                    elif bond.GetStereo() == Chem.BondStereo.STEREOE:
-                        stereo = 4  # E
-
-                if b_idx in rdkit_idx_to_my_id and e_idx in rdkit_idx_to_my_id:
-                    a1_id, a2_id = rdkit_idx_to_my_id[b_idx], rdkit_idx_to_my_id[e_idx]
-                    a1_item = self.host.state_manager.data.atoms[a1_id]["item"]
-                    a2_item = self.host.state_manager.data.atoms[a2_id]["item"]
-                    self.host.init_manager.scene.create_bond(
-                        a1_item, a2_item, bond_order=int(b_type), bond_stereo=stereo
-                    )
+            self._place_mol_bonds(mol, rdkit_idx_to_my_id)
 
             self.host.statusBar().showMessage("Successfully loaded from SMILES.")
             self.host.init_manager.scene.update_all_items()
-            self.host.state_manager.reset_undo_stack()
-            self.host.state_manager.has_unsaved_changes = False
-            self.host.state_manager.update_window_title()
+            self.host.edit_actions_manager.push_undo_state()
             QTimer.singleShot(0, self.host.view_3d_manager.fit_to_view)
 
         except (AttributeError, RuntimeError, ValueError, TypeError) as e:
             self.host.statusBar().showMessage(f"Error loading from SMILES: {e}")
 
     def load_from_inchi(self, inchi_string: str) -> None:
-        """Load molecule from InChI string to 2D editor."""
-        if not self.host.state_manager.check_unsaved_changes():
-            return  # User cancelled
-
+        """Add a molecule from an InChI string to the 2D editor."""
         cleaned_inchi = inchi_string.strip()
 
         try:
@@ -168,7 +178,6 @@ class StringImporterManager:
 
             AllChem.Compute2DCoords(mol)
             Chem.Kekulize(mol)
-
             AllChem.AssignStereochemistry(mol, cleanIt=True, force=True)
             conf = mol.GetConformer()
             AllChem.WedgeMolBonds(mol, conf)
@@ -180,73 +189,15 @@ class StringImporterManager:
             return
 
         try:
-            self.host.ui_manager.restore_ui_for_editing()
-            self.host.edit_actions_manager.clear_2d_editor(push_to_undo=False)
-            self.host.view_3d_manager.current_mol = None
-            self.host.view_3d_manager.plotter.clear()
-            self.host.init_manager.analysis_action.setEnabled(False)
-
-            conf = mol.GetConformer()
-            SCALE_FACTOR = 50.0
-
-            view_center = self.host.init_manager.view_2d.mapToScene(
-                self.host.init_manager.view_2d.viewport().rect().center()
+            place_center = self._placement_center()
+            rdkit_idx_to_my_id = self._place_mol_atoms(
+                mol, mol.GetConformer(), place_center
             )
-            positions = [conf.GetAtomPosition(i) for i in range(mol.GetNumAtoms())]
-            mol_center_x = (
-                sum(p.x for p in positions) / len(positions) if positions else 0.0
-            )
-            mol_center_y = (
-                sum(p.y for p in positions) / len(positions) if positions else 0.0
-            )
-
-            rdkit_idx_to_my_id = {}
-            for i in range(mol.GetNumAtoms()):
-                atom = mol.GetAtomWithIdx(i)
-                pos = conf.GetAtomPosition(i)
-                charge = atom.GetFormalCharge()
-
-                relative_x = pos.x - mol_center_x
-                relative_y = pos.y - mol_center_y
-
-                scene_x = (relative_x * SCALE_FACTOR) + view_center.x()
-                scene_y = (-relative_y * SCALE_FACTOR) + view_center.y()
-
-                atom_id = self.host.init_manager.scene.create_atom(
-                    atom.GetSymbol(), QPointF(scene_x, scene_y), charge=charge
-                )
-                rdkit_idx_to_my_id[i] = atom_id
-
-            for bond in mol.GetBonds():
-                b_idx, e_idx = bond.GetBeginAtomIdx(), bond.GetEndAtomIdx()
-                b_type = bond.GetBondTypeAsDouble()
-                b_dir = bond.GetBondDir()
-                stereo = 0
-                # Single bond stereo
-                if b_dir == Chem.BondDir.BEGINWEDGE:
-                    stereo = 1  # Wedge
-                elif b_dir == Chem.BondDir.BEGINDASH:
-                    stereo = 2  # Dash
-                # Double bond E/Z
-                if bond.GetBondType() == Chem.BondType.DOUBLE:
-                    if bond.GetStereo() == Chem.BondStereo.STEREOZ:
-                        stereo = 3  # Z
-                    elif bond.GetStereo() == Chem.BondStereo.STEREOE:
-                        stereo = 4  # E
-
-                if b_idx in rdkit_idx_to_my_id and e_idx in rdkit_idx_to_my_id:
-                    a1_id, a2_id = rdkit_idx_to_my_id[b_idx], rdkit_idx_to_my_id[e_idx]
-                    a1_item = self.host.state_manager.data.atoms[a1_id]["item"]
-                    a2_item = self.host.state_manager.data.atoms[a2_id]["item"]
-                    self.host.init_manager.scene.create_bond(
-                        a1_item, a2_item, bond_order=int(b_type), bond_stereo=stereo
-                    )
+            self._place_mol_bonds(mol, rdkit_idx_to_my_id)
 
             self.host.statusBar().showMessage("Successfully loaded from InChI.")
             self.host.init_manager.scene.update_all_items()
-            self.host.state_manager.reset_undo_stack()
-            self.host.state_manager.has_unsaved_changes = False
-            self.host.state_manager.update_window_title()
+            self.host.edit_actions_manager.push_undo_state()
             QTimer.singleShot(0, self.host.view_3d_manager.fit_to_view)
 
         except (AttributeError, RuntimeError, ValueError, TypeError) as e:

--- a/moleditpy-linux/src/moleditpy_linux/ui/user_template_dialog.py
+++ b/moleditpy-linux/src/moleditpy_linux/ui/user_template_dialog.py
@@ -634,10 +634,6 @@ class UserTemplateDialog(QDialog):
                     return
 
             if self.save_template_file(filepath, template_data):
-                # Mark main window as saved
-                self.main_window.state_manager.has_unsaved_changes = False
-                self.main_window.state_manager.update_window_title()
-
                 QMessageBox.information(
                     self, "Success", f"Template '{name}' saved successfully."
                 )

--- a/moleditpy-linux/src/moleditpy_linux/ui/view_3d_logic.py
+++ b/moleditpy-linux/src/moleditpy_linux/ui/view_3d_logic.py
@@ -282,8 +282,9 @@ class View3DManager:
         self.host.view_3d_manager.plotter.camera_position = camera_state
 
         # Update projection mode and force render
-        settings = getattr(self, "settings", {})
-        proj_mode = settings.get("projection_mode", "Perspective")
+        proj_mode = self.host.init_manager.settings.get(
+            "projection_mode", "Perspective"
+        )
         if hasattr(self.host.view_3d_manager.plotter, "renderer") and hasattr(
             self.host.view_3d_manager.plotter.renderer, "GetActiveCamera"
         ):

--- a/moleditpy-linux/src/moleditpy_linux/utils/constants.py
+++ b/moleditpy-linux/src/moleditpy_linux/utils/constants.py
@@ -16,7 +16,7 @@ from PyQt6.QtGui import QColor, QFont
 from rdkit import Chem
 
 # Version
-VERSION = "3.0.6"
+VERSION = "3.1.0"
 
 ATOM_RADIUS = 18
 BOND_OFFSET = 3.5

--- a/moleditpy/pyproject.toml
+++ b/moleditpy/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "MoleditPy"
 
-version = "3.0.6"
+version = "3.1.0"
 
 license = {file = "LICENSE"}
 

--- a/moleditpy/src/moleditpy/ui/app_state.py
+++ b/moleditpy/src/moleditpy/ui/app_state.py
@@ -364,9 +364,9 @@ class StateManager:
             # 'Save As' if not PMEPRJ
             file_path = self.host.init_manager.current_file_path
             if not file_path or not file_path.lower().endswith(".pmeprj"):
-                self.save_project_as()
+                self.host.io_manager.save_project_as()
             else:
-                self.save_project()
+                self.host.io_manager.save_project()
             return (
                 not self.host.state_manager.has_unsaved_changes
             )  # Return True only if save was successful

--- a/moleditpy/src/moleditpy/ui/dialog_logic.py
+++ b/moleditpy/src/moleditpy/ui/dialog_logic.py
@@ -200,10 +200,6 @@ class DialogManager:
             with open(filepath, "w", encoding="utf-8") as f:
                 json.dump(template_data, f, indent=2, ensure_ascii=False)
 
-            # Mark as saved (no unsaved changes for this operation)
-            self.host.state_manager.has_unsaved_changes = False
-            self.host.state_manager.update_window_title()
-
             QMessageBox.information(
                 self.host, "Success", f"Template '{name}' saved successfully."
             )

--- a/moleditpy/src/moleditpy/ui/io_logic.py
+++ b/moleditpy/src/moleditpy/ui/io_logic.py
@@ -564,10 +564,7 @@ class IOManager:
             self.host.statusBar().showMessage(f"Export error: {e}")
 
     def load_mol_file(self, file_path: Optional[str] = None) -> None:
-        """Regular 2D MOL file loading logic."""
-        if not self.host.state_manager.check_unsaved_changes():
-            return
-
+        """Import a MOL/SDF file and add its contents to the 2D editor."""
         if not file_path:
             default_dir = (
                 os.path.dirname(self.host.init_manager.current_file_path)
@@ -601,11 +598,6 @@ class IOManager:
                 raise ValueError("Failed to read molecule from file.")
 
             Chem.Kekulize(mol)
-            self.host.ui_manager.restore_ui_for_editing()
-            self.host.edit_actions_manager.clear_2d_editor(push_to_undo=False)
-            self.host.view_3d_manager.current_mol = None
-            self.host.view_3d_manager.plotter.clear()
-            self.host.init_manager.analysis_action.setEnabled(False)
 
             if mol.GetNumConformers() == 0:
                 AllChem.Compute2DCoords(mol)
@@ -615,9 +607,22 @@ class IOManager:
             AllChem.WedgeMolBonds(mol, conf)
 
             SCALE_FACTOR = 50.0
-            view_center = self.host.init_manager.view_2d.mapToScene(
-                self.host.init_manager.view_2d.viewport().rect().center()
-            )
+            existing_atoms = self.host.state_manager.data.atoms
+            if existing_atoms:
+                max_x = max(
+                    v["pos"].x() if hasattr(v["pos"], "x") else v["pos"][0]
+                    for v in existing_atoms.values()
+                )
+                avg_y = sum(
+                    v["pos"].y() if hasattr(v["pos"], "y") else v["pos"][1]
+                    for v in existing_atoms.values()
+                ) / len(existing_atoms)
+                place_center = QPointF(max_x + 80.0, avg_y)
+            else:
+                place_center = self.host.init_manager.view_2d.mapToScene(
+                    self.host.init_manager.view_2d.viewport().rect().center()
+                )
+
             positions = [conf.GetAtomPosition(i) for i in range(mol.GetNumAtoms())]
             mol_center_x = (
                 sum(p.x for p in positions) / len(positions) if positions else 0.0
@@ -630,8 +635,8 @@ class IOManager:
             for i in range(mol.GetNumAtoms()):
                 atom = mol.GetAtomWithIdx(i)
                 pos = conf.GetAtomPosition(i)
-                scene_x = ((pos.x - mol_center_x) * SCALE_FACTOR) + view_center.x()
-                scene_y = (-(pos.y - mol_center_y) * SCALE_FACTOR) + view_center.y()
+                scene_x = ((pos.x - mol_center_x) * SCALE_FACTOR) + place_center.x()
+                scene_y = (-(pos.y - mol_center_y) * SCALE_FACTOR) + place_center.y()
                 atom_id = self.host.init_manager.scene.create_atom(
                     atom.GetSymbol(),
                     QPointF(scene_x, scene_y),
@@ -662,18 +667,9 @@ class IOManager:
                     bond_stereo=stereo,
                 )
 
-            self.host.statusBar().showMessage(f"Successfully loaded {file_path}")
-            self.host.state_manager.reset_undo_stack()
-            self.host.init_manager.current_file_path = file_path
-            self.host.state_manager.has_unsaved_changes = False
-            self.host.state_manager.update_window_title()
+            self.host.statusBar().showMessage(f"Successfully imported {file_path}")
             self.host.init_manager.scene.update_all_items()
-
-            # Reset camera/zoom after drawing
-            QTimer.singleShot(
-                50, lambda: self.host.view_3d_manager.plotter.view_isometric()
-            )
-            QTimer.singleShot(100, lambda: self.host.view_3d_manager.plotter.render())
+            self.host.edit_actions_manager.push_undo_state()
             QTimer.singleShot(100, self.host.view_3d_manager.fit_to_view)
         except Exception as e:
             self.host.statusBar().showMessage(f"Error loading file: {e}")

--- a/moleditpy/src/moleditpy/ui/string_importers.py
+++ b/moleditpy/src/moleditpy/ui/string_importers.py
@@ -52,11 +52,83 @@ class StringImporterManager:
         if ok and inchi:
             self.load_from_inchi(inchi)
 
-    def load_from_smiles(self, smiles_string: str) -> None:
-        """Load molecule from SMILES string to 2D editor."""
-        if not self.host.state_manager.check_unsaved_changes():
-            return  # User cancelled
+    def _placement_center(self) -> QPointF:
+        """Return the scene point where the next imported molecule should be centered.
 
+        If the editor already contains atoms, offset to the right of the
+        rightmost atom so the new fragment does not overlap.  Otherwise use
+        the current viewport center.
+        """
+        existing = self.host.state_manager.data.atoms
+        if existing:
+
+            def _x(v):
+                return v["pos"].x() if hasattr(v["pos"], "x") else v["pos"][0]
+
+            def _y(v):
+                return v["pos"].y() if hasattr(v["pos"], "y") else v["pos"][1]
+
+            max_x = max(_x(v) for v in existing.values())
+            avg_y = sum(_y(v) for v in existing.values()) / len(existing)
+            return QPointF(max_x + 80.0, avg_y)
+
+        return self.host.init_manager.view_2d.mapToScene(
+            self.host.init_manager.view_2d.viewport().rect().center()
+        )
+
+    def _place_mol_bonds(self, mol, rdkit_idx_to_my_id: dict) -> None:
+        """Create bonds in the 2D scene from an RDKit molecule."""
+        for bond in mol.GetBonds():
+            b_idx, e_idx = bond.GetBeginAtomIdx(), bond.GetEndAtomIdx()
+            b_type = bond.GetBondTypeAsDouble()
+            b_dir = bond.GetBondDir()
+            stereo = 0
+            if b_dir == Chem.BondDir.BEGINWEDGE:
+                stereo = 1
+            elif b_dir == Chem.BondDir.BEGINDASH:
+                stereo = 2
+            if bond.GetBondType() == Chem.BondType.DOUBLE:
+                if bond.GetStereo() == Chem.BondStereo.STEREOZ:
+                    stereo = 3
+                elif bond.GetStereo() == Chem.BondStereo.STEREOE:
+                    stereo = 4
+
+            if b_idx in rdkit_idx_to_my_id and e_idx in rdkit_idx_to_my_id:
+                a1_id = rdkit_idx_to_my_id[b_idx]
+                a2_id = rdkit_idx_to_my_id[e_idx]
+                a1_item = self.host.state_manager.data.atoms[a1_id]["item"]
+                a2_item = self.host.state_manager.data.atoms[a2_id]["item"]
+                self.host.init_manager.scene.create_bond(
+                    a1_item, a2_item, bond_order=int(b_type), bond_stereo=stereo
+                )
+
+    def _place_mol_atoms(self, mol, conf, place_center: QPointF) -> dict:
+        """Create atoms in the 2D scene and return rdkit_idx → atom_id mapping."""
+        SCALE_FACTOR = 50.0
+        positions = [conf.GetAtomPosition(i) for i in range(mol.GetNumAtoms())]
+        mol_center_x = (
+            sum(p.x for p in positions) / len(positions) if positions else 0.0
+        )
+        mol_center_y = (
+            sum(p.y for p in positions) / len(positions) if positions else 0.0
+        )
+
+        rdkit_idx_to_my_id = {}
+        for i in range(mol.GetNumAtoms()):
+            atom = mol.GetAtomWithIdx(i)
+            pos = conf.GetAtomPosition(i)
+            scene_x = ((pos.x - mol_center_x) * SCALE_FACTOR) + place_center.x()
+            scene_y = (-(pos.y - mol_center_y) * SCALE_FACTOR) + place_center.y()
+            atom_id = self.host.init_manager.scene.create_atom(
+                atom.GetSymbol(),
+                QPointF(scene_x, scene_y),
+                charge=atom.GetFormalCharge(),
+            )
+            rdkit_idx_to_my_id[i] = atom_id
+        return rdkit_idx_to_my_id
+
+    def load_from_smiles(self, smiles_string: str) -> None:
+        """Add a molecule from a SMILES string to the 2D editor."""
         cleaned_smiles = smiles_string.strip()
 
         try:
@@ -68,7 +140,6 @@ class StringImporterManager:
 
             AllChem.Compute2DCoords(mol)
             Chem.Kekulize(mol)
-
             AllChem.AssignStereochemistry(mol, cleanIt=True, force=True)
             conf = mol.GetConformer()
             AllChem.WedgeMolBonds(mol, conf)
@@ -80,83 +151,22 @@ class StringImporterManager:
             return
 
         try:
-            self.host.ui_manager.restore_ui_for_editing()
-            self.host.edit_actions_manager.clear_2d_editor(push_to_undo=False)
-            self.host.view_3d_manager.current_mol = None
-            self.host.view_3d_manager.plotter.clear()
-            self.host.init_manager.analysis_action.setEnabled(False)
-
-            conf = mol.GetConformer()
-            SCALE_FACTOR = 50.0
-
-            view_center = self.host.init_manager.view_2d.mapToScene(
-                self.host.init_manager.view_2d.viewport().rect().center()
+            place_center = self._placement_center()
+            rdkit_idx_to_my_id = self._place_mol_atoms(
+                mol, mol.GetConformer(), place_center
             )
-            positions = [conf.GetAtomPosition(i) for i in range(mol.GetNumAtoms())]
-            mol_center_x = (
-                sum(p.x for p in positions) / len(positions) if positions else 0.0
-            )
-            mol_center_y = (
-                sum(p.y for p in positions) / len(positions) if positions else 0.0
-            )
-
-            rdkit_idx_to_my_id = {}
-            for i in range(mol.GetNumAtoms()):
-                atom = mol.GetAtomWithIdx(i)
-                pos = conf.GetAtomPosition(i)
-                charge = atom.GetFormalCharge()
-
-                relative_x = pos.x - mol_center_x
-                relative_y = pos.y - mol_center_y
-
-                scene_x = (relative_x * SCALE_FACTOR) + view_center.x()
-                scene_y = (-relative_y * SCALE_FACTOR) + view_center.y()
-
-                atom_id = self.host.init_manager.scene.create_atom(
-                    atom.GetSymbol(), QPointF(scene_x, scene_y), charge=charge
-                )
-                rdkit_idx_to_my_id[i] = atom_id
-
-            for bond in mol.GetBonds():
-                b_idx, e_idx = bond.GetBeginAtomIdx(), bond.GetEndAtomIdx()
-                b_type = bond.GetBondTypeAsDouble()
-                b_dir = bond.GetBondDir()
-                stereo = 0
-                # Single bond stereo
-                if b_dir == Chem.BondDir.BEGINWEDGE:
-                    stereo = 1  # Wedge
-                elif b_dir == Chem.BondDir.BEGINDASH:
-                    stereo = 2  # Dash
-                # Double bond E/Z
-                if bond.GetBondType() == Chem.BondType.DOUBLE:
-                    if bond.GetStereo() == Chem.BondStereo.STEREOZ:
-                        stereo = 3  # Z
-                    elif bond.GetStereo() == Chem.BondStereo.STEREOE:
-                        stereo = 4  # E
-
-                if b_idx in rdkit_idx_to_my_id and e_idx in rdkit_idx_to_my_id:
-                    a1_id, a2_id = rdkit_idx_to_my_id[b_idx], rdkit_idx_to_my_id[e_idx]
-                    a1_item = self.host.state_manager.data.atoms[a1_id]["item"]
-                    a2_item = self.host.state_manager.data.atoms[a2_id]["item"]
-                    self.host.init_manager.scene.create_bond(
-                        a1_item, a2_item, bond_order=int(b_type), bond_stereo=stereo
-                    )
+            self._place_mol_bonds(mol, rdkit_idx_to_my_id)
 
             self.host.statusBar().showMessage("Successfully loaded from SMILES.")
             self.host.init_manager.scene.update_all_items()
-            self.host.state_manager.reset_undo_stack()
-            self.host.state_manager.has_unsaved_changes = False
-            self.host.state_manager.update_window_title()
+            self.host.edit_actions_manager.push_undo_state()
             QTimer.singleShot(0, self.host.view_3d_manager.fit_to_view)
 
         except (AttributeError, RuntimeError, ValueError, TypeError) as e:
             self.host.statusBar().showMessage(f"Error loading from SMILES: {e}")
 
     def load_from_inchi(self, inchi_string: str) -> None:
-        """Load molecule from InChI string to 2D editor."""
-        if not self.host.state_manager.check_unsaved_changes():
-            return  # User cancelled
-
+        """Add a molecule from an InChI string to the 2D editor."""
         cleaned_inchi = inchi_string.strip()
 
         try:
@@ -168,7 +178,6 @@ class StringImporterManager:
 
             AllChem.Compute2DCoords(mol)
             Chem.Kekulize(mol)
-
             AllChem.AssignStereochemistry(mol, cleanIt=True, force=True)
             conf = mol.GetConformer()
             AllChem.WedgeMolBonds(mol, conf)
@@ -180,73 +189,15 @@ class StringImporterManager:
             return
 
         try:
-            self.host.ui_manager.restore_ui_for_editing()
-            self.host.edit_actions_manager.clear_2d_editor(push_to_undo=False)
-            self.host.view_3d_manager.current_mol = None
-            self.host.view_3d_manager.plotter.clear()
-            self.host.init_manager.analysis_action.setEnabled(False)
-
-            conf = mol.GetConformer()
-            SCALE_FACTOR = 50.0
-
-            view_center = self.host.init_manager.view_2d.mapToScene(
-                self.host.init_manager.view_2d.viewport().rect().center()
+            place_center = self._placement_center()
+            rdkit_idx_to_my_id = self._place_mol_atoms(
+                mol, mol.GetConformer(), place_center
             )
-            positions = [conf.GetAtomPosition(i) for i in range(mol.GetNumAtoms())]
-            mol_center_x = (
-                sum(p.x for p in positions) / len(positions) if positions else 0.0
-            )
-            mol_center_y = (
-                sum(p.y for p in positions) / len(positions) if positions else 0.0
-            )
-
-            rdkit_idx_to_my_id = {}
-            for i in range(mol.GetNumAtoms()):
-                atom = mol.GetAtomWithIdx(i)
-                pos = conf.GetAtomPosition(i)
-                charge = atom.GetFormalCharge()
-
-                relative_x = pos.x - mol_center_x
-                relative_y = pos.y - mol_center_y
-
-                scene_x = (relative_x * SCALE_FACTOR) + view_center.x()
-                scene_y = (-relative_y * SCALE_FACTOR) + view_center.y()
-
-                atom_id = self.host.init_manager.scene.create_atom(
-                    atom.GetSymbol(), QPointF(scene_x, scene_y), charge=charge
-                )
-                rdkit_idx_to_my_id[i] = atom_id
-
-            for bond in mol.GetBonds():
-                b_idx, e_idx = bond.GetBeginAtomIdx(), bond.GetEndAtomIdx()
-                b_type = bond.GetBondTypeAsDouble()
-                b_dir = bond.GetBondDir()
-                stereo = 0
-                # Single bond stereo
-                if b_dir == Chem.BondDir.BEGINWEDGE:
-                    stereo = 1  # Wedge
-                elif b_dir == Chem.BondDir.BEGINDASH:
-                    stereo = 2  # Dash
-                # Double bond E/Z
-                if bond.GetBondType() == Chem.BondType.DOUBLE:
-                    if bond.GetStereo() == Chem.BondStereo.STEREOZ:
-                        stereo = 3  # Z
-                    elif bond.GetStereo() == Chem.BondStereo.STEREOE:
-                        stereo = 4  # E
-
-                if b_idx in rdkit_idx_to_my_id and e_idx in rdkit_idx_to_my_id:
-                    a1_id, a2_id = rdkit_idx_to_my_id[b_idx], rdkit_idx_to_my_id[e_idx]
-                    a1_item = self.host.state_manager.data.atoms[a1_id]["item"]
-                    a2_item = self.host.state_manager.data.atoms[a2_id]["item"]
-                    self.host.init_manager.scene.create_bond(
-                        a1_item, a2_item, bond_order=int(b_type), bond_stereo=stereo
-                    )
+            self._place_mol_bonds(mol, rdkit_idx_to_my_id)
 
             self.host.statusBar().showMessage("Successfully loaded from InChI.")
             self.host.init_manager.scene.update_all_items()
-            self.host.state_manager.reset_undo_stack()
-            self.host.state_manager.has_unsaved_changes = False
-            self.host.state_manager.update_window_title()
+            self.host.edit_actions_manager.push_undo_state()
             QTimer.singleShot(0, self.host.view_3d_manager.fit_to_view)
 
         except (AttributeError, RuntimeError, ValueError, TypeError) as e:

--- a/moleditpy/src/moleditpy/ui/user_template_dialog.py
+++ b/moleditpy/src/moleditpy/ui/user_template_dialog.py
@@ -634,10 +634,6 @@ class UserTemplateDialog(QDialog):
                     return
 
             if self.save_template_file(filepath, template_data):
-                # Mark main window as saved
-                self.main_window.state_manager.has_unsaved_changes = False
-                self.main_window.state_manager.update_window_title()
-
                 QMessageBox.information(
                     self, "Success", f"Template '{name}' saved successfully."
                 )

--- a/moleditpy/src/moleditpy/ui/view_3d_logic.py
+++ b/moleditpy/src/moleditpy/ui/view_3d_logic.py
@@ -282,7 +282,9 @@ class View3DManager:
         self.host.view_3d_manager.plotter.camera_position = camera_state
 
         # Update projection mode and force render
-        proj_mode = self.host.init_manager.settings.get("projection_mode", "Perspective")
+        proj_mode = self.host.init_manager.settings.get(
+            "projection_mode", "Perspective"
+        )
         if hasattr(self.host.view_3d_manager.plotter, "renderer") and hasattr(
             self.host.view_3d_manager.plotter.renderer, "GetActiveCamera"
         ):

--- a/moleditpy/src/moleditpy/ui/view_3d_logic.py
+++ b/moleditpy/src/moleditpy/ui/view_3d_logic.py
@@ -282,8 +282,7 @@ class View3DManager:
         self.host.view_3d_manager.plotter.camera_position = camera_state
 
         # Update projection mode and force render
-        settings = getattr(self, "settings", {})
-        proj_mode = settings.get("projection_mode", "Perspective")
+        proj_mode = self.host.init_manager.settings.get("projection_mode", "Perspective")
         if hasattr(self.host.view_3d_manager.plotter, "renderer") and hasattr(
             self.host.view_3d_manager.plotter.renderer, "GetActiveCamera"
         ):

--- a/moleditpy/src/moleditpy/utils/constants.py
+++ b/moleditpy/src/moleditpy/utils/constants.py
@@ -16,7 +16,7 @@ from PyQt6.QtGui import QColor, QFont
 from rdkit import Chem
 
 # Version
-VERSION = "3.0.6"
+VERSION = "3.1.0"
 
 ATOM_RADIUS = 18
 BOND_OFFSET = 3.5

--- a/tests/coverage_report.md
+++ b/tests/coverage_report.md
@@ -1,7 +1,7 @@
 # MoleditPy Coverage Report
 
-- **Overall Project Coverage (Full)**: **69.69%**
-- **Core Molecular Logic Coverage**: **77.54%**
+- **Overall Project Coverage (Full)**: **69.59%**
+- **Core Molecular Logic Coverage**: **77.43%**
 
 > [!NOTE]
 > **Core Molecular Logic Coverage** excludes UI boilerplate (dialogs, view managers, and interactor styles) to focus on scientific algorithm reliability.
@@ -28,23 +28,23 @@
 | moleditpy\src\moleditpy\ui\calculation_worker.py        |    546 |     91 |   83.3% |
 | moleditpy\src\moleditpy\ui\color_settings_dialog.py     |    197 |     65 |   67.0% |
 | moleditpy\src\moleditpy\ui\compute_logic.py             |    401 |     96 |   76.1% |
-| moleditpy\src\moleditpy\ui\dialog_logic.py              |    228 |     31 |   86.4% |
+| moleditpy\src\moleditpy\ui\dialog_logic.py              |    226 |     31 |   86.3% |
 | moleditpy\src\moleditpy\ui\dihedral_dialog.py           |    221 |     89 |   59.7% |
 | moleditpy\src\moleditpy\ui\edit_3d_logic.py             |    236 |     88 |   62.7% |
 | moleditpy\src\moleditpy\ui\edit_actions_logic.py        |    852 |    215 |   74.8% |
 | moleditpy\src\moleditpy\ui\export_logic.py              |    512 |    150 |   70.7% |
-| moleditpy\src\moleditpy\ui\io_logic.py                  |    643 |    129 |   79.9% |
+| moleditpy\src\moleditpy\ui\io_logic.py                  |    636 |    131 |   79.4% |
 | moleditpy\src\moleditpy\ui\main_window_init.py          |   1188 |    167 |   85.9% |
 | moleditpy\src\moleditpy\ui\molecular_scene_handler.py   |    858 |    178 |   79.3% |
-| moleditpy\src\moleditpy\ui\molecule_scene.py            |    502 |    182 |   63.7% |
+| moleditpy\src\moleditpy\ui\molecule_scene.py            |    502 |    180 |   64.1% |
 | moleditpy\src\moleditpy\ui\sip_isdeleted_safe.py        |     13 |      4 |   69.2% |
-| moleditpy\src\moleditpy\ui\string_importers.py          |    165 |     26 |   84.2% |
+| moleditpy\src\moleditpy\ui\string_importers.py          |    127 |     27 |   78.7% |
 | moleditpy\src\moleditpy\ui\ui_manager.py                |    372 |    112 |   69.9% |
-| moleditpy\src\moleditpy\ui\view_3d_logic.py             |    986 |    246 |   75.1% |
+| moleditpy\src\moleditpy\ui\view_3d_logic.py             |    985 |    246 |   75.0% |
 | moleditpy\src\moleditpy\utils\constants.py              |     31 |      0 |  100.0% |
 | moleditpy\src\moleditpy\utils\default_settings.py       |      1 |      0 |  100.0% |
 | moleditpy\src\moleditpy\utils\sip_isdeleted_safe.py     |     19 |      8 |   57.9% |
-| **TOTAL** | **11038** | **2479** | **77.54%** |
+| **TOTAL** | **10990** | **2480** | **77.43%** |
 
 ### Full Application Breakdown
 
@@ -75,30 +75,30 @@
 | moleditpy\src\moleditpy\ui\custom_interactor_style.py   |    454 |    391 |   13.9% |
 | moleditpy\src\moleditpy\ui\custom_qt_interactor.py      |     43 |     35 |   18.6% |
 | moleditpy\src\moleditpy\ui\dialog_3d_picking_mixin.py   |    115 |     60 |   47.8% |
-| moleditpy\src\moleditpy\ui\dialog_logic.py              |    228 |     31 |   86.4% |
+| moleditpy\src\moleditpy\ui\dialog_logic.py              |    226 |     31 |   86.3% |
 | moleditpy\src\moleditpy\ui\dihedral_dialog.py           |    221 |     89 |   59.7% |
 | moleditpy\src\moleditpy\ui\edit_3d_logic.py             |    236 |     88 |   62.7% |
 | moleditpy\src\moleditpy\ui\edit_actions_logic.py        |    852 |    215 |   74.8% |
 | moleditpy\src\moleditpy\ui\export_logic.py              |    512 |    150 |   70.7% |
 | moleditpy\src\moleditpy\ui\geometry_base_dialog.py      |     56 |     41 |   26.8% |
-| moleditpy\src\moleditpy\ui\io_logic.py                  |    643 |    129 |   79.9% |
+| moleditpy\src\moleditpy\ui\io_logic.py                  |    636 |    131 |   79.4% |
 | moleditpy\src\moleditpy\ui\main_window.py               |     64 |     20 |   68.8% |
 | moleditpy\src\moleditpy\ui\main_window_init.py          |   1188 |    167 |   85.9% |
 | moleditpy\src\moleditpy\ui\mirror_dialog.py             |     70 |      7 |   90.0% |
 | moleditpy\src\moleditpy\ui\molecular_scene_handler.py   |    858 |    178 |   79.3% |
-| moleditpy\src\moleditpy\ui\molecule_scene.py            |    502 |    182 |   63.7% |
+| moleditpy\src\moleditpy\ui\molecule_scene.py            |    502 |    180 |   64.1% |
 | moleditpy\src\moleditpy\ui\move_group_dialog.py         |    350 |    208 |   40.6% |
 | moleditpy\src\moleditpy\ui\periodic_table_dialog.py     |     33 |      7 |   78.8% |
 | moleditpy\src\moleditpy\ui\planarize_dialog.py          |    102 |     27 |   73.5% |
 | moleditpy\src\moleditpy\ui\settings_dialog.py           |    106 |     89 |   16.0% |
 | moleditpy\src\moleditpy\ui\sip_isdeleted_safe.py        |     13 |      4 |   69.2% |
-| moleditpy\src\moleditpy\ui\string_importers.py          |    165 |     26 |   84.2% |
+| moleditpy\src\moleditpy\ui\string_importers.py          |    127 |     27 |   78.7% |
 | moleditpy\src\moleditpy\ui\template_preview_item.py     |    101 |     77 |   23.8% |
 | moleditpy\src\moleditpy\ui\template_preview_view.py     |     42 |     14 |   66.7% |
 | moleditpy\src\moleditpy\ui\translation_dialog.py        |    236 |     49 |   79.2% |
 | moleditpy\src\moleditpy\ui\ui_manager.py                |    372 |    112 |   69.9% |
-| moleditpy\src\moleditpy\ui\user_template_dialog.py      |    366 |    130 |   64.5% |
-| moleditpy\src\moleditpy\ui\view_3d_logic.py             |    986 |    246 |   75.1% |
+| moleditpy\src\moleditpy\ui\user_template_dialog.py      |    364 |    128 |   64.8% |
+| moleditpy\src\moleditpy\ui\view_3d_logic.py             |    985 |    246 |   75.0% |
 | moleditpy\src\moleditpy\ui\zoomable_view.py             |     70 |     37 |   47.1% |
 | moleditpy\src\moleditpy\ui\settings_tabs\settings_2d_tab.py |     79 |     68 |   13.9% |
 | moleditpy\src\moleditpy\ui\settings_tabs\settings_3d_tabs.py |    133 |    117 |   12.0% |
@@ -108,7 +108,7 @@
 | moleditpy\src\moleditpy\utils\default_settings.py       |      1 |      0 |  100.0% |
 | moleditpy\src\moleditpy\utils\sip_isdeleted_safe.py     |     19 |      8 |   57.9% |
 | moleditpy\src\moleditpy\utils\system_utils.py           |     34 |     18 |   47.1% |
-| **TOTAL** | **14168** | **4294** | **69.69%** |
+| **TOTAL** | **14118** | **4293** | **69.59%** |
 
 ## Test Suite Status
 - **Unit tests**: PASSED


### PR DESCRIPTION
## Summary

<!-- What does this PR do? List the key changes in 2–4 bullet points. -->

  Bug Fixes
  - Fixed AttributeError crash when closing with unsaved changes — StateManager was calling self.save_project() instead
  of self.host.io_manager.save_project()
  - Fixed projection mode always defaulting to Perspective — View3DManager used getattr(self, "settings", {}) which
  always returned {} instead of reading from init_manager.settings
  - Fixed saving a user template (.pmetmplt) incorrectly clearing the project's unsaved-changes flag in both
  dialog_logic and user_template_dialog

  Improvements
  - SMILES, InChI, and MOL/SDF 2D imports now append to the existing editor instead of clearing it — new fragments are
  placed to the right of existing atoms with an 80 px gap, or at view center if the scene is empty
  - Imports now push to the undo stack and mark the project as unsaved, making them fully undoable
  - Refactored StringImporterManager to extract shared _placement_center, _place_mol_atoms, and _place_mol_bonds
  helpers, eliminating ~50 lines of duplication between SMILES and InChI paths

## Type of change

<!-- Check all that apply. -->

- [x] Bug fix
- [x] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] Tests
- [ ] CI / build

## Related issues

<!-- Link any related issues, e.g. Closes #123 -->

## Test plan

<!-- How did you verify the change works? -->

- [x] Ran `python -m pytest tests/unit/ tests/integration/` — all pass
- [x] Manually tested in the GUI (describe what you tested below)
- [ ] Added new unit tests

**Manual test notes:**
<!-- Optional: describe what you clicked/drew/exported to verify -->

## Checklist

- [x] `python -m flake8 moleditpy/src/ --select=F` returns 0 issues
- [x] No bare `except:` clauses added (use `except Exception as e:` and log the error)
- [x] No new unused imports or variables
- [x] Plugin API changes are backwards-compatible (or documented in Summary)
