### PR TITLE
Dev 4.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,9 +134,9 @@ moleditpy
   * **3D Visualization (PyVista / pyvistaqt):** 3D rendering is achieved by generating PyVista meshes (spheres and cylinders) from RDKit conformer coordinates. A custom `vtkInteractorStyle` enables direct drag-and-drop editing of atoms in the 3D view.
   * **Modular Architecture:** The codebase is organized into dedicated packages for `core` logic, `ui` components, and `utils`. The main application logic is decomposed into reusable mixins, ensuring long-term maintainability and easier verification.
 
-## License
+## License & Disclaimer
 
-This project is licensed under the **GNU General Public License v3.0 (GPL-v3)**. See the `LICENSE` file for details.
+This project is licensed under the GNU General Public License v3.0 (GPLv3) - see the [LICENSE](LICENSE) file for details. As open-source software, it is provided 'as is' without warranty of any kind, and the author assumes no responsibility or liability for the results. Although outputs have been carefully verified, users are strongly encouraged to independently check and validate them for critical applications (such as publications). If you encounter any bugs, please open an issue.
 
 ## Citation
 
@@ -268,9 +268,9 @@ moleditpy
   * **化学計算 (RDKit / Open Babel):** 2DデータからRDKit分子オブジェクトを生成し、3D座標生成や分子特性計算を実行します。RDKitでの3D座標生成が失敗した際は、Open Babelにフォールバックします。重い計算処理は別スレッド (`QThread`) で実行し、GUIの応答性を維持しています。
   * **3D可視化 (PyVista / pyvistaqt):** RDKitのコンフォーマ座標からPyVistaのメッシュ（球や円柱）を生成して描画します。カスタムの`vtkInteractorStyle`を実装し、3Dビュー内での原子の直接的なドラッグ＆ドロップ編集を可能にしています。
 
-## ライセンス
+## ライセンス & 免責事項
 
-このプロジェクトは **GNU General Public License v3.0 (GPL-v3)** のもとで公開されています。詳細は `LICENSE` ファイルを参照してください。
+このプロジェクトは GNU General Public License v3.0 (GPLv3) のもとでライセンスされています。詳細は [LICENSE](LICENSE) ファイルを参照してください。オープンソースソフトウェアとして、本ソフトウェアは「現状のまま」提供され、いかなる明示または黙示の保証も行いません。また、本ソフトウェアを使用した結果について、作者は一切の責任や義務を負いません。出力結果は慎重に検証されていますが、学術論文の作成など重要な用途においては、ユーザーご自身で結果を独立して確認および検証することを強くお勧めします。バグに遭遇した場合は、Issueを作成してください。
 
 ## 引用
 

--- a/moleditpy-linux/README.md
+++ b/moleditpy-linux/README.md
@@ -134,9 +134,9 @@ moleditpy
   * **3D Visualization (PyVista / pyvistaqt):** 3D rendering is achieved by generating PyVista meshes (spheres and cylinders) from RDKit conformer coordinates. A custom `vtkInteractorStyle` enables direct drag-and-drop editing of atoms in the 3D view.
   * **Modular Architecture:** The codebase is organized into dedicated packages for `core` logic, `ui` components, and `utils`. The main application logic is decomposed into reusable mixins, ensuring long-term maintainability and easier verification.
 
-## License
+## License & Disclaimer
 
-This project is licensed under the **GNU General Public License v3.0 (GPL-v3)**. See the `LICENSE` file for details.
+This project is licensed under the GNU General Public License v3.0 (GPLv3) - see the [LICENSE](LICENSE) file for details. As open-source software, it is provided 'as is' without warranty of any kind, and the author assumes no responsibility or liability for the results. Although outputs have been carefully verified, users are strongly encouraged to independently check and validate them for critical applications (such as publications). If you encounter any bugs, please open an issue.
 
 ## Citation
 
@@ -268,9 +268,9 @@ moleditpy
   * **化学計算 (RDKit / Open Babel):** 2DデータからRDKit分子オブジェクトを生成し、3D座標生成や分子特性計算を実行します。RDKitでの3D座標生成が失敗した際は、Open Babelにフォールバックします。重い計算処理は別スレッド (`QThread`) で実行し、GUIの応答性を維持しています。
   * **3D可視化 (PyVista / pyvistaqt):** RDKitのコンフォーマ座標からPyVistaのメッシュ（球や円柱）を生成して描画します。カスタムの`vtkInteractorStyle`を実装し、3Dビュー内での原子の直接的なドラッグ＆ドロップ編集を可能にしています。
 
-## ライセンス
+## ライセンス & 免責事項
 
-このプロジェクトは **GNU General Public License v3.0 (GPL-v3)** のもとで公開されています。詳細は `LICENSE` ファイルを参照してください。
+このプロジェクトは GNU General Public License v3.0 (GPLv3) のもとでライセンスされています。詳細は [LICENSE](LICENSE) ファイルを参照してください。オープンソースソフトウェアとして、本ソフトウェアは「現状のまま」提供され、いかなる明示または黙示の保証も行いません。また、本ソフトウェアを使用した結果について、作者は一切の責任や義務を負いません。出力結果は慎重に検証されていますが、学術論文の作成など重要な用途においては、ユーザーご自身で結果を独立して確認および検証することを強くお勧めします。バグに遭遇した場合は、Issueを作成してください。
 
 ## 引用
 

--- a/moleditpy/README.md
+++ b/moleditpy/README.md
@@ -134,9 +134,9 @@ moleditpy
   * **3D Visualization (PyVista / pyvistaqt):** 3D rendering is achieved by generating PyVista meshes (spheres and cylinders) from RDKit conformer coordinates. A custom `vtkInteractorStyle` enables direct drag-and-drop editing of atoms in the 3D view.
   * **Modular Architecture:** The codebase is organized into dedicated packages for `core` logic, `ui` components, and `utils`. The main application logic is decomposed into reusable mixins, ensuring long-term maintainability and easier verification.
 
-## License
+## License & Disclaimer
 
-This project is licensed under the **GNU General Public License v3.0 (GPL-v3)**. See the `LICENSE` file for details.
+This project is licensed under the GNU General Public License v3.0 (GPLv3) - see the [LICENSE](LICENSE) file for details. As open-source software, it is provided 'as is' without warranty of any kind, and the author assumes no responsibility or liability for the results. Although outputs have been carefully verified, users are strongly encouraged to independently check and validate them for critical applications (such as publications). If you encounter any bugs, please open an issue.
 
 ## Citation
 
@@ -268,9 +268,9 @@ moleditpy
   * **化学計算 (RDKit / Open Babel):** 2DデータからRDKit分子オブジェクトを生成し、3D座標生成や分子特性計算を実行します。RDKitでの3D座標生成が失敗した際は、Open Babelにフォールバックします。重い計算処理は別スレッド (`QThread`) で実行し、GUIの応答性を維持しています。
   * **3D可視化 (PyVista / pyvistaqt):** RDKitのコンフォーマ座標からPyVistaのメッシュ（球や円柱）を生成して描画します。カスタムの`vtkInteractorStyle`を実装し、3Dビュー内での原子の直接的なドラッグ＆ドロップ編集を可能にしています。
 
-## ライセンス
+## ライセンス & 免責事項
 
-このプロジェクトは **GNU General Public License v3.0 (GPL-v3)** のもとで公開されています。詳細は `LICENSE` ファイルを参照してください。
+このプロジェクトは GNU General Public License v3.0 (GPLv3) のもとでライセンスされています。詳細は [LICENSE](LICENSE) ファイルを参照してください。オープンソースソフトウェアとして、本ソフトウェアは「現状のまま」提供され、いかなる明示または黙示の保証も行いません。また、本ソフトウェアを使用した結果について、作者は一切の責任や義務を負いません。出力結果は慎重に検証されていますが、学術論文の作成など重要な用途においては、ユーザーご自身で結果を独立して確認および検証することを強くお勧めします。バグに遭遇した場合は、Issueを作成してください。
 
 ## 引用
 

--- a/moleditpy/src/moleditpy/ui/calculation_worker.py
+++ b/moleditpy/src/moleditpy/ui/calculation_worker.py
@@ -548,7 +548,22 @@ def _perform_direct_conversion(
             _safe_status,
             options=options if backend == "RDKIT" else None,
         ):
-            raise RuntimeError(f"Optimization with {opt_method} failed.")
+            fallback_success = False
+            if backend == "RDKIT" and "MMFF" in method_key:
+                _safe_status("MMFF optimization failed. Auto-falling back to UFF...")
+                fallback_success = opt_func(
+                    mol, "UFF", _check_halted, _safe_status, options=options
+                )
+                if fallback_success:
+                    with contextlib.suppress(Exception):
+                        mol.SetProp("_pme_optimization_method", "UFF_RDKIT")
+
+            if not fallback_success:
+                _safe_status(
+                    "Warning: Optimization failed. Using unoptimized structure."
+                )
+                with contextlib.suppress(Exception):
+                    mol.ClearProp("_pme_optimization_method")
 
     if _check_halted():
         raise WorkerHaltError("Halted")
@@ -664,15 +679,30 @@ print(ob_mol.write("mol"))
             _safe_status,
             options=options if backend == "RDKIT" else None,
         ):
-            _safe_status("Warning: Optimization failed. Using unoptimized structure.")
-            # Best-effort property cleanup if optimization was skipped
-            with contextlib.suppress(AttributeError, RuntimeError, TypeError):
-                rd_mol.ClearProp("_pme_optimization_method")
+            fallback_success = False
+            if backend == "RDKIT" and "MMFF" in method_key:
+                _safe_status("MMFF optimization failed. Auto-falling back to UFF...")
+                fallback_success = opt_func(
+                    rd_mol, "UFF", _check_halted, _safe_status, options=options
+                )
+                if fallback_success:
+                    with contextlib.suppress(Exception):
+                        rd_mol.SetProp("_pme_optimization_method", "UFF_RDKIT")
+
+            if not fallback_success:
+                _safe_status(
+                    "Warning: Optimization failed. Using unoptimized structure."
+                )
+                with contextlib.suppress(Exception):
+                    rd_mol.ClearProp("_pme_optimization_method")
 
         if _check_halted():
             raise WorkerHaltError("Halted")
         # Final status message before finishing (to ensure it doesn't overwrite error/halt messages)
-        opt_label = _OPT_METHOD_LABELS.get(opt_method, opt_method)
+        final_opt = "Unoptimized"
+        if rd_mol.HasProp("_pme_optimization_method"):
+            final_opt = rd_mol.GetProp("_pme_optimization_method")
+        opt_label = _OPT_METHOD_LABELS.get(final_opt, final_opt)
         _safe_status(f"Process completed (Open Babel Conversion / {opt_label}).")
         _safe_finished((worker_id, rd_mol))
         return True
@@ -925,9 +955,22 @@ class CalculationWorker(QObject):
             _safe_status,
             options=options if backend == "RDKIT" else None,
         ):
-            _safe_status("Warning: Optimization failed. Using unoptimized structure.")
-            with contextlib.suppress(Exception):
-                mol.ClearProp("_pme_optimization_method")
+            fallback_success = False
+            if backend == "RDKIT" and "MMFF" in method_key:
+                _safe_status("MMFF optimization failed. Auto-falling back to UFF...")
+                fallback_success = opt_func(
+                    mol, "UFF", _check_halted, _safe_status, options=options
+                )
+                if fallback_success:
+                    with contextlib.suppress(Exception):
+                        mol.SetProp("_pme_optimization_method", "UFF_RDKIT")
+
+            if not fallback_success:
+                _safe_status(
+                    "Warning: Optimization failed. Using unoptimized structure."
+                )
+                with contextlib.suppress(Exception):
+                    mol.ClearProp("_pme_optimization_method")
 
         # Final stereo restoration check
         for b_idx, s, satoms in orig_stereo:
@@ -939,7 +982,10 @@ class CalculationWorker(QObject):
         if _check_halted():
             raise WorkerHaltError("Halted")
         # Final status message before finishing (to ensure it doesn't overwrite error/halt messages)
-        opt_label = _OPT_METHOD_LABELS.get(opt_method, opt_method)
+        final_opt = "Unoptimized"
+        if mol.HasProp("_pme_optimization_method"):
+            final_opt = mol.GetProp("_pme_optimization_method")
+        opt_label = _OPT_METHOD_LABELS.get(final_opt, final_opt)
         _safe_status(f"Process completed (RDKit Conversion / {opt_label}).")
         _safe_finished((w_id, mol))
         return True
@@ -972,9 +1018,11 @@ class CalculationWorker(QObject):
         )
         # Final status message before finishing (to ensure it doesn't overwrite error/halt messages)
         _safe_status = helpers["status"]
-        opt_method = (options or {}).get("optimization_method") or "MMFF94s_RDKIT"
         if (options or {}).get("do_optimize", True):
-            opt_label = _OPT_METHOD_LABELS.get(opt_method, opt_method)
+            final_opt = "Unoptimized"
+            if mol.HasProp("_pme_optimization_method"):
+                final_opt = mol.GetProp("_pme_optimization_method")
+            opt_label = _OPT_METHOD_LABELS.get(final_opt, final_opt)
             _safe_status(f"Process completed (Direct 2D->3D Conversion / {opt_label}).")
         else:
             _safe_status("Process completed (Direct 2D->3D Conversion).")

--- a/moleditpy/src/moleditpy/ui/compute_logic.py
+++ b/moleditpy/src/moleditpy/ui/compute_logic.py
@@ -484,13 +484,13 @@ class ComputeManager:
             method_key = None
             if mol and mol.HasProp("_pme_optimization_method"):
                 method_key = mol.GetProp("_pme_optimization_method")
-            if not method_key:
-                method_key = self.host.init_manager.optimization_method
             if method_key:
                 labels = self.host.init_manager.opt3d_method_labels or {}
                 self.last_successful_optimization_method = labels.get(
                     method_key, method_key
                 )
+            else:
+                self.last_successful_optimization_method = "Unoptimized"
         except (AttributeError, TypeError):
             # Safe defensive fallback catching AttributeError, TypeError
             pass
@@ -539,7 +539,7 @@ class ComputeManager:
                     "Retry with UFF?",
                     f"{msg}\n\nWould you like to retry using UFF (RDKit) instead?",
                     QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
-                    QMessageBox.StandardButton.No,
+                    QMessageBox.StandardButton.Yes,
                 )
                 if reply == QMessageBox.StandardButton.Yes:
                     self.optimize_3d_structure("UFF_RDKIT")

--- a/tests/assertion_catalog.md
+++ b/tests/assertion_catalog.md
@@ -7014,6 +7014,7 @@ _Test that MMFF optimization failure auto-falls back to UFF._
 - assert res_mol is not None
 - assert res_mol.HasProp('_pme_optimization_method')
 - assert res_mol.GetProp('_pme_optimization_method') == 'UFF_RDKIT'
+- assert any(('Process completed (RDKit Conversion / UFF (RDKit))' in msg for msg in status_messages))
 
 ### test_calculation_worker_mmff_variants
 _Test switching between MMFF94 and MMFF94s._

--- a/tests/assertion_catalog.md
+++ b/tests/assertion_catalog.md
@@ -7007,11 +7007,13 @@ _Test the fallback to constraint-based embedding when initial embedding fails._
 
 - assert mock_embed.call_count >= 2
 
-### test_calculation_worker_opt_failure_emits_error
-_Test that optimization failure emits an error string instead of failing silently or hanging._
+### test_calculation_worker_opt_failure_auto_fallback_to_uff
+_Test that MMFF optimization failure auto-falls back to UFF._
 
 - assert mock_mmff_props.called
 - assert res_mol is not None
+- assert res_mol.HasProp('_pme_optimization_method')
+- assert res_mol.GetProp('_pme_optimization_method') == 'UFF_RDKIT'
 
 ### test_calculation_worker_mmff_variants
 _Test switching between MMFF94 and MMFF94s._

--- a/tests/coverage_report.md
+++ b/tests/coverage_report.md
@@ -1,6 +1,6 @@
 # MoleditPy Coverage Report
 
-- **Overall Project Coverage**: **82.47%**
+- **Overall Project Coverage**: **82.48%**
 
 ### Coverage Breakdown
 
@@ -43,7 +43,7 @@
 | moleditpy\src\moleditpy\ui\main_window_init.py          |   1052 |    112 |   89.4% |
 | moleditpy\src\moleditpy\ui\mirror_dialog.py             |     72 |      7 |   90.3% |
 | moleditpy\src\moleditpy\ui\molecular_scene_handler.py   |    952 |    161 |   83.1% |
-| moleditpy\src\moleditpy\ui\molecule_scene.py            |    614 |    128 |   79.2% |
+| moleditpy\src\moleditpy\ui\molecule_scene.py            |    614 |    126 |   79.5% |
 | moleditpy\src\moleditpy\ui\move_group_dialog.py         |    386 |    130 |   66.3% |
 | moleditpy\src\moleditpy\ui\move_selected_atoms_dialog.py |    390 |     41 |   89.5% |
 | moleditpy\src\moleditpy\ui\periodic_table_dialog.py     |     37 |      2 |   94.6% |
@@ -66,7 +66,7 @@
 | moleditpy\src\moleditpy\utils\default_settings.py       |      1 |      0 |  100.0% |
 | moleditpy\src\moleditpy\utils\sip_isdeleted_safe.py     |     19 |      0 |  100.0% |
 | moleditpy\src\moleditpy\utils\system_utils.py           |     36 |      0 |  100.0% |
-| **TOTAL** | **15677** | **2748** | **82.47%** |
+| **TOTAL** | **15677** | **2746** | **82.48%** |
 
 ## Test Suite Status
 - **Unit tests**: PASSED

--- a/tests/coverage_report.md
+++ b/tests/coverage_report.md
@@ -1,6 +1,6 @@
 # MoleditPy Coverage Report
 
-- **Overall Project Coverage**: **82.54%**
+- **Overall Project Coverage**: **82.47%**
 
 ### Coverage Breakdown
 
@@ -25,9 +25,9 @@
 | moleditpy\src\moleditpy\ui\base_picking_dialog.py       |     80 |      4 |   95.0% |
 | moleditpy\src\moleditpy\ui\bond_item.py                 |    362 |     56 |   84.5% |
 | moleditpy\src\moleditpy\ui\bond_length_dialog.py        |    237 |     17 |   92.8% |
-| moleditpy\src\moleditpy\ui\calculation_worker.py        |    547 |     87 |   84.1% |
+| moleditpy\src\moleditpy\ui\calculation_worker.py        |    581 |    103 |   82.3% |
 | moleditpy\src\moleditpy\ui\color_settings_dialog.py     |    166 |     13 |   92.2% |
-| moleditpy\src\moleditpy\ui\compute_logic.py             |    388 |     89 |   77.1% |
+| moleditpy\src\moleditpy\ui\compute_logic.py             |    387 |     89 |   77.0% |
 | moleditpy\src\moleditpy\ui\constrained_optimization_dialog.py |    472 |    120 |   74.6% |
 | moleditpy\src\moleditpy\ui\custom_interactor_style.py   |    470 |    247 |   47.4% |
 | moleditpy\src\moleditpy\ui\custom_qt_interactor.py      |     44 |     35 |   20.5% |
@@ -66,7 +66,7 @@
 | moleditpy\src\moleditpy\utils\default_settings.py       |      1 |      0 |  100.0% |
 | moleditpy\src\moleditpy\utils\sip_isdeleted_safe.py     |     19 |      0 |  100.0% |
 | moleditpy\src\moleditpy\utils\system_utils.py           |     36 |      0 |  100.0% |
-| **TOTAL** | **15644** | **2732** | **82.54%** |
+| **TOTAL** | **15677** | **2748** | **82.47%** |
 
 ## Test Suite Status
 - **Unit tests**: PASSED

--- a/tests/integration/test_calculation_worker.py
+++ b/tests/integration/test_calculation_worker.py
@@ -392,6 +392,8 @@ def test_calculation_worker_opt_failure_auto_fallback_to_uff(qtbot, app):
     mol_block = data.to_mol_block()
 
     worker = CalculationWorker()
+    status_messages = []
+    worker.status_update.connect(lambda msg: status_messages.append(msg))
 
     with (
         patch(
@@ -409,6 +411,10 @@ def test_calculation_worker_opt_failure_auto_fallback_to_uff(qtbot, app):
         assert res_mol is not None
         assert res_mol.HasProp("_pme_optimization_method")
         assert res_mol.GetProp("_pme_optimization_method") == "UFF_RDKIT"
+        assert any(
+            "Process completed (RDKit Conversion / UFF (RDKit))" in msg
+            for msg in status_messages
+        )
 
 
 def test_calculation_worker_mmff_variants(qtbot, app):

--- a/tests/integration/test_calculation_worker.py
+++ b/tests/integration/test_calculation_worker.py
@@ -380,9 +380,9 @@ def test_calculation_worker_constraint_embedding_fallback(qtbot, app):
         assert mock_embed.call_count >= 2
 
 
-def test_calculation_worker_opt_failure_emits_error(qtbot, app):
+def test_calculation_worker_opt_failure_auto_fallback_to_uff(qtbot, app):
     """
-    Test that optimization failure emits an error string instead of failing silently or hanging.
+    Test that MMFF optimization failure auto-falls back to UFF.
     """
     data = MolecularData()
     c = data.add_atom("C", QPointF(0, 0))
@@ -398,15 +398,17 @@ def test_calculation_worker_opt_failure_emits_error(qtbot, app):
             "rdkit.Chem.AllChem.MMFFGetMoleculeProperties", return_value=None
         ) as mock_mmff_props,
     ):
-        # We now wait for the finished signal because optimization failure is non-fatal
         with qtbot.waitSignal(worker.finished, timeout=10000) as blocker:
-            worker.run_calculation(mol_block, {"conversion_mode": "rdkit"})
+            worker.run_calculation(
+                mol_block,
+                {"conversion_mode": "rdkit", "optimization_method": "MMFF_RDKIT"},
+            )
 
         assert mock_mmff_props.called
         res_id, res_mol = blocker.args[0]
         assert res_mol is not None
-        # Check that it tried to set the optimization method property but maybe cleared it or didn't set it
-        # The key is that it didn't emit an error and returned a molecule.
+        assert res_mol.HasProp("_pme_optimization_method")
+        assert res_mol.GetProp("_pme_optimization_method") == "UFF_RDKIT"
 
 
 def test_calculation_worker_mmff_variants(qtbot, app):


### PR DESCRIPTION
## Summary

- Fixes the auto-fallback status message formatting during 2D-to-3D conversion by reading `_pme_optimization_method` from RDKit molecule properties instead of using the initially requested method.
- Modifies the confirmation dialog for UFF fallback to default to "Yes" instead of "No" when pressing Enter.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [x] Documentation
- [x] Tests
- [ ] CI / build

## Related issues

<!-- Link any related issues, e.g. Closes #123 -->

## Test plan

- [x] Ran `python tests/run_all_tests.py` — all pass
- [-] Manually tested in the GUI with the check list
- [x] Added new unit tests

## Checklist

- [x] `python -m flake8 moleditpy/src/ --select=F` returns 0 issues
- [x] No bare `except:` clauses added (use `except Exception as e:` and log the error)
- [x] No new unused imports or variables
- [x] Plugin API changes are backwards-compatible (or documented in Summary)