### PR TITLE
Update XYZ coordinate formatting to use symbol:<5 and coords:>15.8f

### DIFF
--- a/moleditpy/src/moleditpy/ui/io_logic.py
+++ b/moleditpy/src/moleditpy/ui/io_logic.py
@@ -942,7 +942,7 @@ class IOManager:
                     symbol = self.host.view_3d_manager.current_mol.GetAtomWithIdx(
                         i
                     ).GetSymbol()
-                    xyz_lines.append(f"  {symbol:<11}{pos.x:11.8f}      {pos.y:11.8f}      {pos.z:11.8f}")
+                    xyz_lines.append(f"  {symbol:<5}{pos.x:>15.8f}{pos.y:>15.8f}{pos.z:>15.8f}")
 
                 with open(file_path, "w", encoding="utf-8") as f:
                     f.write("\n".join(xyz_lines) + "\n")


### PR DESCRIPTION
## Summary

<!-- What does this PR do? List the key changes in 2–4 bullet points. -->

- Update XYZ coordinate formatting to use symbol

## Type of change

<!-- Check all that apply. -->

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] Tests
- [ ] CI / build

## Related issues

<!-- Link any related issues, e.g. Closes #123 -->

## Test plan

<!-- How did you verify the change works? -->

- [x] Ran `python tests/run_all_tests.py` — all pass
- [-] Manually tested in the GUI with the check list
- [-] Added new unit tests

## Checklist

- [x] `python -m flake8 moleditpy/src/ --select=F` returns 0 issues
- [x] No bare `except:` clauses added (use `except Exception as e:` and log the error)
- [x] No new unused imports or variables
- [x] Plugin API changes are backwards-compatible (or documented in Summary)
