### PR TITLE
Dev 4.1.2

### DIFF
--- a/docs/LOGGING.md
+++ b/docs/LOGGING.md
@@ -1,0 +1,112 @@
+# Logging in MoleditPy
+
+This document describes the main application's logging system — how it is configured, where output goes, and the correct pattern for contributors writing internal app code.
+
+---
+
+## How Logging Is Set Up
+
+Logging is configured **once** at startup in [`main.py`](../moleditpy/src/moleditpy/main.py) by `setup_logging()`, which is called before the Qt event loop starts.
+
+```
+main() → setup_logging() → QApplication → MainWindow
+```
+
+### What `setup_logging()` does
+
+1. **Reads user settings** from `~/.moleditpy/settings.json` (before Qt is running):
+   - `"log_to_file"` (bool) — whether to also write to a rotating log file.
+   - `"log_level_debug"` (bool) — whether to use `DEBUG` level instead of `INFO`.
+
+2. **Calls `logging.basicConfig(..., stream=sys.stdout)`** on the root logger with level `INFO` (or `DEBUG`) and a full format string:
+   ```
+   %(asctime)s [%(levelname)s] %(name)s (%(pathname)s:%(lineno)d): %(message)s
+   ```
+
+3. **Optionally adds a `RotatingFileHandler`** to the root logger:
+   - Path: `~/.moleditpy/moleditpy.log`
+   - Max size: 1 MB, 3 backup files kept.
+
+4. **Installs `sys.excepthook`** so unhandled Python exceptions are logged as `ERROR` instead of printing to stderr silently.
+
+5. **Routes Qt messages** (`qInstallMessageHandler`) to Python logging. Known noisy Qt warnings (e.g. `"Retrying to obtain clipboard"`) are silently downgraded to `DEBUG`.
+
+---
+
+## User-Facing Settings
+
+| `settings.json` key | Type | Default | Effect |
+|---|---|---|---|
+| `log_to_file` | bool | `false` | Writes to `~/.moleditpy/moleditpy.log` in addition to stdout |
+| `log_level_debug` | bool | `false` | Sets root logger level to `DEBUG` (very verbose) |
+
+Settings are read **before Qt starts** so the full startup sequence is captured.
+
+---
+
+## The Correct Pattern for Internal Code
+
+All modules inside `moleditpy/` must use a **named logger** — never the root logger directly.
+
+```python
+import logging
+
+log = logging.getLogger(__name__)
+
+# Then use it anywhere in the module:
+log.debug("Detailed trace: %s", some_var)
+log.info("File loaded: %s", path)
+log.warning("Unexpected state; continuing anyway")
+log.error("Failed to parse mol block: %s", e)
+log.exception("Unhandled error in callback")  # includes full traceback
+```
+
+Using `__name__` means log records carry the fully-qualified module path (e.g. `moleditpy.ui.io_logic`), which makes filtering and debugging straightforward.
+
+> [!CAUTION]
+> **Never call `logging.basicConfig()` inside a module.** The root logger is already configured by `setup_logging()` at startup. A second `basicConfig()` call is silently ignored in Python 3, but it is misleading and may cause hard-to-debug behaviour if the call order ever changes.
+
+> [!WARNING]
+> **Never use `print()` for diagnostic output in production code.** `print()` bypasses the logging system entirely, does not appear in the log file, and cannot be suppressed by log level. Use `log.debug(...)` instead.
+
+---
+
+## Log Levels — When to Use Which
+
+| Level | Call | Use when |
+|---|---|---|
+| `DEBUG` | `log.debug(...)` | Detailed trace info useful only when debugging (off by default) |
+| `INFO` | `log.info(...)` | Normal significant events (file loaded, plugin initialised, etc.) |
+| `WARNING` | `log.warning(...)` | Unexpected but recoverable situations |
+| `ERROR` | `log.error(...)` | Failures that prevented an operation from completing |
+| `CRITICAL` | `log.critical(...)` | App-level failures (rarely needed in module code) |
+
+Use `log.exception(msg)` inside an `except` block — it logs at `ERROR` level and automatically appends the current traceback.
+
+---
+
+## Log File Location
+
+```
+~/.moleditpy/moleditpy.log          ← current
+~/.moleditpy/moleditpy.log.1        ← previous (up to .3)
+```
+
+Only created when `"log_to_file": true` is set in `settings.json`. The file rotates automatically when it reaches 1 MB.
+
+---
+
+## Qt Message Integration
+
+Qt's own logging (`qDebug`, `qWarning`, etc.) is piped through `_qt_message_handler` into Python logging at the equivalent level. All Qt messages appear with the prefix `Qt:` in the log output so they can be filtered separately.
+
+Known noisy patterns (currently just `"Retrying to obtain clipboard"`) are downgraded to `DEBUG` to avoid flooding the log.
+
+To add a new downgrade pattern, edit the tuple in [`main.py`](../moleditpy/src/moleditpy/main.py#L39):
+
+```python
+_DOWNGRADED_QT_PATTERNS = (
+    "Retrying to obtain clipboard",
+    "Your new noisy pattern here",
+)
+```

--- a/docs/PLUGIN_DEVELOPMENT_MANUAL_V4.md
+++ b/docs/PLUGIN_DEVELOPMENT_MANUAL_V4.md
@@ -129,6 +129,7 @@ The `context` object passed to `initialize(context)` is your safe proxy to the a
 | **Files** | `register_drop_handler(cb, priority)` | Handle drag-and-drop onto the window |
 | **Molecule** | `current_molecule` | Get / set the active RDKit mol |
 | **Molecule** | `load_from_smiles(smiles)` | Add molecule from SMILES string |
+| **Molecule** | `show_xyz_data(xyz_text, source_name="XYZ data")` | Display XYZ text in the 3D viewer |
 | **Molecule** | `to_xyz_block()` | Export current 3D coordinates as an XYZ block |
 | **Molecule** | `get_selected_atom_indices()` | Indices of user-selected atoms |
 | **Molecule** | `push_undo_checkpoint()` | Snapshot state to undo stack |
@@ -290,6 +291,25 @@ Get or set the active RDKit molecule object.
 #### `load_from_smiles(smiles)`
 Generate a 2D structure from a SMILES string and automatically add it to the 2D editor canvas.
 - **smiles** (`str`): The SMILES string.
+
+#### `show_xyz_data(xyz_text, source_name="XYZ data")`
+Parse XYZ text, set it as the active molecule, switch to the 3D viewer, and draw it immediately.
+- **xyz_text** (`str`): Either a full XYZ block with atom count/comment lines, or headerless atom rows in `symbol x y z` format.
+- **source_name** (`str`): Optional label used in the status bar.
+- **Returns** (`Optional[rdkit.Chem.Mol]`): The loaded molecule, or None if parsing fails.
+
+Dummy or non-standard atom labels are loaded as RDKit dummy atoms (`*`). This includes labels such as `-`, `X`, `X:`, and any unrecognized element token. Dummy atoms keep their original token in the atom property `xyz_original_symbol`.
+
+```python
+xyz_text = """- 0.000 0.000 0.000
+C 1.250 0.000 0.000
+O 2.400 0.000 0.000
+"""
+
+mol = context.show_xyz_data(xyz_text, source_name="ORCA result")
+if mol is None:
+    context.show_status_message("Failed to display XYZ data.", 3000)
+```
 
 #### `to_xyz_block()`
 Extracts the current 3D molecule structure and returns it as a string containing only the atomic elements and X, Y, Z coordinates. Omits standard XYZ headers (like atom count).

--- a/moleditpy/src/moleditpy/plugins/plugin_interface.py
+++ b/moleditpy/src/moleditpy/plugins/plugin_interface.py
@@ -499,6 +499,17 @@ class PluginContext:
         if mw and hasattr(mw, "string_importer_manager"):
             mw.string_importer_manager.load_from_smiles(smiles)
 
+    def show_xyz_data(
+        self, xyz_text: str, source_name: str = "XYZ data"
+    ) -> Optional[Any]:
+        """Display XYZ text in the 3D viewer and return the loaded RDKit Mol."""
+        mw = self.get_main_window()
+        if mw and hasattr(mw, "io_manager"):
+            show = getattr(mw.io_manager, "show_xyz_data", None)
+            if show is not None:
+                return show(xyz_text, source_name=source_name)
+        return None
+
     def to_xyz_block(self) -> Optional[str]:
         """Return the current 3D structure as an XYZ block (only element x y z lines)."""
         mol = self.current_mol

--- a/moleditpy/src/moleditpy/ui/io_logic.py
+++ b/moleditpy/src/moleditpy/ui/io_logic.py
@@ -37,6 +37,9 @@ from rdkit.Chem import AllChem, rdGeometry, rdMolTransforms, Descriptors
 from ..utils.constants import COVALENT_RADII, VERSION
 
 
+DUMMY_XYZ_SYMBOLS = {"*", "-", "X", "DU", "DUM", "DUMMY", "Q", "BQ", "LP"}
+
+
 class IOManager:
     """Independent manager for IO actions (Load/Save), ported from Mixins."""
 
@@ -84,6 +87,154 @@ class IOManager:
         lines[3] = self.fix_mol_counts_line(lines[3])
         return "\n".join(lines)
 
+    def _normalize_xyz_symbol(self, raw_symbol: str) -> Tuple[str, bool]:
+        """Return the RDKit symbol for an XYZ atom and whether it is a dummy."""
+        stripped = raw_symbol.strip()
+        if ":" in stripped:
+            return "*", True
+        if stripped.upper() in DUMMY_XYZ_SYMBOLS:
+            return "*", True
+        symbol = stripped.capitalize()
+        try:
+            atomic_num = Chem.GetPeriodicTable().GetAtomicNumber(symbol)
+        except (RuntimeError, ValueError, TypeError):
+            return "*", True
+        if atomic_num <= 0:
+            return "*", True
+        return symbol, False
+
+    def _mol_from_xyz_lines(self, raw_lines: list[str]) -> Any:
+        """Create an RDKit molecule from XYZ text lines."""
+        lines = [ln.strip() for ln in raw_lines if not ln.strip().startswith("#")]
+        while lines and not lines[0]:
+            lines.pop(0)
+
+        if not lines:
+            raise ValueError("XYZ file format error: too few lines")
+
+        try:
+            num_atoms = int(lines[0])
+            atom_start = 2
+            if len(lines) < 2:
+                raise ValueError("XYZ file format error: too few lines")
+            if num_atoms == 0:
+                raise ValueError("XYZ file has zero atoms")
+        except ValueError:
+            num_atoms = len(lines)
+            atom_start = 0
+
+        atoms_data = []
+        has_dummy_atoms = False
+        atom_lines = lines[atom_start : atom_start + num_atoms]
+        if len(atom_lines) < num_atoms:
+            raise ValueError("XYZ file format error: fewer atom rows than expected")
+
+        for i, line in enumerate(atom_lines):
+            parts = line.split()
+            if len(parts) < 4:
+                raise ValueError(f"Invalid atom data at line {atom_start + i + 1}")
+            raw_symbol = parts[0]
+            symbol, is_dummy = self._normalize_xyz_symbol(raw_symbol)
+            has_dummy_atoms = has_dummy_atoms or is_dummy
+            atoms_data.append(
+                (symbol, float(parts[1]), float(parts[2]), float(parts[3]))
+            )
+
+        if not atoms_data:
+            raise ValueError("No valid atoms found in XYZ file")
+
+        mol = Chem.RWMol()
+        conf = Chem.Conformer(len(atoms_data))
+        for i, (symbol, x, y, z) in enumerate(atoms_data):
+            atom = Chem.Atom(symbol)
+            atom.SetIntProp("xyz_unique_id", i)
+            if atom.GetAtomicNum() == 0:
+                atom.SetProp("xyz_original_symbol", atom_lines[i].split()[0])
+            mol.AddAtom(atom)
+            conf.SetAtomPosition(i, rdGeometry.Point3D(x, y, z))
+        mol.AddConformer(conf)
+
+        settings = self.host.init_manager.settings
+        skip_checks = bool(settings.get("skip_chemistry_checks", False))
+
+        def _set_prop(m: Chem.Mol, key: str, val: Any) -> None:
+            try:
+                if isinstance(val, int):
+                    m.SetIntProp(key, val)
+                elif isinstance(val, float):
+                    m.SetDoubleProp(key, val)
+            except (RuntimeError, TypeError, ValueError):
+                # Safe defensive fallback catching RuntimeError, TypeError, ValueError
+                pass
+
+        def _process(charge_val: int, use_rd_determine: bool = True) -> Any:
+            if use_rd_determine:
+                try:
+                    from rdkit.Chem import rdDetermineBonds
+
+                    mol_copy = Chem.RWMol(mol)
+                    rdDetermineBonds.DetermineBonds(mol_copy, charge=charge_val)
+                    candidate = mol_copy.GetMol()
+                    _set_prop(candidate, "_xyz_charge", charge_val)
+                    return candidate
+                except (RuntimeError, ValueError, TypeError) as e:
+                    raise e
+            else:
+                self.estimate_bonds_from_distances(mol)
+                candidate = mol.GetMol()
+                _set_prop(candidate, "_xyz_charge", charge_val)
+                return candidate
+
+        if skip_checks or has_dummy_atoms:
+            final_mol = _process(0, use_rd_determine=False)
+            _set_prop(final_mol, "_xyz_skip_checks", 1)
+        else:
+            final_mol = None
+            settings = self.host.init_manager.settings
+            # First try with charge 0 (per user's 'first try with 0 then ask' requirement)
+            # but only if "Always ask" is not explicitly enabled in settings.
+            if not settings.get("always_ask_charge", False):
+                try:
+                    final_mol = _process(0, use_rd_determine=True)
+                except (RuntimeError, ValueError, TypeError):
+                    final_mol = None
+
+            # If still no final_mol (because always_ask is True, or charge 0 failed)
+            if final_mol is None:
+                while True:
+                    prompt_fn = getattr(self, "prompt_for_charge", None)
+                    if callable(prompt_fn):
+                        result = prompt_fn()
+                        if isinstance(result, tuple) and len(result) == 3:
+                            charge_val, ok, skip_flag = result
+                        else:
+                            charge_val, ok, skip_flag = 0, True, False
+                    else:
+                        charge_val, ok, skip_flag = 0, True, False
+
+                    if not ok:
+                        return None
+                    if skip_flag:
+                        final_mol = _process(0, use_rd_determine=False)
+                        _set_prop(final_mol, "_xyz_skip_checks", 1)
+                        break
+                    try:
+                        final_mol = _process(charge_val, use_rd_determine=True)
+                        break
+                    except (RuntimeError, ValueError, TypeError) as e:
+                        if self.host.statusBar():
+                            self.host.statusBar().showMessage(
+                                f"Chemistry failed for charge {charge_val}: {e}. Try a different charge or skip."
+                            )
+                        if not callable(prompt_fn):
+                            raise e
+
+        if final_mol:
+            final_mol.xyz_atom_data = atoms_data
+        if final_mol and has_dummy_atoms and not hasattr(final_mol, "xyz_atom_data"):
+            final_mol.xyz_atom_data = atoms_data
+        return final_mol
+
     def load_xyz_file(self, file_path: str) -> Optional[Any]:
         """Load XYZ file and create RDKit Mol with charge prompt and bond determination."""
         if not self.host.state_manager.check_unsaved_changes():
@@ -91,130 +242,53 @@ class IOManager:
 
         try:
             with open(file_path, "r", encoding="utf-8") as f:
-                raw_lines = f.readlines()
-
-            lines = [ln.strip() for ln in raw_lines if not ln.strip().startswith("#")]
-            while lines and not lines[0]:
-                lines.pop(0)
-
-            if len(lines) < 2:
-                raise ValueError("XYZ file format error: too few lines")
-
-            num_atoms = int(lines[0])
-            if num_atoms == 0:
-                raise ValueError("XYZ file has zero atoms")
-
-            atoms_data = []
-            for i, line in enumerate(lines[2 : 2 + num_atoms]):
-                parts = line.split()
-                if len(parts) < 4:
-                    raise ValueError(f"Invalid atom data at line {i + 3}")
-                symbol = parts[0].capitalize()
-                try:
-                    Chem.Atom(symbol)
-                except (RuntimeError, ValueError):
-                    settings = self.host.init_manager.settings
-                    if settings.get("skip_chemistry_checks", False):
-                        symbol = "C"
-                    else:
-                        raise ValueError(f"Unrecognized element symbol: {parts[0]}")
-                atoms_data.append(
-                    (symbol, float(parts[1]), float(parts[2]), float(parts[3]))
-                )
-
-            if not atoms_data:
-                raise ValueError("No valid atoms found in XYZ file")
-
-            mol = Chem.RWMol()
-            conf = Chem.Conformer(len(atoms_data))
-            for i, (symbol, x, y, z) in enumerate(atoms_data):
-                atom = Chem.Atom(symbol)
-                atom.SetIntProp("xyz_unique_id", i)
-                mol.AddAtom(atom)
-                conf.SetAtomPosition(i, rdGeometry.Point3D(x, y, z))
-            mol.AddConformer(conf)
-
-            settings = self.host.init_manager.settings
-            skip_checks = bool(settings.get("skip_chemistry_checks", False))
-
-            def _set_prop(m: Chem.Mol, key: str, val: Any) -> None:
-                try:
-                    if isinstance(val, int):
-                        m.SetIntProp(key, val)
-                    elif isinstance(val, float):
-                        m.SetDoubleProp(key, val)
-                except (RuntimeError, TypeError, ValueError):
-                    # Safe defensive fallback catching RuntimeError, TypeError, ValueError
-                    pass
-
-            def _process(charge_val: int, use_rd_determine: bool = True) -> Any:
-                if use_rd_determine:
-                    try:
-                        from rdkit.Chem import rdDetermineBonds
-
-                        mol_copy = Chem.RWMol(mol)
-                        rdDetermineBonds.DetermineBonds(mol_copy, charge=charge_val)
-                        candidate = mol_copy.GetMol()
-                        _set_prop(candidate, "_xyz_charge", charge_val)
-                        return candidate
-                    except (RuntimeError, ValueError, TypeError) as e:
-                        raise e
-                else:
-                    self.estimate_bonds_from_distances(mol)
-                    candidate = mol.GetMol()
-                    _set_prop(candidate, "_xyz_charge", charge_val)
-                    return candidate
-
-            if skip_checks:
-                final_mol = _process(0, use_rd_determine=False)
-                _set_prop(final_mol, "_xyz_skip_checks", 1)
-            else:
-                final_mol = None
-                settings = self.host.init_manager.settings
-                # First try with charge 0 (per user's 'first try with 0 then ask' requirement)
-                # but only if "Always ask" is not explicitly enabled in settings.
-                if not settings.get("always_ask_charge", False):
-                    try:
-                        final_mol = _process(0, use_rd_determine=True)
-                    except (RuntimeError, ValueError, TypeError):
-                        final_mol = None
-
-                # If still no final_mol (because always_ask is True, or charge 0 failed)
-                if final_mol is None:
-                    while True:
-                        prompt_fn = getattr(self, "prompt_for_charge", None)
-                        if callable(prompt_fn):
-                            result = prompt_fn()
-                            if isinstance(result, tuple) and len(result) == 3:
-                                charge_val, ok, skip_flag = result
-                            else:
-                                charge_val, ok, skip_flag = 0, True, False
-                        else:
-                            charge_val, ok, skip_flag = 0, True, False
-
-                        if not ok:
-                            return None
-                        if skip_flag:
-                            final_mol = _process(0, use_rd_determine=False)
-                            _set_prop(final_mol, "_xyz_skip_checks", 1)
-                            break
-                        try:
-                            final_mol = _process(charge_val, use_rd_determine=True)
-                            break
-                        except (RuntimeError, ValueError, TypeError) as e:
-                            if self.host.statusBar():
-                                self.host.statusBar().showMessage(
-                                    f"Chemistry failed for charge {charge_val}: {e}. Try a different charge or skip."
-                                )
-                            if not callable(prompt_fn):
-                                raise e
-
-                if final_mol:
-                    final_mol.xyz_atom_data = atoms_data
-            return final_mol
-
+                return self._mol_from_xyz_lines(f.readlines())
         except (RuntimeError, TypeError, ValueError, UnicodeDecodeError) as e:
             self.host.statusBar().showMessage(f"Error parsing XYZ file: {e}")
+            return None
+
+    def load_xyz_block(self, xyz_text: str) -> Optional[Any]:
+        """Load XYZ text and create an RDKit Mol without opening a file dialog."""
+        try:
+            return self._mol_from_xyz_lines(xyz_text.splitlines())
+        except (RuntimeError, TypeError, ValueError, UnicodeDecodeError) as e:
+            self.host.statusBar().showMessage(f"Error parsing XYZ data: {e}")
+            return None
+
+    def show_xyz_data(
+        self, xyz_text: str, source_name: str = "XYZ data"
+    ) -> Optional[Any]:
+        """Load XYZ text, set it as the current molecule, and draw it in 3D."""
+        try:
+            mol = self.load_xyz_block(xyz_text)
+            if mol is None:
+                return None
+
+            self.host.edit_actions_manager.clear_all(skip_check=True)
+            self.host.set_current_molecule(mol)
+            self.host.set_atom_id_to_rdkit_idx_map({})
+
+            skip_flag = False
+            if mol.HasProp("_xyz_skip_checks"):
+                skip_flag = bool(mol.GetIntProp("_xyz_skip_checks"))
+            self.host.is_xyz_derived = skip_flag or (mol.GetNumBonds() == 0)
+
+            self.host.view_3d_manager.draw_molecule_3d(mol)
+            self.host.ui_manager.enter_3d_viewer_mode()
+            self.host.ui_manager.enable_3d_features(True)
+            self.host.view_3d_manager.update_atom_id_menu_text()
+            self.host.view_3d_manager.update_atom_id_menu_state()
+
+            if self.host.statusBar():
+                self.host.statusBar().showMessage(
+                    f"3D Viewer Mode: Loaded {source_name}"
+                )
+            self.host.set_has_unsaved_changes(False)
+            self.host.state_manager.update_window_title()
+            return mol
+        except (RuntimeError, TypeError, ValueError, AttributeError) as e:
+            if self.host.statusBar():
+                self.host.statusBar().showMessage(f"XYZ display failed: {e}")
             return None
 
     def prompt_for_charge(self) -> Tuple[Optional[int], bool, bool]:
@@ -261,6 +335,8 @@ class IOManager:
             for j in range(i + 1, num_atoms):
                 atom_i = mol.GetAtomWithIdx(i)
                 atom_j = mol.GetAtomWithIdx(j)
+                if atom_i.GetAtomicNum() == 0 or atom_j.GetAtomicNum() == 0:
+                    continue
                 distance = rdMolTransforms.GetBondLength(conf, i, j)
                 symbol_i = atom_i.GetSymbol()
                 symbol_j = atom_j.GetSymbol()

--- a/moleditpy/src/moleditpy/ui/io_logic.py
+++ b/moleditpy/src/moleditpy/ui/io_logic.py
@@ -34,10 +34,7 @@ from PyQt6.QtWidgets import (
 from rdkit import Chem
 from rdkit.Chem import AllChem, rdGeometry, rdMolTransforms, Descriptors
 
-from ..utils.constants import COVALENT_RADII, VERSION
-
-
-DUMMY_XYZ_SYMBOLS = {"*", "-", "X", "DU", "DUM", "DUMMY", "Q", "BQ", "LP"}
+from ..utils.constants import COVALENT_RADII, DUMMY_XYZ_SYMBOLS, VERSION
 
 
 class IOManager:

--- a/moleditpy/src/moleditpy/ui/io_logic.py
+++ b/moleditpy/src/moleditpy/ui/io_logic.py
@@ -112,14 +112,17 @@ class IOManager:
         if not lines:
             raise ValueError("XYZ file format error: too few lines")
 
+        atom_start = 2
         try:
-            num_atoms = int(lines[0])
-            atom_start = 2
             if len(lines) < 2:
                 raise ValueError("XYZ file format error: too few lines")
+            num_atoms = int(lines[0])
             if num_atoms == 0:
                 raise ValueError("XYZ file has zero atoms")
-        except ValueError:
+        except ValueError as exc:
+            # Not a standard headed XYZ — treat all lines as atom rows
+            if "zero atoms" in str(exc) or "too few" in str(exc):
+                raise
             num_atoms = len(lines)
             atom_start = 0
 
@@ -177,8 +180,8 @@ class IOManager:
                     candidate = mol_copy.GetMol()
                     _set_prop(candidate, "_xyz_charge", charge_val)
                     return candidate
-                except (RuntimeError, ValueError, TypeError) as e:
-                    raise e
+                except (RuntimeError, ValueError, TypeError):
+                    raise
             else:
                 self.estimate_bonds_from_distances(mol)
                 candidate = mol.GetMol()
@@ -190,7 +193,6 @@ class IOManager:
             _set_prop(final_mol, "_xyz_skip_checks", 1)
         else:
             final_mol = None
-            settings = self.host.init_manager.settings
             # First try with charge 0 (per user's 'first try with 0 then ask' requirement)
             # but only if "Always ask" is not explicitly enabled in settings.
             if not settings.get("always_ask_charge", False):
@@ -230,8 +232,6 @@ class IOManager:
                             raise e
 
         if final_mol:
-            final_mol.xyz_atom_data = atoms_data
-        if final_mol and has_dummy_atoms and not hasattr(final_mol, "xyz_atom_data"):
             final_mol.xyz_atom_data = atoms_data
         return final_mol
 

--- a/moleditpy/src/moleditpy/utils/constants.py
+++ b/moleditpy/src/moleditpy/utils/constants.py
@@ -57,7 +57,7 @@ CLIPBOARD_MIME_TYPE = "application/x-moleditpy-fragment"
 
 # XYZ dummy/pseudo-atom labels that map to RDKit wildcard atom (*)
 DUMMY_XYZ_SYMBOLS: frozenset[str] = frozenset(
-    {"*", "-", "X", "DU", "DUM", "DUMMY", "Q", "BQ", "LP"}
+    {"*", "-", "X", "DA", "DU", "DUM", "DUMMY", "Q", "BQ", "LP"}
 )
 
 # Physical bond length (approximate) used to convert scene pixels to angstroms.

--- a/moleditpy/src/moleditpy/utils/constants.py
+++ b/moleditpy/src/moleditpy/utils/constants.py
@@ -55,6 +55,11 @@ BOND_OFFSET = 3.5
 DEFAULT_BOND_LENGTH = 75  # Standard bond length used in templates
 CLIPBOARD_MIME_TYPE = "application/x-moleditpy-fragment"
 
+# XYZ dummy/pseudo-atom labels that map to RDKit wildcard atom (*)
+DUMMY_XYZ_SYMBOLS: frozenset[str] = frozenset(
+    {"*", "-", "X", "DU", "DUM", "DUMMY", "Q", "BQ", "LP"}
+)
+
 # Physical bond length (approximate) used to convert scene pixels to angstroms.
 # DEFAULT_BOND_LENGTH is the length in pixels used in the editor UI for a typical bond.
 # Many molecular file formats expect coordinates in angstroms; use ~1.5 Å as a typical single-bond length.

--- a/tests/assertion_catalog.md
+++ b/tests/assertion_catalog.md
@@ -2806,6 +2806,16 @@ _init_manager.current_file_path is updated to the loaded file._
 
 - assert host.init_manager.current_file_path == str(xyz)
 
+### TestShowXYZData.test_sets_current_mol_and_draws
+_XYZ text display sets current_mol and enters 3D viewer mode._
+
+- assert result is mol
+- assert host.view_3d_manager.current_mol is mol
+- host.view_3d_manager.draw_molecule_3d.assert_called_once_with(mol)
+- host.ui_manager.enter_3d_viewer_mode.assert_called_once()
+- host.ui_manager.enable_3d_features.assert_called_once_with(True)
+- assert host.is_xyz_derived is True
+
 ### TestSave3DAsMol.test_no_mol_shows_error_no_dialog
 _current_mol is None → error message, dialog never opened._
 
@@ -4004,6 +4014,25 @@ _Verify XYZ loading with automatic bond estimation._
 - assert mol.GetNumAtoms() == 2
 - assert mol.GetNumBonds() == 1
 
+### test_load_xyz_with_dummy_atom
+_Verify XYZ dummy atoms load as atomic-number-zero placeholders._
+
+- assert mol is not None
+- assert mol.GetNumAtoms() == 2
+- assert mol.GetNumBonds() == 0
+- assert dummy_atom.GetAtomicNum() == 0
+- assert dummy_atom.GetSymbol() == '*'
+- assert dummy_atom.GetProp('xyz_original_symbol') == dummy_symbol
+- assert mol.HasProp('_xyz_skip_checks')
+
+### test_load_headerless_xyz_atom_rows
+_Verify XYZ import also accepts atom coordinate rows without headers._
+
+- assert mol is not None
+- assert mol.GetNumAtoms() == 2
+- assert mol.GetAtomWithIdx(0).GetAtomicNum() == 0
+- assert mol.GetAtomWithIdx(0).GetProp('xyz_original_symbol') == '-'
+
 ### test_save_as_mol_logic
 _Verify saving a molecule as a MOL file._
 
@@ -4026,11 +4055,15 @@ _Verify handling of user cancellation during the charge input loop._
 
 - assert result is None
 
-### test_load_xyz_unrecognized_symbol
-_Test load_xyz_file raises ValueError for unrecognized element symbols._
+### test_load_xyz_unrecognized_symbol_as_dummy
+_Verify unrecognized XYZ symbols load as dummy atom placeholders._
 
-- assert mol is None
-- assert any(('Unrecognized element symbol' in m for m in msgs))
+- assert mol is not None
+- assert mol.GetNumAtoms() == 1
+- assert dummy_atom.GetAtomicNum() == 0
+- assert dummy_atom.GetSymbol() == '*'
+- assert dummy_atom.GetProp('xyz_original_symbol') == 'Xx'
+- assert mol.HasProp('_xyz_skip_checks')
 
 ### test_load_mol_file_with_v2000_fix
 _Verify that malformed V2000 headers are fixed automatically during MOL load._
@@ -4401,6 +4434,12 @@ _enter_3d_mode is an alias for enter_3d_viewer_mode._
 _load_from_smiles delegates to string_importer_manager and is safe when absent._
 
 - mock_main_window.string_importer_manager.load_from_smiles.assert_called_once_with('C')
+
+### TestPluginInterface.test_show_xyz_data
+_show_xyz_data delegates to IOManager and returns the loaded molecule._
+
+- assert mol == 'mol'
+- mock_main_window.io_manager.show_xyz_data.assert_called_once_with(xyz_text, source_name='plugin result')
 
 ### TestPluginInterface.test_to_xyz_block
 _to_xyz_block returns an XYZ string from current_mol, or None if no mol._

--- a/tests/coverage_report.md
+++ b/tests/coverage_report.md
@@ -1,6 +1,6 @@
 # MoleditPy Coverage Report
 
-- **Overall Project Coverage**: **82.48%**
+- **Overall Project Coverage**: **82.47%**
 
 ### Coverage Breakdown
 
@@ -10,7 +10,7 @@
 | moleditpy\src\moleditpy\main.py                         |    112 |     33 |   70.5% |
 | moleditpy\src\moleditpy\core\mol_geometry.py            |    260 |     19 |   92.7% |
 | moleditpy\src\moleditpy\core\molecular_data.py          |    245 |     29 |   88.2% |
-| moleditpy\src\moleditpy\plugins\plugin_interface.py     |    224 |      5 |   97.8% |
+| moleditpy\src\moleditpy\plugins\plugin_interface.py     |    231 |      6 |   97.4% |
 | moleditpy\src\moleditpy\plugins\plugin_manager.py       |    369 |     10 |   97.3% |
 | moleditpy\src\moleditpy\plugins\plugin_manager_window.py |    185 |      2 |   98.9% |
 | moleditpy\src\moleditpy\ui\__init__.py                  |      7 |      3 |   57.1% |
@@ -38,12 +38,12 @@
 | moleditpy\src\moleditpy\ui\edit_actions_logic.py        |    813 |    199 |   75.5% |
 | moleditpy\src\moleditpy\ui\export_logic.py              |    520 |    153 |   70.6% |
 | moleditpy\src\moleditpy\ui\geometry_base_dialog.py      |     51 |      1 |   98.0% |
-| moleditpy\src\moleditpy\ui\io_logic.py                  |    599 |    107 |   82.1% |
+| moleditpy\src\moleditpy\ui\io_logic.py                  |    657 |    118 |   82.0% |
 | moleditpy\src\moleditpy\ui\main_window.py               |    196 |     14 |   92.9% |
 | moleditpy\src\moleditpy\ui\main_window_init.py          |   1052 |    112 |   89.4% |
 | moleditpy\src\moleditpy\ui\mirror_dialog.py             |     72 |      7 |   90.3% |
 | moleditpy\src\moleditpy\ui\molecular_scene_handler.py   |    952 |    161 |   83.1% |
-| moleditpy\src\moleditpy\ui\molecule_scene.py            |    614 |    126 |   79.5% |
+| moleditpy\src\moleditpy\ui\molecule_scene.py            |    614 |    128 |   79.2% |
 | moleditpy\src\moleditpy\ui\move_group_dialog.py         |    386 |    130 |   66.3% |
 | moleditpy\src\moleditpy\ui\move_selected_atoms_dialog.py |    390 |     41 |   89.5% |
 | moleditpy\src\moleditpy\ui\periodic_table_dialog.py     |     37 |      2 |   94.6% |
@@ -62,11 +62,11 @@
 | moleditpy\src\moleditpy\ui\settings_tabs\settings_3d_tabs.py |    142 |      0 |  100.0% |
 | moleditpy\src\moleditpy\ui\settings_tabs\settings_other_tab.py |     89 |      0 |  100.0% |
 | moleditpy\src\moleditpy\ui\settings_tabs\settings_tab_base.py |     56 |      0 |  100.0% |
-| moleditpy\src\moleditpy\utils\constants.py              |     54 |      0 |  100.0% |
+| moleditpy\src\moleditpy\utils\constants.py              |     55 |      0 |  100.0% |
 | moleditpy\src\moleditpy\utils\default_settings.py       |      1 |      0 |  100.0% |
 | moleditpy\src\moleditpy\utils\sip_isdeleted_safe.py     |     19 |      0 |  100.0% |
 | moleditpy\src\moleditpy\utils\system_utils.py           |     36 |      0 |  100.0% |
-| **TOTAL** | **15677** | **2746** | **82.48%** |
+| **TOTAL** | **15743** | **2760** | **82.47%** |
 
 ## Test Suite Status
 - **Unit tests**: PASSED

--- a/tests/unit/test_io_manager.py
+++ b/tests/unit/test_io_manager.py
@@ -352,6 +352,29 @@ class TestLoadXYZFor3DViewing:
         assert host.init_manager.current_file_path == str(xyz)
 
 
+class TestShowXYZData:
+    """Tests for IOManager.show_xyz_data()."""
+
+    def test_sets_current_mol_and_draws(self, qapp):
+        """XYZ text display sets current_mol and enters 3D viewer mode."""
+        host = DummyHost()
+        io = IOManager(host)
+        mol = MagicMock()
+        mol.HasProp.return_value = True
+        mol.GetIntProp.return_value = 1
+        mol.GetNumBonds.return_value = 0
+        io.load_xyz_block = MagicMock(return_value=mol)
+
+        result = io.show_xyz_data("- 0.0 0.0 0.0\n", "plugin result")
+
+        assert result is mol
+        assert host.view_3d_manager.current_mol is mol
+        host.view_3d_manager.draw_molecule_3d.assert_called_once_with(mol)
+        host.ui_manager.enter_3d_viewer_mode.assert_called_once()
+        host.ui_manager.enable_3d_features.assert_called_once_with(True)
+        assert host.is_xyz_derived is True
+
+
 # ===========================================================================
 # Tests for save_3d_as_mol
 # ===========================================================================

--- a/tests/unit/test_parser_robustness.py
+++ b/tests/unit/test_parser_robustness.py
@@ -150,7 +150,7 @@ def test_load_mol_counts_fix():
     "invalid_xyz",
     [
         "1\nTitle\n",  # Missing atom line
-        "1\nTitle\nX 0 0 0",  # Invalid element
+        "1\nTitle\nC 0.0 0.0",  # Missing coordinate (Z)
         "0\nTitle\n",  # Zero atoms
     ],
 )

--- a/tests/unit/test_parsers.py
+++ b/tests/unit/test_parsers.py
@@ -282,6 +282,40 @@ def test_load_xyz_file_with_estimation(mock_parser_host, tmp_path):
     assert mol.GetNumBonds() == 1
 
 
+@pytest.mark.parametrize("dummy_symbol", ["X", "X:", "-"])
+def test_load_xyz_with_dummy_atom(mock_parser_host, tmp_path, dummy_symbol):
+    """Verify XYZ dummy atoms load as atomic-number-zero placeholders."""
+    parser = DummyParser(mock_parser_host)
+    xyz_content = f"2\nDummy site\n{dummy_symbol} 0.0 0.0 0.0\nC 1.0 0.0 0.0\n"
+    xyz_file = tmp_path / "dummy.xyz"
+    xyz_file.write_text(xyz_content)
+
+    mol = parser.load_xyz_file(str(xyz_file))
+
+    assert mol is not None
+    assert mol.GetNumAtoms() == 2
+    assert mol.GetNumBonds() == 0
+    dummy_atom = mol.GetAtomWithIdx(0)
+    assert dummy_atom.GetAtomicNum() == 0
+    assert dummy_atom.GetSymbol() == "*"
+    assert dummy_atom.GetProp("xyz_original_symbol") == dummy_symbol
+    assert mol.HasProp("_xyz_skip_checks")
+
+
+def test_load_headerless_xyz_atom_rows(mock_parser_host, tmp_path):
+    """Verify XYZ import also accepts atom coordinate rows without headers."""
+    parser = DummyParser(mock_parser_host)
+    xyz_file = tmp_path / "headerless.xyz"
+    xyz_file.write_text("- 0.0 0.0 0.0\nC 1.0 0.0 0.0\n")
+
+    mol = parser.load_xyz_file(str(xyz_file))
+
+    assert mol is not None
+    assert mol.GetNumAtoms() == 2
+    assert mol.GetAtomWithIdx(0).GetAtomicNum() == 0
+    assert mol.GetAtomWithIdx(0).GetProp("xyz_original_symbol") == "-"
+
+
 def test_save_as_mol_logic(mock_parser_host, tmp_path):
     """Verify saving a molecule as a MOL file."""
     parser = DummyParser(mock_parser_host)
@@ -343,18 +377,20 @@ def test_load_xyz_charge_loop_cancel(mock_parser_host, tmp_path):
     assert result is None
 
 
-def test_load_xyz_unrecognized_symbol(mock_parser_host, tmp_path):
-    """Test load_xyz_file raises ValueError for unrecognized element symbols."""
+def test_load_xyz_unrecognized_symbol_as_dummy(mock_parser_host, tmp_path):
+    """Verify unrecognized XYZ symbols load as dummy atom placeholders."""
     parser = DummyParserExt(mock_parser_host)
     xyz_path = tmp_path / "unknown.xyz"
     xyz_path.write_text("1\nUnknown\nXx 0.0 0.0 0.0\n")
     parser.settings["skip_chemistry_checks"] = False
     mol = parser.load_xyz_file(str(xyz_path))
-    assert mol is None
-    msgs = [
-        str(c.args[0]) for c in parser.statusBar().showMessage.call_args_list if c.args
-    ]
-    assert any("Unrecognized element symbol" in m for m in msgs)
+    assert mol is not None
+    assert mol.GetNumAtoms() == 1
+    dummy_atom = mol.GetAtomWithIdx(0)
+    assert dummy_atom.GetAtomicNum() == 0
+    assert dummy_atom.GetSymbol() == "*"
+    assert dummy_atom.GetProp("xyz_original_symbol") == "Xx"
+    assert mol.HasProp("_xyz_skip_checks")
 
 
 def test_load_mol_file_with_v2000_fix(mock_parser_host, tmp_path):

--- a/tests/unit/test_plugin_interface.py
+++ b/tests/unit/test_plugin_interface.py
@@ -442,6 +442,21 @@ class TestPluginInterface:
         del mock_main_window.string_importer_manager
         ctx.load_from_smiles("C")  # Should not raise
 
+    def test_show_xyz_data(self, mock_manager, mock_main_window):
+        """show_xyz_data delegates to IOManager and returns the loaded molecule."""
+        mock_manager.get_main_window.return_value = mock_main_window
+        mock_main_window.io_manager = MagicMock()
+        mock_main_window.io_manager.show_xyz_data.return_value = "mol"
+        ctx = PluginContext(mock_manager, "TestPlugin")
+        xyz_text = "1\nGenerated\n- 0.0 0.0 0.0\n"
+
+        mol = ctx.show_xyz_data(xyz_text, source_name="plugin result")
+
+        assert mol == "mol"
+        mock_main_window.io_manager.show_xyz_data.assert_called_once_with(
+            xyz_text, source_name="plugin result"
+        )
+
     def test_to_xyz_block(self, mock_manager, mock_main_window):
         """to_xyz_block returns an XYZ string from current_mol, or None if no mol."""
         from rdkit import Chem


### PR DESCRIPTION
## Summary

<!-- What does this PR do? List the key changes in 2–4 bullet points. -->

- **Robust XYZ Dummy/Unknown Atom Parsing**: Implemented robust handling for unrecognized atom symbols (like `DA`, `Xx`, `-`, `X`, `X:`, etc.) by normalizing them to dummy atoms (`*` / atomic number 0) and preserving original symbols in `xyz_original_symbol`.
- **Bond Estimation Fix**: Switched to distance-based bond estimation (skipping dummy atoms) when dummy atoms are detected to prevent crashes in the valence-based `DetermineBonds` routine. Also fixed a return indentation bug in `_mol_from_xyz_lines`.
- **New Plugin API (`show_xyz_data`)**: Exposed `show_xyz_data` on `PluginContext` to allow external plugins to directly load and display raw XYZ strings.
- **Documentation & Logging Reference**: Created `docs/LOGGING.md` for the main application's logging framework and updated `docs/PLUGIN_DEVELOPMENT_MANUAL_V4.md` for the new API.

## Type of change

<!-- Check all that apply. -->

- [x] Bug fix
- [x] New feature
- [x] Refactor / code cleanup
- [x] Documentation
- [x] Tests
- [ ] CI / build

## Related issues

<!-- Link any related issues, e.g. Closes #123 -->

## Test plan

<!-- How did you verify the change works? -->

- [x] Ran `python tests/run_all_tests.py` — all pass
- [-] Manually tested in the GUI with the check list
- [x] Added new unit tests

## Checklist

- [x] `python -m flake8 moleditpy/src/ --select=F` returns 0 issues
- [x] No bare `except:` clauses added (use `except Exception as e:` and log the error)
- [x] No new unused imports or variables
- [x] Plugin API changes are backwards-compatible (or documented in Summary)