### PR TITLE
Fix tests

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -15,7 +15,7 @@ Only the latest release receives security fixes.
 
 To report a vulnerability, send an email to:
 
-**titech.yoko.hiro@gmail.com**
+**titech.yoko.hiro[at]gmail.com**
 
 Include the following in your report:
 

--- a/tests/gui/pytest.ini
+++ b/tests/gui/pytest.ini
@@ -8,5 +8,4 @@ markers =
 norecursedirs = .git venv venv3 .venv dist build __pycache__ *.egg-info
 python_files = test_*.py
 addopts = -q --ignore-glob="*site-packages*" --strict-markers
-filterwarnings =
-    ignore::pytest.PytestRemovedIn9Warning
+


### PR DESCRIPTION
## Summary

<!-- What does this PR do? List the key changes in 2–4 bullet points. -->

- [fix: remove obsolete pytest warning filter causing CI AttributeError](https://github.com/HiroYokoyama/python_molecular_editor/commit/7363c1fe5b2be79dee5d0ac51ef4abd4cd362180)
