### PR TITLE
Dev 4.2.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -211,7 +211,7 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add moleditpy/pyproject.toml moleditpy/README.md moleditpy-linux/ windows-installer/script/script.iss windows-installer/script/MoleditPy.spec windows-installer/windows_installer.md windows-installer/windows_installer-jp.md
-          git commit -m "Bump version to ${env:APP_VERSION}"
+          if (git diff --staged --name-only) { git commit -m "Bump version to ${env:APP_VERSION}" }
           git tag "v${env:APP_VERSION}"
           git push origin HEAD:${{ github.ref_name }}
           git push origin "v${env:APP_VERSION}"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-MoleditPy is a Python-based molecular editor (v3.6.0) built with PyQt6, RDKit, and PyVista. It provides 2D editing + 3D visualization of molecules with a plugin system.
+MoleditPy is a Python-based molecular editor (v4.x — see moleditpy/pyproject.toml for the current version) built with PyQt6, RDKit, and PyVista. It provides 2D editing + 3D visualization of molecules with a plugin system.
 
 ## Development Setup
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ This application combines a modern GUI built with **PyQt6**, powerful cheminform
       * Import structures from **MOL/SDF** files or **SMILES** strings.
       * Export 3D structures to **MOL** or **XYZ** formats, which are compatible with most DFT calculation software.
       * Export 2D and 3D views as high-resolution PNG images.
-      * Export 2D and 3D views as high-resolution PNG images.
+      * **Security note on `.pmeraw`:** the legacy `.pmeraw` project format uses Python pickle, which can execute arbitrary code when loaded. Only open `.pmeraw` files that you created yourself; prefer the JSON-based `.pmeprj` format for sharing.
 
 ### 4. Programmable & Extensible
 
@@ -205,7 +205,7 @@ Additionally, please cite the plugins you used.
       * **MOL/SDF**ファイルや**SMILES**文字列から構造をインポートできます。
       * 3D構造を**MOL**または**XYZ**形式でエクスポートでき、これらは多くのDFT計算ソフトウェアと互換性があります。
       * 2Dおよび3Dビューを高解像度のPNG画像としてエクスポートできます。
-      * 2Dおよび3Dビューを高解像度のPNG画像としてエクスポートできます。
+      * **`.pmeraw` に関するセキュリティ上の注意:** 旧形式の `.pmeraw` プロジェクトは Python の pickle を使用しており、読み込み時に任意のコードが実行される可能性があります。自分で作成した `.pmeraw` ファイルのみを開き、共有には JSON ベースの `.pmeprj` 形式を使用してください。
 
 ### 4. プログラマブルで拡張可能
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -19,7 +19,7 @@ The `MainWindow` (the application's heartbeat) is no longer a collection of inhe
 ### 2. "Never Hide Errors" Diagnostic Strategy
 To ensure stability in the hybrid Python/C++ environment (PyQt6/VTK), the application employs a **Diagnostic Hardening** strategy:
 
-- **Visible Failures**: We prioritize "loud" failures over silent inconsistencies. Every `hasattr()` check or `try-except` block used for architectural routing must include a diagnostic `logging.error()` or re-raise.
+- **Visible Failures**: We prioritize "loud" failures over silent inconsistencies. Every `hasattr()` check or `try-except` block used for architectural routing should include a diagnostic log (`logging.error()` for routing failures, `logging.debug(..., exc_info=True)` for best-effort suppression) or re-raise.
 - **Active Hardening**: The codebase is instrumented with defensive `else: logging.error()` branches for missing attributes, providing high-fidelity tracebacks directly from the architectural surface.
 - **Global Error Capture**: A custom `sys.excepthook` in `main.py` catches unhandled exceptions, ensuring that even unpredicted GUI crashes leave a clear audit trail.
 - **Path-Aware Logging**: Logs include absolute system paths (`%(pathname)s`) for immediate navigation to failing architectural disconnections.

--- a/docs/PLUGIN_DEVELOPMENT_MANUAL_V4.md
+++ b/docs/PLUGIN_DEVELOPMENT_MANUAL_V4.md
@@ -401,9 +401,14 @@ Register a fully custom 3D visualization mode. This allows you to completely byp
 - **callback** (`Callable[[MainWindow, rdkit.Chem.Mol], None]`): Function responsible for the entire drawing process. Access the PyVista plotter via `mw.plotter`.
 
 #### `register_optimization_method(method_name, callback)`
-Add a custom geometry optimizer to the **Compute > Optimize Geometry** menu.
-- **method_name** (`str`): Name as it appears in the menu.
-- **callback** (`Callable[[rdkit.Chem.Mol], bool]`): Function that receives the RDKit molecule. It should modify the coordinates in-place and return `True` on success.
+Add a custom geometry optimizer. It appears in the **right-click menu of the "Optimize 3D" button**, labelled `<method_name> (Plugin)`.
+- **method_name** (`str`): Name as it appears in the menu (stored upper-cased).
+- **callback** (`Callable[[rdkit.Chem.Mol], bool]`): Receives the current 3D RDKit molecule. Modify its conformer coordinates **in place** and return `True` on success or `False` on failure.
+
+Behaviour notes:
+- The callback runs **synchronously on the GUI thread** (unlike built-in force fields, which run on a worker thread) — keep it fast or drive your own progress UI.
+- On success the app redraws the 3D view, pushes an undo state, and records the method as the last successful optimization.
+- Exceptions are caught, logged with traceback, and reported in the status bar; they never crash the app.
 
 #### `plotter` (Property)
 Direct access to the `pyvista.Plotter` instance. Use for adding custom actors, text, or shapes to the 3D scene (e.g., `context.plotter.add_mesh(...)`).

--- a/moleditpy-linux/pyproject.toml
+++ b/moleditpy-linux/pyproject.toml
@@ -34,8 +34,8 @@ classifiers = [
 
 dependencies = [
     "numpy",
-    "pyqt6 < 6.10; sys_platform == 'darwin' and python_version < '3.12'",
-    "pyqt6 < 6.12; sys_platform != 'darwin' or python_version >= '3.12'",
+    "pyqt6 < 6.10; sys_platform == 'darwin' and python_version == '3.9'",
+    "pyqt6 < 6.12; sys_platform != 'darwin' or python_version != '3.9'",
     "pyvista < 0.49",
     "pyvistaqt < 0.12",
     "rdkit < 2026.4",

--- a/moleditpy-linux/pyproject.toml
+++ b/moleditpy-linux/pyproject.toml
@@ -34,8 +34,8 @@ classifiers = [
 
 dependencies = [
     "numpy",
-    "pyqt6 < 6.10; sys_platform == 'darwin' and python_version == '3.9'",
-    "pyqt6 < 6.12; sys_platform != 'darwin' or python_version != '3.9'",
+    "pyqt6 < 6.10; python_version == '3.9'",
+    "pyqt6 < 6.12; python_version != '3.9'",
     "pyvista < 0.49",
     "pyvistaqt < 0.12",
     "rdkit < 2026.4",

--- a/moleditpy-linux/pyproject.toml
+++ b/moleditpy-linux/pyproject.toml
@@ -34,9 +34,9 @@ classifiers = [
 
 dependencies = [
     "numpy",
-    "pyqt6 < 6.10; sys_platform == 'darwin'",
-    "pyqt6 < 6.11; sys_platform != 'darwin'",
-    "pyvista < 0.48",
+    "pyqt6 < 6.10; sys_platform == 'darwin' and python_version < '3.12'",
+    "pyqt6 < 6.12; sys_platform != 'darwin' or python_version >= '3.12'",
+    "pyvista < 0.49",
     "pyvistaqt < 0.12",
     "rdkit < 2026.4",
 ]

--- a/moleditpy-linux/src/moleditpy_linux/ui/planarize_dialog.py
+++ b/moleditpy-linux/src/moleditpy_linux/ui/planarize_dialog.py
@@ -177,7 +177,9 @@ class PlanarizeDialog(BasePickingDialog):
             centroid = np.mean(selected_positions, axis=0)
             centered_positions = selected_positions - centroid
 
-            from moleditpy_linux.core.mol_geometry import calculate_best_fit_plane_projection
+            from moleditpy_linux.core.mol_geometry import (
+                calculate_best_fit_plane_projection,
+            )
 
             # Get normal of the least-squares plane via SVD
             u, s, vh = np.linalg.svd(centered_positions, full_matrices=False)

--- a/moleditpy-linux/src/moleditpy_linux/ui/settings_tabs/settings_other_tab.py
+++ b/moleditpy-linux/src/moleditpy_linux/ui/settings_tabs/settings_other_tab.py
@@ -120,7 +120,8 @@ class SettingsOtherTab(SettingsTabBase):
             "Save application log to ~/.moleditpy/moleditpy_linux.log (rotated, max 1 MB × 3)."
         )
         form_layout.addRow(
-            "Save log to file (~/.moleditpy/moleditpy_linux.log):", self.log_to_file_checkbox
+            "Save log to file (~/.moleditpy/moleditpy_linux.log):",
+            self.log_to_file_checkbox,
         )
 
         self.log_level_debug_checkbox = QCheckBox()

--- a/moleditpy/pyproject.toml
+++ b/moleditpy/pyproject.toml
@@ -34,8 +34,8 @@ classifiers = [
 
 dependencies = [
   "numpy",
-  "pyqt6 < 6.10; sys_platform == 'darwin' and python_version < '3.12'",
-  "pyqt6 < 6.12; sys_platform != 'darwin' or python_version >= '3.12'",
+  "pyqt6 < 6.10; sys_platform == 'darwin' and python_version == '3.9'",
+  "pyqt6 < 6.12; sys_platform != 'darwin' or python_version != '3.9'",
   "pyvista < 0.49",
   "pyvistaqt < 0.12",
   "rdkit < 2026.4",

--- a/moleditpy/pyproject.toml
+++ b/moleditpy/pyproject.toml
@@ -34,8 +34,8 @@ classifiers = [
 
 dependencies = [
   "numpy",
-  "pyqt6 < 6.10; sys_platform == 'darwin' and python_version == '3.9'",
-  "pyqt6 < 6.12; sys_platform != 'darwin' or python_version != '3.9'",
+  "pyqt6 < 6.10; python_version == '3.9'",
+  "pyqt6 < 6.12; python_version != '3.9'",
   "pyvista < 0.49",
   "pyvistaqt < 0.12",
   "rdkit < 2026.4",

--- a/moleditpy/pyproject.toml
+++ b/moleditpy/pyproject.toml
@@ -34,9 +34,9 @@ classifiers = [
 
 dependencies = [
   "numpy",
-  "pyqt6 < 6.10; sys_platform == 'darwin'",
-  "pyqt6 < 6.11; sys_platform != 'darwin'",
-  "pyvista < 0.48",
+  "pyqt6 < 6.10; sys_platform == 'darwin' and python_version < '3.12'",
+  "pyqt6 < 6.12; sys_platform != 'darwin' or python_version >= '3.12'",
+  "pyvista < 0.49",
   "pyvistaqt < 0.12",
   "rdkit < 2026.4",
   "openbabel-wheel < 3.2"

--- a/moleditpy/src/moleditpy/core/mol_geometry.py
+++ b/moleditpy/src/moleditpy/core/mol_geometry.py
@@ -618,7 +618,7 @@ def resolve_2d_overlaps(
     parent = {aid: aid for aid in atom_ids}
 
     def find_set(aid: int) -> int:
-        # Iterative path compression (avoids recursion limit on large groups)
+        # Iterative path compression avoids recursion limits
         root = aid
         while parent[root] != root:
             root = parent[root]

--- a/moleditpy/src/moleditpy/core/mol_geometry.py
+++ b/moleditpy/src/moleditpy/core/mol_geometry.py
@@ -618,10 +618,13 @@ def resolve_2d_overlaps(
     parent = {aid: aid for aid in atom_ids}
 
     def find_set(aid: int) -> int:
-        if parent[aid] == aid:
-            return aid
-        parent[aid] = find_set(parent[aid])
-        return parent[aid]
+        # Iterative path compression (avoids recursion limit on large groups)
+        root = aid
+        while parent[root] != root:
+            root = parent[root]
+        while parent[aid] != root:
+            parent[aid], aid = root, parent[aid]
+        return root
 
     def unite_sets(aid1: int, aid2: int) -> None:
         root1 = find_set(aid1)

--- a/moleditpy/src/moleditpy/core/mol_geometry.py
+++ b/moleditpy/src/moleditpy/core/mol_geometry.py
@@ -517,6 +517,14 @@ def identify_valence_problems(
     list
         IDs of atoms with problematic valence.
     """
+    # Preferred: RDKit's own detection on an unsanitized mol. Unlike the
+    # heuristic table below, it knows every element and accounts for formal
+    # charges and radical electrons (e.g. hypervalent N+, S, B, radicals).
+    rdkit_ids = _identify_problems_rdkit(atoms_data, bonds_data)
+    if rdkit_ids is not None:
+        return rdkit_ids
+
+    # Fallback heuristic when RDKit cannot even construct the atoms
     problem_atom_ids = []
 
     # Pre-calculate bond orders per atom
@@ -535,6 +543,52 @@ def identify_valence_problems(
             problem_atom_ids.append(atom_id)
 
     return problem_atom_ids
+
+
+def _identify_problems_rdkit(
+    atoms_data: Dict[int, Any], bonds_data: Dict[Tuple[int, int], Any]
+) -> Optional[List[int]]:
+    """Find problem atoms via Chem.DetectChemistryProblems (no sanitization).
+
+    Returns None when the molecule cannot be constructed at all (unknown
+    symbols etc.), signalling the caller to use the heuristic fallback.
+    """
+    try:
+        from rdkit import Chem as _Chem
+
+        mol = _Chem.RWMol()
+        id_to_idx = {}
+        for atom_id, data in atoms_data.items():
+            atom = _Chem.Atom(data["symbol"])
+            atom.SetFormalCharge(data.get("charge", 0))
+            atom.SetNumRadicalElectrons(data.get("radical", 0))
+            atom.SetNoImplicit(False)
+            id_to_idx[atom_id] = mol.AddAtom(atom)
+
+        bond_type_map = {
+            1.0: _Chem.BondType.SINGLE,
+            1.5: _Chem.BondType.AROMATIC,
+            2.0: _Chem.BondType.DOUBLE,
+            3.0: _Chem.BondType.TRIPLE,
+        }
+        for (id1, id2), bond in bonds_data.items():
+            if id1 not in id_to_idx or id2 not in id_to_idx:
+                continue
+            order = bond_type_map.get(
+                float(bond.get("order", 1)), _Chem.BondType.SINGLE
+            )
+            mol.AddBond(id_to_idx[id1], id_to_idx[id2], order)
+
+        idx_to_id = {v: k for k, v in id_to_idx.items()}
+        problem_ids = set()
+        for prob in _Chem.DetectChemistryProblems(mol.GetMol()):
+            if hasattr(prob, "GetAtomIdx"):
+                problem_ids.add(idx_to_id[prob.GetAtomIdx()])
+            elif hasattr(prob, "GetAtomIndices"):
+                problem_ids.update(idx_to_id[i] for i in prob.GetAtomIndices())
+        return sorted(problem_ids)
+    except (RuntimeError, ValueError, TypeError, KeyError):
+        return None
 
 
 def optimize_2d_coords(mol: Chem.Mol) -> Dict[int, Tuple[float, float]]:

--- a/moleditpy/src/moleditpy/core/molecular_data.py
+++ b/moleditpy/src/moleditpy/core/molecular_data.py
@@ -400,12 +400,12 @@ class MolecularData:
             elif bond_stereo == 2:
                 stereo_code = 6
 
-            bond_lines.append(f"{idx1:3d}{idx2:3d}{order:3d}{stereo_code:3d}  0  0  0\n")
+            bond_lines.append(
+                f"{idx1:3d}{idx2:3d}{order:3d}{stereo_code:3d}  0  0  0\n"
+            )
 
         mol_block = "\n  MoleditPy\n\n"
-        mol_block += (
-            f"{len(atom_lines):3d}{len(bond_lines):3d}  0  0  0  0  0  0  0  0999 V2000\n"
-        )
+        mol_block += f"{len(atom_lines):3d}{len(bond_lines):3d}  0  0  0  0  0  0  0  0999 V2000\n"
         mol_block += "".join(atom_lines)
         mol_block += "".join(bond_lines)
         mol_block += "M  END\n"

--- a/moleditpy/src/moleditpy/core/molecular_data.py
+++ b/moleditpy/src/moleditpy/core/molecular_data.py
@@ -176,7 +176,7 @@ class MolecularData:
             atom_id_to_idx_map[atom_id] = idx
 
         # save bonds & stereo info (label info is kept here)
-        bond_stereo_info = {}  # bond_idx -> {'type': int, 'atom_ids': (id1,id2), 'bond_data': bond_data}
+        bond_stereo_info: Dict[int, Dict[str, Any]] = {}  # bond_idx -> {'type', 'atom_ids', 'bond_data'}
         for (id1, id2), bond_data in self.bonds.items():
             if id1 not in atom_id_to_idx_map or id2 not in atom_id_to_idx_map:
                 continue
@@ -284,7 +284,7 @@ class MolecularData:
                 begin_atom_idx = bond.GetBeginAtomIdx()
                 end_atom_idx = bond.GetEndAtomIdx()
 
-                label_bond_data: dict[str, Any] = info.get("bond_data") or {}
+                label_bond_data = info.get("bond_data") or {}
                 stereo_atoms_specified = label_bond_data.get("stereo_atoms")
 
                 if stereo_atoms_specified:

--- a/moleditpy/src/moleditpy/core/molecular_data.py
+++ b/moleditpy/src/moleditpy/core/molecular_data.py
@@ -176,7 +176,9 @@ class MolecularData:
             atom_id_to_idx_map[atom_id] = idx
 
         # save bonds & stereo info (label info is kept here)
-        bond_stereo_info: Dict[int, Dict[str, Any]] = {}  # bond_idx -> {'type', 'atom_ids', 'bond_data'}
+        bond_stereo_info: Dict[
+            int, Dict[str, Any]
+        ] = {}  # bond_idx -> {'type', 'atom_ids', 'bond_data'}
         for (id1, id2), bond_data in self.bonds.items():
             if id1 not in atom_id_to_idx_map or id2 not in atom_id_to_idx_map:
                 continue

--- a/moleditpy/src/moleditpy/core/molecular_data.py
+++ b/moleditpy/src/moleditpy/core/molecular_data.py
@@ -101,9 +101,15 @@ class MolecularData:
         if (id1, id2) in self.bonds:
             self.bonds[(id1, id2)].update(bond_data)
             return (id1, id2), "updated"
-        else:
-            self.bonds[(id1, id2)] = bond_data
-            return (id1, id2), "created"
+        if (id2, id1) in self.bonds:
+            # Same bond stored under the reversed key (e.g. the stereo
+            # direction changed): re-key it instead of creating a duplicate.
+            existing = self.bonds.pop((id2, id1))
+            existing.update(bond_data)
+            self.bonds[(id1, id2)] = existing
+            return (id1, id2), "updated"
+        self.bonds[(id1, id2)] = bond_data
+        return (id1, id2), "created"
 
     def remove_atom(self, atom_id: int) -> None:
         """Remove an atom and all bonds involving it from the data model."""
@@ -338,10 +344,11 @@ class MolecularData:
 
         if not self.atoms:
             return None
-        atom_map = {old_id: new_id for new_id, old_id in enumerate(self.atoms.keys())}
-        num_atoms, num_bonds = len(self.atoms), len(self.bonds)
-        mol_block = "\n  MoleditPy\n\n"
-        mol_block += f"{num_atoms:3d}{num_bonds:3d}  0  0  0  0  0  0  0  0999 V2000\n"
+
+        # Emit atom lines first so the counts line and bond indices only
+        # reflect atoms that actually have a usable position.
+        atom_map = {}
+        atom_lines = []
         for old_id, atom in self.atoms.items():
             # Convert scene pixel coordinates to angstroms when emitting MOL block
             pos = atom.get("pos")
@@ -373,10 +380,19 @@ class MolecularData:
             elif charge == -3:
                 chg_code = 7
 
-            mol_block += f"{x:10.4f}{y:10.4f}{z:10.4f} {symbol:<3} 0  0  0{chg_code:3d}  0  0  0  0  0  0  0\n"
+            atom_map[old_id] = len(atom_lines)
+            atom_lines.append(
+                f"{x:10.4f}{y:10.4f}{z:10.4f} {symbol:<3} 0  0  0{chg_code:3d}  0  0  0  0  0  0  0\n"
+            )
 
+        bond_lines = []
         for (id1, id2), bond in self.bonds.items():
-            idx1, idx2, order = atom_map[id1] + 1, atom_map[id2] + 1, bond["order"]
+            if id1 not in atom_map or id2 not in atom_map:
+                continue
+            idx1, idx2 = atom_map[id1] + 1, atom_map[id2] + 1
+            # Bond order may be a float (1.5 = aromatic); V2000 uses code 4.
+            order_val = float(bond["order"])
+            order = 4 if order_val == 1.5 else int(order_val)
             stereo_code = 0
             bond_stereo = bond.get("stereo", 0)
             if bond_stereo == 1:
@@ -384,8 +400,14 @@ class MolecularData:
             elif bond_stereo == 2:
                 stereo_code = 6
 
-            mol_block += f"{idx1:3d}{idx2:3d}{order:3d}{stereo_code:3d}  0  0  0\n"
+            bond_lines.append(f"{idx1:3d}{idx2:3d}{order:3d}{stereo_code:3d}  0  0  0\n")
 
+        mol_block = "\n  MoleditPy\n\n"
+        mol_block += (
+            f"{len(atom_lines):3d}{len(bond_lines):3d}  0  0  0  0  0  0  0  0999 V2000\n"
+        )
+        mol_block += "".join(atom_lines)
+        mol_block += "".join(bond_lines)
         mol_block += "M  END\n"
         return mol_block
 

--- a/moleditpy/src/moleditpy/core/molecular_data.py
+++ b/moleditpy/src/moleditpy/core/molecular_data.py
@@ -284,8 +284,8 @@ class MolecularData:
                 begin_atom_idx = bond.GetBeginAtomIdx()
                 end_atom_idx = bond.GetEndAtomIdx()
 
-                bond_data: dict[str, Any] = info.get("bond_data") or {}  # type: ignore[assignment]
-                stereo_atoms_specified = bond_data.get("stereo_atoms")
+                label_bond_data: dict[str, Any] = info.get("bond_data") or {}
+                stereo_atoms_specified = label_bond_data.get("stereo_atoms")
 
                 if stereo_atoms_specified:
                     try:
@@ -345,8 +345,8 @@ class MolecularData:
             return None
 
         # Counts line and bond indices must only reflect atoms actually written
-        atom_map = {}
-        atom_lines = []
+        atom_map: Dict[int, int] = {}
+        atom_lines: List[str] = []
         for old_id, atom in self.atoms.items():
             # Convert scene pixel coordinates to angstroms when emitting MOL block
             pos = atom.get("pos")

--- a/moleditpy/src/moleditpy/core/molecular_data.py
+++ b/moleditpy/src/moleditpy/core/molecular_data.py
@@ -102,8 +102,7 @@ class MolecularData:
             self.bonds[(id1, id2)].update(bond_data)
             return (id1, id2), "updated"
         if (id2, id1) in self.bonds:
-            # Same bond stored under the reversed key (e.g. the stereo
-            # direction changed): re-key it instead of creating a duplicate.
+            # Re-key reversed entry (stereo direction changed) to avoid duplicates
             existing = self.bonds.pop((id2, id1))
             existing.update(bond_data)
             self.bonds[(id1, id2)] = existing
@@ -345,8 +344,7 @@ class MolecularData:
         if not self.atoms:
             return None
 
-        # Emit atom lines first so the counts line and bond indices only
-        # reflect atoms that actually have a usable position.
+        # Counts line and bond indices must only reflect atoms actually written
         atom_map = {}
         atom_lines = []
         for old_id, atom in self.atoms.items():

--- a/moleditpy/src/moleditpy/main.py
+++ b/moleditpy/src/moleditpy/main.py
@@ -17,7 +17,7 @@ import logging.handlers
 import os
 import sys
 import argparse
-from typing import Any
+from typing import Any, Optional
 
 from .utils.constants import VERSION
 
@@ -39,8 +39,11 @@ _QT_LOG_LEVEL = {
 _DOWNGRADED_QT_PATTERNS = ("Retrying to obtain clipboard",)
 
 
-def _qt_message_handler(mode: QtMsgType, _context: Any, message: str) -> None:
+def _qt_message_handler(
+    mode: QtMsgType, _context: Any, message: Optional[str]
+) -> None:
     """Route Qt log messages to Python logging, downgrading known noisy warnings."""
+    message = message or ""
     for pattern in _DOWNGRADED_QT_PATTERNS:
         if pattern in message:
             logging.debug("Qt: %s", message)

--- a/moleditpy/src/moleditpy/main.py
+++ b/moleditpy/src/moleditpy/main.py
@@ -39,9 +39,7 @@ _QT_LOG_LEVEL = {
 _DOWNGRADED_QT_PATTERNS = ("Retrying to obtain clipboard",)
 
 
-def _qt_message_handler(
-    mode: QtMsgType, _context: Any, message: Optional[str]
-) -> None:
+def _qt_message_handler(mode: QtMsgType, _context: Any, message: Optional[str]) -> None:
     """Route Qt log messages to Python logging, downgrading known noisy warnings."""
     message = message or ""
     for pattern in _DOWNGRADED_QT_PATTERNS:

--- a/moleditpy/src/moleditpy/main.py
+++ b/moleditpy/src/moleditpy/main.py
@@ -204,6 +204,6 @@ def main() -> None:
         except (
             Exception
         ):  # [COSMETIC] Icon refresh is best-effort; Qt timing errors are non-fatal.
-            pass
+            logging.debug("Suppressed non-critical error", exc_info=True)
 
     sys.exit(app.exec())

--- a/moleditpy/src/moleditpy/main.py
+++ b/moleditpy/src/moleditpy/main.py
@@ -109,7 +109,7 @@ def main() -> None:
     setup_logging()
 
     if sys.platform == "win32":
-        # Derive from the app's major version so taskbar grouping follows releases
+        # Taskbar grouping ID follows the major version
         major = VERSION.split(".")[0] if VERSION and VERSION != "Unknown" else "0"
         myappid = f"hyoko.moleditpy.{major}"
         ctypes.windll.shell32.SetCurrentProcessExplicitAppUserModelID(myappid)

--- a/moleditpy/src/moleditpy/main.py
+++ b/moleditpy/src/moleditpy/main.py
@@ -109,7 +109,9 @@ def main() -> None:
     setup_logging()
 
     if sys.platform == "win32":
-        myappid = "hyoko.moleditpy.1.0"
+        # Derive from the app's major version so taskbar grouping follows releases
+        major = VERSION.split(".")[0] if VERSION and VERSION != "Unknown" else "0"
+        myappid = f"hyoko.moleditpy.{major}"
         ctypes.windll.shell32.SetCurrentProcessExplicitAppUserModelID(myappid)
 
     parser = argparse.ArgumentParser(

--- a/moleditpy/src/moleditpy/plugins/plugin_interface.py
+++ b/moleditpy/src/moleditpy/plugins/plugin_interface.py
@@ -133,7 +133,7 @@ class PluginContext:
 
     def get_selected_atom_indices(self) -> List[int]:
         """
-        Returns a list of RDKit atom indices currently selected in the 2D or 3D view.
+        Returns a list of RDKit atom indices currently selected in the 2D view.
         Note: RDKit indices are returned, which map to the current_mol.
         """
         return self._manager.get_selected_atom_indices()  # type: ignore[no-any-return]
@@ -397,7 +397,7 @@ class PluginContext:
                 if fn:
                     fn()
             except Exception:
-                pass
+                logging.debug("mark_project_modified failed", exc_info=True)
 
     def refresh_ui(self) -> None:
         """Refresh all UI state after modifying the molecule.

--- a/moleditpy/src/moleditpy/plugins/plugin_manager.py
+++ b/moleditpy/src/moleditpy/plugins/plugin_manager.py
@@ -679,7 +679,9 @@ class PluginManager:
                                     ValueError,
                                     TypeError,
                                 ):  # [AST PARSE] Complex/unexpected AST node shapes during metadata extraction; skip gracefully.
-                                    logging.debug("Suppressed non-critical error", exc_info=True)
+                                    logging.debug(
+                                        "Suppressed non-critical error", exc_info=True
+                                    )
 
                         if val is not None:
                             if target.id == "PLUGIN_NAME":

--- a/moleditpy/src/moleditpy/plugins/plugin_manager.py
+++ b/moleditpy/src/moleditpy/plugins/plugin_manager.py
@@ -151,23 +151,23 @@ class PluginManager:
                     # Smart Extraction: Check if ZIP has a single top-level folder
                     # Fix for paths with backslashes on Windows if zip was created on Windows
                     roots = set()
+                    root_is_dir = False
                     for name in zf.namelist():
                         # Normalize path separators to forward slash for consistent check
                         name = name.replace("\\", "/")
                         parts = name.split("/")
                         if parts[0]:
                             roots.add(parts[0])
+                            # Entries below the root (or explicit dir entries)
+                            # prove the single root is a folder, not a file.
+                            if len(parts) > 1:
+                                root_is_dir = True
 
-                    is_nested = len(roots) == 1
+                    is_nested = len(roots) == 1 and root_is_dir
 
                     if is_nested:
                         # Case A: ZIP contains a single folder (e.g. MyPlugin/init.py)
                         top_folder = list(roots)[0]
-
-                        # Guard: If the single item is __init__.py, we MUST create a wrapper folder
-                        # otherwise we pollute the plugin_dir root.
-                        if top_folder == "__init__.py":
-                            is_nested = False
 
                     if is_nested:
                         # Case A (Confirmed): Extract directly
@@ -249,8 +249,10 @@ class PluginManager:
             return []
 
         for root, dirs, files in os.walk(self.plugin_dir):
-            # Exclude hidden directories
-            dirs[:] = [d for d in dirs if not d.startswith("__") and d != "__pycache__"]
+            # Exclude hidden and dunder directories (e.g. .git, __pycache__)
+            dirs[:] = [
+                d for d in dirs if not d.startswith("__") and not d.startswith(".")
+            ]
 
             # [Check] Is current dir a package (plugin body)?
             if "__init__.py" in files:
@@ -608,10 +610,6 @@ class PluginManager:
                                     selected_indices.append(i)
                             except (RuntimeError, ValueError, TypeError):
                                 continue
-        except (
-            ImportError
-        ):  # [OPTIONAL DEP] importlib.metadata unavailable (<3.8); silently skip.
-            pass
         except (RuntimeError, AttributeError) as e:
             logging.error(f"Error retrieving selected atom indices: {e}")
 

--- a/moleditpy/src/moleditpy/plugins/plugin_manager.py
+++ b/moleditpy/src/moleditpy/plugins/plugin_manager.py
@@ -158,8 +158,7 @@ class PluginManager:
                         parts = name.split("/")
                         if parts[0]:
                             roots.add(parts[0])
-                            # Entries below the root (or explicit dir entries)
-                            # prove the single root is a folder, not a file.
+                            # Sub-entries prove the root is a folder
                             if len(parts) > 1:
                                 root_is_dir = True
 
@@ -169,8 +168,7 @@ class PluginManager:
                         # Case A: ZIP contains a single folder (e.g. MyPlugin/init.py)
                         top_folder = list(roots)[0]
 
-                        # Guard: a root named __init__.py (file or folder) must get
-                        # a wrapper folder, otherwise we pollute the plugin_dir root.
+                        # A root named __init__.py always needs a wrapper folder
                         if top_folder == "__init__.py":
                             is_nested = False
 

--- a/moleditpy/src/moleditpy/plugins/plugin_manager.py
+++ b/moleditpy/src/moleditpy/plugins/plugin_manager.py
@@ -169,6 +169,11 @@ class PluginManager:
                         # Case A: ZIP contains a single folder (e.g. MyPlugin/init.py)
                         top_folder = list(roots)[0]
 
+                        # Guard: a root named __init__.py (file or folder) must get
+                        # a wrapper folder, otherwise we pollute the plugin_dir root.
+                        if top_folder == "__init__.py":
+                            is_nested = False
+
                     if is_nested:
                         # Case A (Confirmed): Extract directly
                         dest_path = os.path.join(self.plugin_dir, top_folder)

--- a/moleditpy/src/moleditpy/plugins/plugin_manager.py
+++ b/moleditpy/src/moleditpy/plugins/plugin_manager.py
@@ -338,7 +338,7 @@ class PluginManager:
                 sys.modules[spec.name] = module
 
                 # Inject category info
-                module.PLUGIN_CATEGORY = category
+                module.PLUGIN_CATEGORY = category  # type: ignore[attr-defined]
 
                 spec.loader.exec_module(module)
 
@@ -661,15 +661,15 @@ class PluginManager:
                     if isinstance(target, ast.Name):
                         # Helper to extract value
                         val = None
-                        if node.value:  # AnnAssign might presumably not have value? (though usually does for module globals)
-                            if isinstance(node.value, ast.Constant):  # Py3.8+
-                                val = node.value.value
-                            elif isinstance(node.value, ast.Tuple):
+                        if node.value:  # type: ignore[attr-defined]  # AnnAssign might presumably not have value? (though usually does for module globals)
+                            if isinstance(node.value, ast.Constant):  # type: ignore[attr-defined]  # Py3.8+
+                                val = node.value.value  # type: ignore[attr-defined]
+                            elif isinstance(node.value, ast.Tuple):  # type: ignore[attr-defined]
                                 # Handle version tuples e.g. (1, 0, 0)
                                 try:
                                     # Extract simple constants from tuple
                                     elts = []
-                                    for elt in node.value.elts:
+                                    for elt in node.value.elts:  # type: ignore[attr-defined]
                                         if isinstance(elt, ast.Constant):
                                             elts.append(elt.value)
                                     val = ".".join(map(str, elts))
@@ -713,7 +713,7 @@ class PluginManager:
                     elif hasattr(ast, "Str") and isinstance(
                         node.value, getattr(ast, "Str", type(None))
                     ):
-                        val = node.value.s
+                        val = node.value.s  # type: ignore[attr-defined]
 
                     if val and not info["description"]:
                         info["description"] = val.strip().split("\n")[0]

--- a/moleditpy/src/moleditpy/plugins/plugin_manager.py
+++ b/moleditpy/src/moleditpy/plugins/plugin_manager.py
@@ -679,7 +679,7 @@ class PluginManager:
                                     ValueError,
                                     TypeError,
                                 ):  # [AST PARSE] Complex/unexpected AST node shapes during metadata extraction; skip gracefully.
-                                    pass
+                                    logging.debug("Suppressed non-critical error", exc_info=True)
 
                         if val is not None:
                             if target.id == "PLUGIN_NAME":

--- a/moleditpy/src/moleditpy/plugins/plugin_manager_window.py
+++ b/moleditpy/src/moleditpy/plugins/plugin_manager_window.py
@@ -241,7 +241,7 @@ class PluginManagerWindow(QDialog):
         """Accept drag events carrying file URLs."""
         if event is None:
             return
-        if event.mimeData().hasUrls():
+        if event.mimeData().hasUrls():  # type: ignore[union-attr]
             event.accept()
         else:
             event.ignore()
@@ -252,7 +252,7 @@ class PluginManagerWindow(QDialog):
             return
         files_installed = []
         errors = []
-        for url in event.mimeData().urls():
+        for url in event.mimeData().urls():  # type: ignore[union-attr]
             file_path = url.toLocalFile()
 
             is_valid = False

--- a/moleditpy/src/moleditpy/plugins/plugin_manager_window.py
+++ b/moleditpy/src/moleditpy/plugins/plugin_manager_window.py
@@ -37,8 +37,8 @@ class PluginManagerWindow(QDialog):
 
     def __init__(self, plugin_manager: Any, parent: Optional[QWidget] = None) -> None:
         super().__init__(parent)
-        self.btn_remove = None
-        self.table = None
+        self.btn_remove: Any = None
+        self.table: Any = None
         self.plugin_manager = plugin_manager
         self.setWindowTitle("Plugin Manager")
         self.resize(800, 500)

--- a/moleditpy/src/moleditpy/ui/about_dialog.py
+++ b/moleditpy/src/moleditpy/ui/about_dialog.py
@@ -34,7 +34,7 @@ class AboutDialog(QDialog):
 
     def __init__(self, main_window: Any, parent: Optional[QWidget] = None) -> None:
         super().__init__(parent)
-        self.image_label = None
+        self.image_label: Any = None
         self.main_window = main_window
         self.setWindowTitle("About MoleditPy")
         self.setFixedSize(250, 300)

--- a/moleditpy/src/moleditpy/ui/align_plane_dialog.py
+++ b/moleditpy/src/moleditpy/ui/align_plane_dialog.py
@@ -11,7 +11,7 @@ DOI: 10.5281/zenodo.17268532
 """
 
 import logging
-from typing import TYPE_CHECKING, Literal, Optional, Sequence
+from typing import TYPE_CHECKING, Any, Literal, Optional, Sequence
 
 import numpy as np
 
@@ -66,9 +66,9 @@ class AlignPlaneDialog(BasePickingDialog):
         return self._selected_atoms
 
     @selected_atoms.setter
-    def selected_atoms(self, val: object) -> None:
+    def selected_atoms(self, val: Any) -> None:
         """Replace the selection with a new SelectionList built from val."""
-        self._selected_atoms = SelectionList(val)  # type: ignore[arg-type]
+        self._selected_atoms = SelectionList(val)
 
     def init_ui(self) -> None:
         """Build and lay out all widgets for the plane-alignment dialog."""

--- a/moleditpy/src/moleditpy/ui/alignment_dialog.py
+++ b/moleditpy/src/moleditpy/ui/alignment_dialog.py
@@ -11,7 +11,7 @@ DOI: 10.5281/zenodo.17268532
 """
 
 import logging
-from typing import TYPE_CHECKING, Literal, Optional, Sequence
+from typing import TYPE_CHECKING, Any, Literal, Optional, Sequence
 
 import numpy as np
 
@@ -74,9 +74,9 @@ class AlignmentDialog(Dialog3DPickingMixin, QDialog):
         return self._selected_atoms
 
     @selected_atoms.setter
-    def selected_atoms(self, val: object) -> None:
+    def selected_atoms(self, val: Any) -> None:
         """Replace the selection with a new SelectionList built from val."""
-        self._selected_atoms = SelectionList(val)  # type: ignore[arg-type]
+        self._selected_atoms = SelectionList(val)
 
     def init_ui(self) -> None:
         """Build and lay out all widgets for the alignment dialog."""

--- a/moleditpy/src/moleditpy/ui/analysis_window.py
+++ b/moleditpy/src/moleditpy/ui/analysis_window.py
@@ -235,8 +235,8 @@ class AnalysisWindow(QDialog):
     def copy_to_clipboard(self, text: str) -> None:
         """Copy text to the system clipboard and show a status bar message."""
         clipboard = QApplication.clipboard()
-        clipboard.setText(text)
+        clipboard.setText(text)  # type: ignore[union-attr]
         if self.parent() and hasattr(self.parent(), "statusBar"):
-            self.parent().statusBar().showMessage(
+            self.parent().statusBar().showMessage(  # type: ignore[union-attr]
                 f"Copied '{text}' to clipboard.", 2000
             )

--- a/moleditpy/src/moleditpy/ui/angle_dialog.py
+++ b/moleditpy/src/moleditpy/ui/angle_dialog.py
@@ -12,7 +12,7 @@ DOI: 10.5281/zenodo.17268532
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Optional, Sequence
+from typing import Any, TYPE_CHECKING, Optional, Sequence
 
 from PyQt6.QtCore import Qt
 from PyQt6.QtWidgets import (
@@ -50,18 +50,18 @@ class AngleDialog(GeometryBaseDialog):
         parent: Optional[QWidget] = None,
     ) -> None:
         super().__init__(mol, main_window, parent)
-        self._baseline_positions = None
+        self._baseline_positions: Any = None
         self._snapshot_positions = None
-        self.angle_input = None
-        self.angle_label = None
-        self.angle_slider = None
-        self.apply_button = None
-        self.both_groups_radio = None
-        self.clear_button = None
+        self.angle_input: Any = None
+        self.angle_label: Any = None
+        self.angle_slider: Any = None
+        self.apply_button: Any = None
+        self.both_groups_radio: Any = None
+        self.clear_button: Any = None
         self.picker_connection = None
-        self.rotate_atom_radio = None
-        self.rotate_group_radio = None
-        self.selection_label = None
+        self.rotate_atom_radio: Any = None
+        self.rotate_group_radio: Any = None
+        self.selection_label: Any = None
         self.atom1_idx: Optional[int] = None
         self.atom2_idx: Optional[int] = None  # vertex atom
         self.atom3_idx: Optional[int] = None

--- a/moleditpy/src/moleditpy/ui/angle_dialog.py
+++ b/moleditpy/src/moleditpy/ui/angle_dialog.py
@@ -11,6 +11,7 @@ DOI: 10.5281/zenodo.17268532
 """
 
 from __future__ import annotations
+import logging
 
 from typing import Any, TYPE_CHECKING, Optional, Sequence
 
@@ -249,7 +250,7 @@ class AngleDialog(GeometryBaseDialog):
                 self.angle_slider.blockSignals(False)
             except (AttributeError, RuntimeError, ValueError, TypeError):
                 # Safe defensive fallback catching AttributeError, RuntimeError, ValueError, TypeError
-                pass
+                logging.debug("Suppressed non-critical error", exc_info=True)
         elif self.atom2_idx is None:
             symbol1 = self.mol.GetAtomWithIdx(self.atom1_idx).GetSymbol()
             self.selection_label.setText(
@@ -271,7 +272,7 @@ class AngleDialog(GeometryBaseDialog):
                 self.angle_slider.blockSignals(False)
             except (AttributeError, RuntimeError, ValueError, TypeError):
                 # Safe defensive fallback catching AttributeError, RuntimeError, ValueError, TypeError
-                pass
+                logging.debug("Suppressed non-critical error", exc_info=True)
         elif self.atom3_idx is None:
             symbol1 = self.mol.GetAtomWithIdx(self.atom1_idx).GetSymbol()
             symbol2 = self.mol.GetAtomWithIdx(self.atom2_idx).GetSymbol()
@@ -295,7 +296,7 @@ class AngleDialog(GeometryBaseDialog):
                 self.angle_slider.blockSignals(False)
             except (AttributeError, RuntimeError, ValueError, TypeError):
                 # Safe defensive fallback catching AttributeError, RuntimeError, ValueError, TypeError
-                pass
+                logging.debug("Suppressed non-critical error", exc_info=True)
         else:
             symbol1 = self.mol.GetAtomWithIdx(self.atom1_idx).GetSymbol()
             symbol2 = self.mol.GetAtomWithIdx(self.atom2_idx).GetSymbol()
@@ -333,7 +334,7 @@ class AngleDialog(GeometryBaseDialog):
                     self.angle_slider.setEnabled(True)
             except (AttributeError, RuntimeError, TypeError):
                 # Safe defensive fallback catching AttributeError, RuntimeError, TypeError
-                pass
+                logging.debug("Suppressed non-critical error", exc_info=True)
 
             # Add labels
             self.add_selection_label(self.atom1_idx, "1")

--- a/moleditpy/src/moleditpy/ui/app_state.py
+++ b/moleditpy/src/moleditpy/ui/app_state.py
@@ -203,7 +203,10 @@ class StateManager:
                                         )
                                     except (RuntimeError, ValueError, TypeError):
                                         # Safe defensive fallback catching RuntimeError, ValueError, TypeError
-                                        logging.debug("Suppressed non-critical error", exc_info=True)
+                                        logging.debug(
+                                            "Suppressed non-critical error",
+                                            exc_info=True,
+                                        )
 
                     # Sync 2D atoms with 3D actors
                     if self.host.compute_manager:
@@ -627,7 +630,10 @@ class StateManager:
                                                 TypeError,
                                                 IndexError,
                                             ):  # [RDKIT GUARD] RDKit atom property assignment may fail on invalid ids; skip silently.
-                                                logging.debug("Suppressed non-critical error", exc_info=True)
+                                                logging.debug(
+                                                    "Suppressed non-critical error",
+                                                    exc_info=True,
+                                                )
                                 self.host.set_3d_atom_positions(positions_3d)
 
                             # Build mapping
@@ -637,7 +643,9 @@ class StateManager:
                                 self.host.view_3d_manager.update_atom_id_menu_state()
                             except (RuntimeError, TypeError, AttributeError):
                                 # Safe defensive fallback catching RuntimeError, TypeError, AttributeError
-                                logging.debug("Suppressed non-critical error", exc_info=True)
+                                logging.debug(
+                                    "Suppressed non-critical error", exc_info=True
+                                )
 
                         # Always show 3D if 3D molecule exists
                         self.host.view_3d_manager.draw_molecule_3d(
@@ -659,7 +667,9 @@ class StateManager:
                             self.host.ui_manager.enable_3d_features(True)
                         except (RuntimeError, TypeError, AttributeError):
                             # Safe defensive fallback catching RuntimeError, TypeError, AttributeError
-                            logging.debug("Suppressed non-critical error", exc_info=True)
+                            logging.debug(
+                                "Suppressed non-critical error", exc_info=True
+                            )
             except (RuntimeError, ValueError, TypeError, binascii.Error) as e:
                 logging.error(f"Could not restore 3D molecular data: {e}")
                 self.host.set_current_molecule(None)

--- a/moleditpy/src/moleditpy/ui/app_state.py
+++ b/moleditpy/src/moleditpy/ui/app_state.py
@@ -18,7 +18,7 @@ import binascii
 import copy
 import logging
 import os
-import contextlib
+from ..utils.suppress_log import suppress_log
 from typing import Any, Dict, Optional, Tuple
 
 
@@ -203,7 +203,7 @@ class StateManager:
                                         )
                                     except (RuntimeError, ValueError, TypeError):
                                         # Safe defensive fallback catching RuntimeError, ValueError, TypeError
-                                        pass
+                                        logging.debug("Suppressed non-critical error", exc_info=True)
 
                     # Sync 2D atoms with 3D actors
                     if self.host.compute_manager:
@@ -489,7 +489,7 @@ class StateManager:
                     except (AttributeError, RuntimeError, TypeError, ValueError):
                         # Suppress InChI generation errors during project save if RDKit lacks InChI support
                         # Safe defensive fallback catching AttributeError, RuntimeError, TypeError, ValueError
-                        pass
+                        logging.debug("Suppressed non-critical error", exc_info=True)
 
                 except (AttributeError, RuntimeError, ValueError, TypeError) as e:
                     logging.warning("Could not generate molecular identifiers: %s", e)
@@ -543,7 +543,7 @@ class StateManager:
         is_3d_mode = json_data.get("is_3d_viewer_mode", False)
         # Restore last successful optimization method if present in file
         method = json_data.get("last_successful_optimization_method", None)
-        with contextlib.suppress(AttributeError, RuntimeError, TypeError):
+        with suppress_log(AttributeError, RuntimeError, TypeError):
             self.host.set_last_successful_optimization_method(method)
 
         # Plugin State Restoration (Phase 3)
@@ -627,7 +627,7 @@ class StateManager:
                                                 TypeError,
                                                 IndexError,
                                             ):  # [RDKIT GUARD] RDKit atom property assignment may fail on invalid ids; skip silently.
-                                                pass
+                                                logging.debug("Suppressed non-critical error", exc_info=True)
                                 self.host.set_3d_atom_positions(positions_3d)
 
                             # Build mapping
@@ -637,7 +637,7 @@ class StateManager:
                                 self.host.view_3d_manager.update_atom_id_menu_state()
                             except (RuntimeError, TypeError, AttributeError):
                                 # Safe defensive fallback catching RuntimeError, TypeError, AttributeError
-                                pass
+                                logging.debug("Suppressed non-critical error", exc_info=True)
 
                         # Always show 3D if 3D molecule exists
                         self.host.view_3d_manager.draw_molecule_3d(
@@ -659,7 +659,7 @@ class StateManager:
                             self.host.ui_manager.enable_3d_features(True)
                         except (RuntimeError, TypeError, AttributeError):
                             # Safe defensive fallback catching RuntimeError, TypeError, AttributeError
-                            pass
+                            logging.debug("Suppressed non-critical error", exc_info=True)
             except (RuntimeError, ValueError, TypeError, binascii.Error) as e:
                 logging.error(f"Could not restore 3D molecular data: {e}")
                 self.host.set_current_molecule(None)

--- a/moleditpy/src/moleditpy/ui/app_state.py
+++ b/moleditpy/src/moleditpy/ui/app_state.py
@@ -237,7 +237,7 @@ class StateManager:
         else:
             self.host.clear_3d_view()
             self.host.init_manager.analysis_action.setEnabled(False)
-            self.host.init_manager.optimize_3d_button.setEnabled(False)
+            self.host.init_manager.optimize_3d_button.setEnabled(False)  # type: ignore[union-attr]
             # Disable 3D features
             self.host.ui_manager.enable_3d_features(False)
 
@@ -246,7 +246,7 @@ class StateManager:
 
         if loaded_data.get("is_3d_viewer_mode", False):
             self.host.ui_manager.enter_3d_viewer_mode()
-            self.host.statusBar().showMessage("Project loaded in 3D Viewer Mode.")
+            self.host.statusBar().showMessage("Project loaded in 3D Viewer Mode.")  # type: ignore[union-attr]
         else:
             self.host.ui_manager.restore_ui_for_editing()
             # Enable 3D edit features even in 2D editor mode if 3D molecule exists

--- a/moleditpy/src/moleditpy/ui/atom_item.py
+++ b/moleditpy/src/moleditpy/ui/atom_item.py
@@ -386,7 +386,9 @@ class AtomItem(QGraphicsItem):
                             # If sip check fails, continue defensively.
                             # This usually means the object is in an inconsistent state.
                             # Safe defensive fallback catching AttributeError, RuntimeError, TypeError  # Silent failure for non-critical partner state check
-                            logging.debug("Suppressed non-critical error", exc_info=True)
+                            logging.debug(
+                                "Suppressed non-critical error", exc_info=True
+                            )
 
                         other_pos = None
                         try:

--- a/moleditpy/src/moleditpy/ui/atom_item.py
+++ b/moleditpy/src/moleditpy/ui/atom_item.py
@@ -11,6 +11,7 @@ DOI: 10.5281/zenodo.17268532
 """
 
 from __future__ import annotations
+import logging
 from typing import TYPE_CHECKING, Any, List, Optional
 
 from PyQt6.QtCore import QPointF, QRectF, Qt
@@ -385,7 +386,7 @@ class AtomItem(QGraphicsItem):
                             # If sip check fails, continue defensively.
                             # This usually means the object is in an inconsistent state.
                             # Safe defensive fallback catching AttributeError, RuntimeError, TypeError  # Silent failure for non-critical partner state check
-                            pass
+                            logging.debug("Suppressed non-critical error", exc_info=True)
 
                         other_pos = None
                         try:

--- a/moleditpy/src/moleditpy/ui/atom_item.py
+++ b/moleditpy/src/moleditpy/ui/atom_item.py
@@ -323,7 +323,7 @@ class AtomItem(QGraphicsItem):
     def paint(
         self,
         painter: Optional[QPainter],
-        option: QStyleOptionGraphicsItem,
+        option: QStyleOptionGraphicsItem,  # type: ignore[override]
         widget: Optional[QWidget] = None,
     ) -> None:
         """Paint the atom symbol and its associated labels (charge, radical)."""
@@ -334,9 +334,9 @@ class AtomItem(QGraphicsItem):
         # Use bond color if specified in settings
         scene = self.scene()
         if hasattr(scene, "get_setting") and (
-            self.symbol == "H" or scene.get_setting("atom_use_bond_color_2d", False)
+            self.symbol == "H" or scene.get_setting("atom_use_bond_color_2d", False)  # type: ignore[union-attr]
         ):
-            custom_color = scene.get_setting("bond_color_2d", "#222222")
+            custom_color = scene.get_setting("bond_color_2d", "#222222")  # type: ignore[union-attr]
             if isinstance(custom_color, str):
                 color = QColor(custom_color)
 
@@ -515,14 +515,14 @@ class AtomItem(QGraphicsItem):
                 self.update_style()
         return res
 
-    def hoverEnterEvent(self, event: QGraphicsSceneHoverEvent) -> None:
+    def hoverEnterEvent(self, event: QGraphicsSceneHoverEvent) -> None:  # type: ignore[override]
         """Highlight the atom on mouse hover."""
         # Enable highlight on hover regardless of scene mode
         self.hovered = True
         self.update()
         super().hoverEnterEvent(event)
 
-    def hoverLeaveEvent(self, event: QGraphicsSceneHoverEvent) -> None:
+    def hoverLeaveEvent(self, event: QGraphicsSceneHoverEvent) -> None:  # type: ignore[override]
         """Remove hover highlight when the mouse leaves."""
         if self.hovered:
             self.hovered = False

--- a/moleditpy/src/moleditpy/ui/atom_picking.py
+++ b/moleditpy/src/moleditpy/ui/atom_picking.py
@@ -42,7 +42,7 @@ def _atom_world_radius(view_3d_manager: Any, mol: Any, atom_idx: int) -> float:
         settings = view_3d_manager.host.init_manager.settings
     except (AttributeError, RuntimeError, TypeError):
         # Safe defensive fallback catching AttributeError, RuntimeError, TypeError
-        pass
+        logging.debug("Suppressed non-critical error", exc_info=True)
 
     style = str(getattr(view_3d_manager, "current_3d_style", "ball_and_stick"))
     style = style.lower().replace(" ", "_")

--- a/moleditpy/src/moleditpy/ui/atom_picking.py
+++ b/moleditpy/src/moleditpy/ui/atom_picking.py
@@ -17,7 +17,7 @@ import logging
 
 import numpy as np
 
-from ..utils.constants import VDW_RADII, pt
+from ..utils.constants import VDW_DISPLAY_RADII, pt
 
 
 def _world_to_display(renderer: Any, pos: Any) -> Optional[tuple[float, float, float]]:
@@ -62,7 +62,7 @@ def _atom_world_radius(view_3d_manager: Any, mol: Any, atom_idx: int) -> float:
         return 0.01
 
     scale = settings.get("ball_stick_atom_scale", 1.0)
-    return float(VDW_RADII.get(symbol, 0.4)) * float(scale)
+    return float(VDW_DISPLAY_RADII.get(symbol, 0.4)) * float(scale)
 
 
 def _projected_radius_px(

--- a/moleditpy/src/moleditpy/ui/base_picking_dialog.py
+++ b/moleditpy/src/moleditpy/ui/base_picking_dialog.py
@@ -10,6 +10,7 @@ Repo: https://github.com/HiroYokoyama/python_molecular_editor
 DOI: 10.5281/zenodo.17268532
 """
 
+import logging
 from typing import TYPE_CHECKING, Any, Optional, Union
 
 import numpy as np
@@ -129,7 +130,7 @@ class BasePickingDialog(Dialog3DPickingMixin, QDialog):
         except (AttributeError, ValueError, TypeError, IndexError):
             # If for some reason the cache is incompatible, draw_molecule_3d below will rebuild it
             # Safe defensive fallback catching AttributeError, ValueError, TypeError, IndexError
-            pass
+            logging.debug("Suppressed non-critical error", exc_info=True)
 
         # 3. Redraw molecule
         self.main_window.view_3d_manager.draw_molecule_3d(self.mol)

--- a/moleditpy/src/moleditpy/ui/base_picking_dialog.py
+++ b/moleditpy/src/moleditpy/ui/base_picking_dialog.py
@@ -10,7 +10,7 @@ Repo: https://github.com/HiroYokoyama/python_molecular_editor
 DOI: 10.5281/zenodo.17268532
 """
 
-from typing import TYPE_CHECKING, Optional, Union
+from typing import TYPE_CHECKING, Any, Optional, Union
 
 import numpy as np
 from PyQt6.QtCore import Qt, QTimer
@@ -38,9 +38,9 @@ class SelectionList(list):
         if item not in self:
             self.append(item)
 
-    def update(self, items: object) -> None:
+    def update(self, items: Any) -> None:
         """Append each item that is not already present."""
-        for item in items:  # type: ignore[union-attr]
+        for item in items:
             self.add(item)
 
 

--- a/moleditpy/src/moleditpy/ui/bond_item.py
+++ b/moleditpy/src/moleditpy/ui/bond_item.py
@@ -80,7 +80,7 @@ class BondItem(QGraphicsItem):
             # Invalidate scene area when removing label
             if new_stereo == 0 and self.stereo in [3, 4] and self.scene():
                 rect = self.mapToScene(self.boundingRect()).boundingRect()
-                self.scene().invalidate(
+                self.scene().invalidate(  # type: ignore[union-attr]
                     rect,
                     QGraphicsScene.SceneLayer.BackgroundLayer
                     | QGraphicsScene.SceneLayer.ForegroundLayer,
@@ -90,10 +90,10 @@ class BondItem(QGraphicsItem):
             self.stereo = new_stereo
             self.update()
 
-            if self.scene() and self.scene().views():
-                view = self.scene().views()[0]
+            if self.scene() and self.scene().views():  # type: ignore[union-attr]
+                view = self.scene().views()[0]  # type: ignore[union-attr]
                 if view and view.viewport():
-                    view.viewport().update()
+                    view.viewport().update()  # type: ignore[union-attr]
 
         except (AttributeError, RuntimeError, TypeError):
             logging.exception("Error in BondItem.set_stereo")
@@ -105,8 +105,8 @@ class BondItem(QGraphicsItem):
         self.prepareGeometryChange()
         self.order = new_order
         self.update()
-        if self.scene() and self.scene().views():
-            self.scene().views()[0].viewport().update()
+        if self.scene() and self.scene().views():  # type: ignore[union-attr]
+            self.scene().views()[0].viewport().update()  # type: ignore[union-attr]
 
     def update_style(self) -> None:
         """Force internal state refresh and redraw (primarily from settings)."""
@@ -332,7 +332,7 @@ class BondItem(QGraphicsItem):
     def paint(
         self,
         painter: Optional[QPainter],
-        option: QStyleOptionGraphicsItem,
+        option: QStyleOptionGraphicsItem,  # type: ignore[override]
         widget: Optional[QWidget] = None,
     ) -> None:
         """Render the bond as single, double, triple, wedge, or dashed line."""
@@ -461,7 +461,7 @@ class BondItem(QGraphicsItem):
                         if self.order == 3
                         else "bond_spacing_double_2d"
                     )
-                    bond_offset = scene.get_setting(key, 3.5)
+                    bond_offset = scene.get_setting(key, 3.5)  # type: ignore[attr-defined]
 
                 offset = QPointF(v.dx(), v.dy()) * bond_offset
 
@@ -607,19 +607,19 @@ class BondItem(QGraphicsItem):
             logging.exception("Error updating bond position")
             # Continue without crashing
 
-    def hoverEnterEvent(self, event: QGraphicsSceneHoverEvent) -> None:
+    def hoverEnterEvent(self, event: QGraphicsSceneHoverEvent) -> None:  # type: ignore[override]
         """Highlight the bond on mouse hover."""
         self.hovered = True
         self.update()
         if self.scene():
-            self.scene().set_hovered_item(self)
+            self.scene().set_hovered_item(self)  # type: ignore[union-attr]
         super().hoverEnterEvent(event)
 
-    def hoverLeaveEvent(self, event: QGraphicsSceneHoverEvent) -> None:
+    def hoverLeaveEvent(self, event: QGraphicsSceneHoverEvent) -> None:  # type: ignore[override]
         """Remove hover highlight when the mouse leaves."""
         if self.hovered:
             self.hovered = False
             self.update()
         if self.scene():
-            self.scene().set_hovered_item(None)
+            self.scene().set_hovered_item(None)  # type: ignore[union-attr]
         super().hoverLeaveEvent(event)

--- a/moleditpy/src/moleditpy/ui/bond_item.py
+++ b/moleditpy/src/moleditpy/ui/bond_item.py
@@ -591,7 +591,7 @@ class BondItem(QGraphicsItem):
                 # Silent failure for non-critical hover highlight drawing.
                 # If highlight fails, it's just a visual artifact.
                 # Safe defensive fallback catching AttributeError, RuntimeError, TypeError, ValueError
-                pass
+                logging.debug("Suppressed non-critical error", exc_info=True)
 
         painter.restore()
 

--- a/moleditpy/src/moleditpy/ui/bond_item.py
+++ b/moleditpy/src/moleditpy/ui/bond_item.py
@@ -52,6 +52,11 @@ if TYPE_CHECKING:
 class BondItem(QGraphicsItem):
     """Visual representation of a molecular bond in the 2D scene."""
 
+    atom1: "AtomItem"
+    atom2: "AtomItem"
+    order: int
+    stereo: int
+
     def get_ez_label_rect(self) -> Optional[QRectF]:
         """Returns the drawing range for E/Z labels (scene coords). Returns None if no label."""
         if self.order != 2 or self.stereo not in [3, 4]:
@@ -157,10 +162,10 @@ class BondItem(QGraphicsItem):
         # Validate input parameters
         if atom1_item is None or atom2_item is None:
             raise ValueError("BondItem requires non-None atom items")
-        self.atom1: Optional[AtomItem] = atom1_item
-        self.atom2: Optional[AtomItem] = atom2_item
-        self.order: int = order
-        self.stereo: int = stereo
+        self.atom1 = atom1_item
+        self.atom2 = atom2_item
+        self.order = order
+        self.stereo = stereo
 
         self.setFlag(QGraphicsItem.GraphicsItemFlag.ItemIsSelectable)
         self.pen: QPen = QPen(Qt.GlobalColor.black, 2)

--- a/moleditpy/src/moleditpy/ui/bond_length_dialog.py
+++ b/moleditpy/src/moleditpy/ui/bond_length_dialog.py
@@ -11,6 +11,7 @@ DOI: 10.5281/zenodo.17268532
 """
 
 from __future__ import annotations
+import logging
 
 import numpy as np
 from typing import Any, TYPE_CHECKING, Optional, Sequence
@@ -234,7 +235,7 @@ class BondLengthDialog(GeometryBaseDialog):
                 self.distance_slider.blockSignals(False)
             except (AttributeError, RuntimeError, ValueError, TypeError):
                 # Safe defensive fallback catching AttributeError, RuntimeError, ValueError, TypeError
-                pass
+                logging.debug("Suppressed non-critical error", exc_info=True)
 
         elif self.atom2_idx is None:
             symbol1 = self.mol.GetAtomWithIdx(self.atom1_idx).GetSymbol()
@@ -257,7 +258,7 @@ class BondLengthDialog(GeometryBaseDialog):
                 self.distance_slider.blockSignals(False)
             except (AttributeError, RuntimeError, ValueError, TypeError):
                 # Safe defensive fallback catching AttributeError, RuntimeError, ValueError, TypeError
-                pass
+                logging.debug("Suppressed non-critical error", exc_info=True)
         else:
             symbol1 = self.mol.GetAtomWithIdx(self.atom1_idx).GetSymbol()
             symbol2 = self.mol.GetAtomWithIdx(self.atom2_idx).GetSymbol()
@@ -289,7 +290,7 @@ class BondLengthDialog(GeometryBaseDialog):
                     self.distance_slider.setEnabled(True)
             except (AttributeError, RuntimeError, TypeError):
                 # Safe defensive fallback catching AttributeError, RuntimeError, TypeError
-                pass
+                logging.debug("Suppressed non-critical error", exc_info=True)
 
             # Add labels
             self.add_selection_label(self.atom1_idx, "1")

--- a/moleditpy/src/moleditpy/ui/bond_length_dialog.py
+++ b/moleditpy/src/moleditpy/ui/bond_length_dialog.py
@@ -13,7 +13,7 @@ DOI: 10.5281/zenodo.17268532
 from __future__ import annotations
 
 import numpy as np
-from typing import TYPE_CHECKING, Optional, Sequence
+from typing import Any, TYPE_CHECKING, Optional, Sequence
 
 from PyQt6.QtCore import Qt
 from PyQt6.QtWidgets import (
@@ -47,18 +47,18 @@ class BondLengthDialog(GeometryBaseDialog):
         parent: Optional[QWidget] = None,
     ) -> None:
         super().__init__(mol, main_window, parent)
-        self._baseline_positions = None
+        self._baseline_positions: Any = None
         self._snapshot_positions = None
-        self.apply_button = None
-        self.atom1_fix_group_radio = None
-        self.atom1_fix_radio = None
-        self.both_groups_radio = None
-        self.clear_button = None
-        self.distance_input = None
-        self.distance_label = None
-        self.distance_slider = None
+        self.apply_button: Any = None
+        self.atom1_fix_group_radio: Any = None
+        self.atom1_fix_radio: Any = None
+        self.both_groups_radio: Any = None
+        self.clear_button: Any = None
+        self.distance_input: Any = None
+        self.distance_label: Any = None
+        self.distance_slider: Any = None
         self.picker_connection = None
-        self.selection_label = None
+        self.selection_label: Any = None
         self.atom1_idx: Optional[int] = None
         self.atom2_idx: Optional[int] = None
 

--- a/moleditpy/src/moleditpy/ui/calculation_worker.py
+++ b/moleditpy/src/moleditpy/ui/calculation_worker.py
@@ -907,9 +907,7 @@ class CalculationWorker(QObject):
 
         # Fallback embedding strategies
         if conf_id == -1:
-            with suppress_log(
-                AttributeError, RuntimeError, ValueError, TypeError
-            ):
+            with suppress_log(AttributeError, RuntimeError, ValueError, TypeError):
                 bm = AllChem.GetMoleculeBoundsMatrix(mol)
                 for b_idx, s, satoms in orig_stereo:
                     if len(satoms) == 2:
@@ -919,9 +917,7 @@ class CalculationWorker(QObject):
                 conf_id = AllChem.EmbedMolecule(mol, bm, params)
 
         if conf_id == -1:
-            with suppress_log(
-                AttributeError, RuntimeError, ValueError, TypeError
-            ):
+            with suppress_log(AttributeError, RuntimeError, ValueError, TypeError):
                 conf_id = AllChem.EmbedMolecule(mol, AllChem.ETKDGv2(randomSeed=42))
 
         if conf_id == -1:

--- a/moleditpy/src/moleditpy/ui/calculation_worker.py
+++ b/moleditpy/src/moleditpy/ui/calculation_worker.py
@@ -626,9 +626,6 @@ def _perform_obabel_conversion(
         script = """
 import sys, contextlib
 from openbabel import pybel
-import os
-# Inherit babel variables if any
-if "BABEL_DATADIR" in os.environ: os.environ["BABEL_DATADIR"] = os.environ["BABEL_DATADIR"]
 mol_block = sys.stdin.read()
 ob_mol = pybel.readstring("mol", mol_block)
 with contextlib.suppress(Exception): ob_mol.addh()
@@ -654,9 +651,10 @@ print(ob_mol.write("mol"))
         except Exception as e:
             raise RuntimeError(f"Open Babel isolated execution failed: {e}")
 
-        rd_mol = Chem.AddHs(Chem.MolFromMolBlock(out_mol_block, removeHs=False))
+        rd_mol = Chem.MolFromMolBlock(out_mol_block, removeHs=False)
         if not rd_mol:
             raise ValueError("Open Babel produced invalid MOL.")
+        rd_mol = Chem.AddHs(rd_mol)
 
         _adjust_collision_avoidance(rd_mol, _check_halted, _safe_status)
         opt_method = opt_method or "MMFF94s_RDKIT"

--- a/moleditpy/src/moleditpy/ui/calculation_worker.py
+++ b/moleditpy/src/moleditpy/ui/calculation_worker.py
@@ -10,7 +10,8 @@ Repo: https://github.com/HiroYokoyama/python_molecular_editor
 DOI: 10.5281/zenodo.17268532
 """
 
-import contextlib
+import logging
+from ..utils.suppress_log import suppress_log
 import math
 import re
 import numpy as np
@@ -30,7 +31,7 @@ from .. import OBABEL_AVAILABLE
 # Only import pybel on demand
 if OBABEL_AVAILABLE:
     # Suppress potential import errors if Open Babel is not correctly installed or configured
-    with contextlib.suppress(ImportError, OSError, RuntimeError):
+    with suppress_log(ImportError, OSError, RuntimeError):
         import os
         import glob
         import openbabel
@@ -212,7 +213,7 @@ def _adjust_collision_avoidance(
     except (AttributeError, RuntimeError, TypeError, ValueError):
         # Suppress non-critical errors during fragment collision resolution if state is inconsistent
         # Safe defensive fallback catching AttributeError, RuntimeError, TypeError, ValueError
-        pass
+        logging.debug("Suppressed non-critical error", exc_info=True)
 
 
 def _iterative_optimize(
@@ -377,7 +378,7 @@ def _perform_direct_conversion(
     parsed_coords, stereo_dirs = [], []
     # Best-effort attempt to parse 2D coordinates from MOL block for direct conversion.
     # We suppress AttributeError/RuntimeError if the block is malformed or RDKit fails internally.
-    with contextlib.suppress(AttributeError, RuntimeError, ValueError, TypeError):
+    with suppress_log(AttributeError, RuntimeError, ValueError, TypeError):
         base2d_all = Chem.MolFromMolBlock(
             mol_block, removeHs=False, sanitize=True
         ) or Chem.MolFromMolBlock(mol_block, removeHs=False, sanitize=False)
@@ -389,7 +390,7 @@ def _perform_direct_conversion(
 
     # Manual parse of bond stereo flags from MOL block text.
     # Suppress IndexError/ValueError if the block format is unexpected or lines are truncated.
-    with contextlib.suppress(IndexError, ValueError, AttributeError):
+    with suppress_log(IndexError, ValueError, AttributeError):
         lines = mol_block.splitlines()
         counts_idx = next(
             (i for i, ln in enumerate(lines[:40]) if re.match(r"^\s*\d+\s+\d+", ln)),
@@ -421,7 +422,7 @@ def _perform_direct_conversion(
     if not parsed_coords:
         # Fallback manual parse of atom coordinates from MOL block text.
         # Suppress IndexError/ValueError if the block format is unexpected.
-        with contextlib.suppress(IndexError, ValueError, AttributeError):
+        with suppress_log(IndexError, ValueError, AttributeError):
             lines = mol_block.splitlines()
             idx = next(
                 (
@@ -507,7 +508,7 @@ def _perform_direct_conversion(
                     conf.SetAtomPosition(i, rdGeometry.Point3D(0.0, 0.0, 0.1))
 
     # Best-effort application of stereo directions to Z-coordinates for direct conversion.
-    with contextlib.suppress(AttributeError, RuntimeError, TypeError, IndexError):
+    with suppress_log(AttributeError, RuntimeError, TypeError, IndexError):
         for b, e, flag in stereo_dirs:
             if b < num_existing and e < num_existing:
                 pos = conf.GetAtomPosition(e)
@@ -533,7 +534,7 @@ def _perform_direct_conversion(
         method_key = _resolve_method_key(opt_method)
 
         # Best-effort property assignment for UI feedback
-        with contextlib.suppress(AttributeError, RuntimeError, TypeError):
+        with suppress_log(AttributeError, RuntimeError, TypeError):
             mol.SetProp("_pme_optimization_method", opt_method)
             mol.SetProp("_pme_conversion_backend", "Direct")
         _safe_status(f"Optimizing ({method_key} / {backend})...")
@@ -555,14 +556,14 @@ def _perform_direct_conversion(
                     mol, "UFF", _check_halted, _safe_status, options=options
                 )
                 if fallback_success:
-                    with contextlib.suppress(Exception):
+                    with suppress_log(Exception):
                         mol.SetProp("_pme_optimization_method", "UFF_RDKIT")
 
             if not fallback_success:
                 _safe_status(
                     "Warning: Optimization failed. Using unoptimized structure."
                 )
-                with contextlib.suppress(Exception):
+                with suppress_log(Exception):
                     mol.ClearProp("_pme_optimization_method")
 
     if _check_halted():
@@ -585,7 +586,7 @@ def _perform_optimize_only(
     method_key = _resolve_method_key(opt_method)
 
     # Best-effort property assignment for UI feedback
-    with contextlib.suppress(AttributeError, RuntimeError, TypeError):
+    with suppress_log(AttributeError, RuntimeError, TypeError):
         mol.SetProp("_pme_optimization_method", opt_method)
 
     opt_func = (
@@ -662,7 +663,7 @@ print(ob_mol.write("mol"))
         method_key = _resolve_method_key(opt_method)
 
         # Best-effort property assignment for UI feedback
-        with contextlib.suppress(AttributeError, RuntimeError, TypeError):
+        with suppress_log(AttributeError, RuntimeError, TypeError):
             rd_mol.SetProp("_pme_optimization_method", opt_method)
             rd_mol.SetProp("_pme_conversion_backend", "Open Babel")
         _safe_status(f"Optimizing ({method_key} / {backend})...")
@@ -684,14 +685,14 @@ print(ob_mol.write("mol"))
                     rd_mol, "UFF", _check_halted, _safe_status, options=options
                 )
                 if fallback_success:
-                    with contextlib.suppress(Exception):
+                    with suppress_log(Exception):
                         rd_mol.SetProp("_pme_optimization_method", "UFF_RDKIT")
 
             if not fallback_success:
                 _safe_status(
                     "Warning: Optimization failed. Using unoptimized structure."
                 )
-                with contextlib.suppress(Exception):
+                with suppress_log(Exception):
                     rd_mol.ClearProp("_pme_optimization_method")
 
         if _check_halted():
@@ -752,19 +753,19 @@ class CalculationWorker(QObject):
         def _safe_status(msg: str) -> None:
             if _check_halted():
                 raise WorkerHaltError("Halted")
-            with contextlib.suppress(AttributeError, RuntimeError):
+            with suppress_log(AttributeError, RuntimeError):
                 self.status_update.emit(msg)
 
         def _safe_finished(payload: Any) -> None:
             if _check_halted():
                 raise WorkerHaltError("Halted")
-            with contextlib.suppress(AttributeError, RuntimeError, TypeError):
+            with suppress_log(AttributeError, RuntimeError, TypeError):
                 self.finished.emit(payload)
 
         def _safe_error(msg: str) -> None:
             # If we're already halting, don't raise another error
             if msg == "Halted":
-                with contextlib.suppress(AttributeError, RuntimeError, TypeError):
+                with suppress_log(AttributeError, RuntimeError, TypeError):
                     self.error.emit((w_id, "Halted"))
                 return
 
@@ -772,7 +773,7 @@ class CalculationWorker(QObject):
             if _check_halted():
                 raise WorkerHaltError("Halted")
 
-            with contextlib.suppress(AttributeError, RuntimeError, TypeError):
+            with suppress_log(AttributeError, RuntimeError, TypeError):
                 self.error.emit((w_id, msg))
 
         helpers = {
@@ -837,13 +838,13 @@ class CalculationWorker(QObject):
 
         except WorkerHaltError:
             # Swallow here; the loop has already been notified
-            with contextlib.suppress(AttributeError, RuntimeError, TypeError):
+            with suppress_log(AttributeError, RuntimeError, TypeError):
                 self.error.emit((w_id, "Halted"))
         except Exception as e:
             try:
                 _safe_error(str(e))
             except WorkerHaltError:
-                with contextlib.suppress(AttributeError, RuntimeError, TypeError):
+                with suppress_log(AttributeError, RuntimeError, TypeError):
                     self.error.emit((w_id, "Halted"))
 
     def _prepare_molecule_for_calc(
@@ -901,12 +902,12 @@ class CalculationWorker(QObject):
             raise WorkerHaltError("Halted")
 
         conf_id = -1
-        with contextlib.suppress(RuntimeError, ValueError):
+        with suppress_log(RuntimeError, ValueError):
             conf_id = AllChem.EmbedMolecule(mol, params)
 
         # Fallback embedding strategies
         if conf_id == -1:
-            with contextlib.suppress(
+            with suppress_log(
                 AttributeError, RuntimeError, ValueError, TypeError
             ):
                 bm = AllChem.GetMoleculeBoundsMatrix(mol)
@@ -918,7 +919,7 @@ class CalculationWorker(QObject):
                 conf_id = AllChem.EmbedMolecule(mol, bm, params)
 
         if conf_id == -1:
-            with contextlib.suppress(
+            with suppress_log(
                 AttributeError, RuntimeError, ValueError, TypeError
             ):
                 conf_id = AllChem.EmbedMolecule(mol, AllChem.ETKDGv2(randomSeed=42))
@@ -938,7 +939,7 @@ class CalculationWorker(QObject):
         backend = "OBABEL" if "OBABEL" in opt_method.upper() else "RDKIT"
         method_key = _resolve_method_key(opt_method)
 
-        with contextlib.suppress(AttributeError, RuntimeError, TypeError):
+        with suppress_log(AttributeError, RuntimeError, TypeError):
             mol.SetProp("_pme_optimization_method", opt_method)
             mol.SetProp("_pme_conversion_backend", "RDKit")
         _safe_status(f"Optimizing ({method_key} / {backend})...")
@@ -960,14 +961,14 @@ class CalculationWorker(QObject):
                     mol, "UFF", _check_halted, _safe_status, options=options
                 )
                 if fallback_success:
-                    with contextlib.suppress(Exception):
+                    with suppress_log(Exception):
                         mol.SetProp("_pme_optimization_method", "UFF_RDKIT")
 
             if not fallback_success:
                 _safe_status(
                     "Warning: Optimization failed. Using unoptimized structure."
                 )
-                with contextlib.suppress(Exception):
+                with suppress_log(Exception):
                     mol.ClearProp("_pme_optimization_method")
 
         # Final stereo restoration check

--- a/moleditpy/src/moleditpy/ui/color_settings_dialog.py
+++ b/moleditpy/src/moleditpy/ui/color_settings_dialog.py
@@ -242,7 +242,7 @@ class ColorSettingsDialog(QDialog):
     def on_element_clicked(self) -> None:
         """Open a color picker for the clicked element button and update its swatch."""
         btn = self.sender()
-        symbol = btn.text()
+        symbol = btn.text()  # type: ignore[union-attr]
         cur = self.current_settings.get("cpk_colors", {}).get(symbol)
         if not cur:
             cur = CPK_COLORS.get(symbol, CPK_COLORS["DEFAULT"]).name()
@@ -253,7 +253,7 @@ class ColorSettingsDialog(QDialog):
                 color.red() * 299 + color.green() * 587 + color.blue() * 114
             ) / 1000
             text_color = "white" if brightness < 128 else "black"
-            btn.setStyleSheet(
+            btn.setStyleSheet(  # type: ignore[union-attr]
                 f"background-color: {color.name()}; color: {text_color}; border: 1px solid #555; font-weight: bold;"
             )
 

--- a/moleditpy/src/moleditpy/ui/color_settings_dialog.py
+++ b/moleditpy/src/moleditpy/ui/color_settings_dialog.py
@@ -10,6 +10,7 @@ Repo: https://github.com/HiroYokoyama/python_molecular_editor
 DOI: 10.5281/zenodo.17268532
 """
 
+import logging
 from typing import Any, Dict, Optional
 
 from PyQt6.QtGui import QColor
@@ -299,7 +300,7 @@ class ColorSettingsDialog(QDialog):
                 except KeyError:
                     # Suppress if cpk_colors key is already missing or removed during reset.
                     # Safe defensive fallback catching KeyError
-                    pass
+                    logging.debug("Suppressed non-critical error", exc_info=True)
         if self.changed_cpk:
             cdict = settings.get("cpk_colors", {}).copy()
             cdict.update(self.changed_cpk)
@@ -326,12 +327,12 @@ class ColorSettingsDialog(QDialog):
                     try:
                         it.update_style()
                     except (AttributeError, RuntimeError, TypeError):
-                        pass
+                        logging.debug("Suppressed non-critical error", exc_info=True)
                 else:
                     try:
                         it.update()
                     except (AttributeError, RuntimeError, TypeError):
-                        pass
+                        logging.debug("Suppressed non-critical error", exc_info=True)
 
         # Update button styles
         for s, btn in self.element_buttons.items():

--- a/moleditpy/src/moleditpy/ui/color_settings_dialog.py
+++ b/moleditpy/src/moleditpy/ui/color_settings_dialog.py
@@ -38,7 +38,7 @@ class ColorSettingsDialog(QDialog):
     def __init__(self, current_settings: Any, parent: Optional[QWidget] = None) -> None:
         super().__init__(parent)
         self.setWindowTitle("CPK Colors")
-        self.parent_window = parent
+        self.parent_window: Any = parent
         self.current_settings = current_settings or {}
 
         self.changed_cpk: Dict[str, str] = {}  # symbol -> hex
@@ -348,12 +348,11 @@ class ColorSettingsDialog(QDialog):
             )
 
         # Refresh SettingsDialog
-        from .settings_dialog import SettingsDialog  # type: ignore[assignment]
+        from .settings_dialog import SettingsDialog
 
-        if SettingsDialog:
-            for w in QApplication.topLevelWidgets():
-                if isinstance(w, SettingsDialog):
-                    w.update_ui_from_settings(settings)
+        for w in QApplication.topLevelWidgets():
+            if isinstance(w, SettingsDialog):
+                w.update_ui_from_settings(settings)
 
         # Persist B&S color
         if getattr(self, "changed_bs_color", None):

--- a/moleditpy/src/moleditpy/ui/compute_logic.py
+++ b/moleditpy/src/moleditpy/ui/compute_logic.py
@@ -73,10 +73,10 @@ class ComputeManager:
 
     def _restore_button_ui(self) -> None:
         """Restore the Convert and Optimize buttons to their default state."""
-        self._safe_disconnect(self.host.init_manager.convert_button.clicked)
-        self.host.init_manager.convert_button.setText("Convert 2D to 3D")
-        self.host.init_manager.convert_button.clicked.connect(self.trigger_conversion)
-        self.host.init_manager.convert_button.setEnabled(True)
+        self._safe_disconnect(self.host.init_manager.convert_button.clicked)  # type: ignore[union-attr]
+        self.host.init_manager.convert_button.setText("Convert 2D to 3D")  # type: ignore[union-attr]
+        self.host.init_manager.convert_button.clicked.connect(self.trigger_conversion)  # type: ignore[union-attr]
+        self.host.init_manager.convert_button.setEnabled(True)  # type: ignore[union-attr]
 
         if self.host.init_manager.optimize_3d_button:
             self._safe_disconnect(self.host.init_manager.optimize_3d_button.clicked)
@@ -132,20 +132,20 @@ class ComputeManager:
                 act.setChecked(k.upper() == method)
 
         label = self.host.init_manager.opt3d_method_labels.get(method, method)
-        self.host.statusBar().showMessage(f"3D optimization method set to: {label}")
+        self.host.statusBar().showMessage(f"3D optimization method set to: {label}")  # type: ignore[union-attr]
 
     def toggle_intermolecular_interaction_rdkit(self, checked: bool) -> None:
         """Toggle intermolecular interactions for RDKit optimization."""
         self.host.get_settings()["optimize_intermolecular_interaction_rdkit"] = checked
         self.host.set_settings_dirty(True)
         state_str = "Enabled" if checked else "Disabled"
-        self.host.statusBar().showMessage(
+        self.host.statusBar().showMessage(  # type: ignore[union-attr]
             f"Intermolecular interaction for RDKit: {state_str}"
         )
 
     def show_convert_menu(self, pos: QPoint) -> None:
         """Temporary 3D conversion menu (right-click)."""
-        if not self.host.init_manager.convert_button.isEnabled():
+        if not self.host.init_manager.convert_button.isEnabled():  # type: ignore[union-attr]
             return
 
         menu = QMenu(self.host)
@@ -163,7 +163,7 @@ class ComputeManager:
                 lambda checked=False, k=key: self._trigger_conversion_with_temp_mode(k)
             )
             menu.addAction(a)
-        menu.exec(self.host.init_manager.convert_button.mapToGlobal(pos))
+        menu.exec(self.host.init_manager.convert_button.mapToGlobal(pos))  # type: ignore[union-attr]
 
     def _trigger_conversion_with_temp_mode(self, mode_key: str) -> None:
         # Store mode as instance attribute so it reaches trigger_conversion
@@ -174,7 +174,7 @@ class ComputeManager:
 
     def show_optimize_menu(self, pos: QPoint) -> None:
         """Temporary 3D optimization menu (right-click)."""
-        if not self.host.init_manager.optimize_3d_button.isEnabled():
+        if not self.host.init_manager.optimize_3d_button.isEnabled():  # type: ignore[union-attr]
             return
 
         menu = QMenu(self.host)
@@ -196,7 +196,7 @@ class ComputeManager:
                 lambda checked=False, k=key: self._trigger_optimize_with_temp_method(k)
             )
             menu.addAction(a)
-        menu.exec(self.host.init_manager.optimize_3d_button.mapToGlobal(pos))
+        menu.exec(self.host.init_manager.optimize_3d_button.mapToGlobal(pos))  # type: ignore[union-attr]
 
     def _trigger_optimize_with_temp_method(self, method_key: str) -> None:
         QTimer.singleShot(0, lambda: self.optimize_3d_structure(method_key))
@@ -231,17 +231,17 @@ class ComputeManager:
         mol = self._prepare_rdkit_mol_for_conversion()
         if not mol:
             self._restore_button_ui()
-            self.host.init_manager.cleanup_button.setEnabled(True)
+            self.host.init_manager.cleanup_button.setEnabled(True)  # type: ignore[union-attr]
             self._remove_calculating_text()
             return
 
         num_frags = len(Chem.GetMolFrags(mol))
         if num_frags > 1:
-            self.host.statusBar().showMessage(
+            self.host.statusBar().showMessage(  # type: ignore[union-attr]
                 f"Converting {num_frags} molecules to 3D with collision detection..."
             )
         else:
-            self.host.statusBar().showMessage("Calculating 3D structure...")
+            self.host.statusBar().showMessage("Calculating 3D structure...")  # type: ignore[union-attr]
 
         mol_block = self._setup_mol_block_for_worker(mol)
 
@@ -250,10 +250,10 @@ class ComputeManager:
         self.active_worker_ids.add(run_id)
 
         # UI Updates
-        self.host.init_manager.convert_button.setText("Halt conversion")
-        self._safe_disconnect(self.host.init_manager.convert_button.clicked)
-        self.host.init_manager.convert_button.clicked.connect(self.halt_conversion)
-        self.host.init_manager.cleanup_button.setEnabled(False)
+        self.host.init_manager.convert_button.setText("Halt conversion")  # type: ignore[union-attr]
+        self._safe_disconnect(self.host.init_manager.convert_button.clicked)  # type: ignore[union-attr]
+        self.host.init_manager.convert_button.clicked.connect(self.halt_conversion)  # type: ignore[union-attr]
+        self.host.init_manager.cleanup_button.setEnabled(False)  # type: ignore[union-attr]
         self.host.ui_manager.enable_3d_features(False)
         self.host.clear_3d_view()
 
@@ -297,18 +297,18 @@ class ComputeManager:
         self.active_worker_ids.clear()
 
         self._restore_button_ui()
-        self.host.init_manager.cleanup_button.setEnabled(True)
+        self.host.init_manager.cleanup_button.setEnabled(True)  # type: ignore[union-attr]
         self._remove_calculating_text()
-        self.host.statusBar().showMessage("Halted")
+        self.host.statusBar().showMessage("Halted")  # type: ignore[union-attr]
 
     def optimize_3d_structure(self, method_key: Optional[str] = None) -> None:
         """Optimize 3D structure."""
         if not self.host.view_3d_manager.current_mol:
-            self.host.statusBar().showMessage("No 3D molecule to optimize.")
+            self.host.statusBar().showMessage("No 3D molecule to optimize.")  # type: ignore[union-attr]
             return
 
         if self.host.view_3d_manager.current_mol.GetNumConformers() == 0:
-            self.host.statusBar().showMessage(
+            self.host.statusBar().showMessage(  # type: ignore[union-attr]
                 "No conformer found. Generate 3D structure first."
             )
             return
@@ -322,12 +322,12 @@ class ComputeManager:
         _plugin_methods = set(getattr(_plugin_mgr, "optimization_methods", {}) or {})
         _all_known = _init_methods | _plugin_methods | {"OPTIMIZE_ONLY"}
         if _all_known and method not in _all_known:
-            self.host.statusBar().showMessage(
+            self.host.statusBar().showMessage(  # type: ignore[union-attr]
                 f"Selected optimization method '{method}' is not available."
             )
             return
 
-        self.host.statusBar().showMessage(f"Optimizing 3D structure ({method})...")
+        self.host.statusBar().showMessage(f"Optimizing 3D structure ({method})...")  # type: ignore[union-attr]
 
         mol_block = Chem.MolToMolBlock(
             self.host.view_3d_manager.current_mol, includeStereo=True
@@ -382,14 +382,14 @@ class ComputeManager:
             Chem.SanitizeMol(mol)
         except (ValueError, RuntimeError) as e:
             logging.error(f"Sanitization failed: {e}")
-            self.host.statusBar().showMessage("Error: Invalid chemical structure.")
+            self.host.statusBar().showMessage("Error: Invalid chemical structure.")  # type: ignore[union-attr]
             return None
         return mol
 
     def _handle_chemistry_problems(self, mol: Chem.Mol, problems: List[Any]) -> None:
         self.host.init_manager.scene.clear_all_problem_flags()
         msg = f"Error: {len(problems)} chemistry problem(s) found (e.g., hypervalency). Fix the 2D layout before converting."
-        self.host.statusBar().showMessage(msg)
+        self.host.statusBar().showMessage(msg)  # type: ignore[union-attr]
 
         with contextlib.suppress(RuntimeError):
             QMessageBox.critical(self.host, "Chemistry Problem", msg)
@@ -512,11 +512,11 @@ class ComputeManager:
                 self._restore_button_ui()
                 # If it was a halt or error from a stale worker, show with ID
                 if msg == "Halt" or msg == "Halted":
-                    self.host.statusBar().showMessage(
+                    self.host.statusBar().showMessage(  # type: ignore[union-attr]
                         f"Ignored halted worker (ID = {worker_id})"
                     )
                 else:
-                    self.host.statusBar().showMessage(
+                    self.host.statusBar().showMessage(  # type: ignore[union-attr]
                         f"Ignored stale worker error: {msg} (ID = {worker_id})"
                     )
                 return  # stale worker, ignore
@@ -528,9 +528,9 @@ class ComputeManager:
         self._restore_button_ui()
 
         if msg == "Halt" or msg == "Halted":
-            self.host.statusBar().showMessage("Halted")
+            self.host.statusBar().showMessage("Halted")  # type: ignore[union-attr]
         else:
-            self.host.statusBar().showMessage(f"Calculation Error: {msg}")
+            self.host.statusBar().showMessage(f"Calculation Error: {msg}")  # type: ignore[union-attr]
 
         # Offer UFF fallback when MMFF fails
         if "MMFF" in msg.upper() and "fail" in msg.lower():
@@ -580,7 +580,7 @@ class ComputeManager:
                 if item:
                     item.has_problem = True
                     item.update()
-            self.host.statusBar().showMessage(
+            self.host.statusBar().showMessage(  # type: ignore[union-attr]
                 f"Error: {len(problem_atom_ids)} chemistry problems found."
             )
         self.host.init_manager.view_2d.setFocus()

--- a/moleditpy/src/moleditpy/ui/compute_logic.py
+++ b/moleditpy/src/moleditpy/ui/compute_logic.py
@@ -327,6 +327,12 @@ class ComputeManager:
             )
             return
 
+        _reg = getattr(_plugin_mgr, "optimization_methods", None)
+        plugin_entry = _reg.get(method) if isinstance(_reg, dict) else None
+        if plugin_entry:
+            self._run_plugin_optimization(method, plugin_entry)
+            return
+
         self.host.statusBar().showMessage(f"Optimizing 3D structure ({method})...")  # type: ignore[union-attr]
 
         mol_block = Chem.MolToMolBlock(
@@ -359,6 +365,38 @@ class ComputeManager:
             self.host.init_manager.optimize_3d_button.setEnabled(True)
 
         self._start_calculation_worker(mol_block, options, run_id)
+
+    def _run_plugin_optimization(self, method: str, entry: Dict[str, Any]) -> None:
+        """Run a plugin-registered optimization callback synchronously.
+
+        The callback receives the current RDKit mol, modifies it in place,
+        and returns True on success (see register_optimization_method).
+        """
+        mol = self.host.view_3d_manager.current_mol
+        label = entry.get("label", method)
+        self.host.update_status_message(f"Optimizing 3D structure ({label})...")
+        try:
+            success = bool(entry["callback"](mol))
+        except Exception:  # plugins have full app access; isolate failures
+            logging.exception("Plugin optimization method '%s' failed", label)
+            self._refresh_ui_state()
+            self.host.update_status_message(
+                f"Plugin optimization '{label}' failed (see log)."
+            )
+            return
+
+        if not success:
+            self._refresh_ui_state()
+            self.host.update_status_message(f"Optimization with {label} failed.")
+            return
+
+        self.last_successful_optimization_method = label
+        self.host.view_3d_manager.draw_molecule_3d(mol)
+        self._refresh_ui_state()
+        self.host.edit_actions_manager.push_undo_state()
+        if self.host.view_3d_manager.plotter:
+            self.host.view_3d_manager.plotter.reset_camera()
+        self.host.update_status_message(f"Process completed ({label}).")
 
     def _prepare_rdkit_mol_for_conversion(self) -> Optional[Chem.Mol]:
         mol = self.host.state_manager.data.to_rdkit_mol(use_2d_stereo=False)

--- a/moleditpy/src/moleditpy/ui/compute_logic.py
+++ b/moleditpy/src/moleditpy/ui/compute_logic.py
@@ -391,7 +391,7 @@ class ComputeManager:
         msg = f"Error: {len(problems)} chemistry problem(s) found (e.g., hypervalency). Fix the 2D layout before converting."
         self.host.statusBar().showMessage(msg)
 
-        with contextlib.suppress(TypeError, RuntimeError):
+        with contextlib.suppress(RuntimeError):
             QMessageBox.critical(self.host, "Chemistry Problem", msg)
 
         for prob in problems:

--- a/moleditpy/src/moleditpy/ui/compute_logic.py
+++ b/moleditpy/src/moleditpy/ui/compute_logic.py
@@ -61,13 +61,12 @@ class ComputeManager:
     def _remove_calculating_text(self) -> None:
         """Safely remove the 'Calculating...' text actor from the plotter."""
         actor = getattr(self, "_calculating_text_actor", None)
-        if (
-            actor
-            and self.host.view_3d_manager.plotter.renderer
-            and self.host.view_3d_manager.plotter.renderer
-        ):
+        plotter = self.host.view_3d_manager.plotter
+        if actor and plotter is not None and getattr(plotter, "renderer", None):
             with contextlib.suppress(AttributeError, RuntimeError, TypeError):
-                self.host.view_3d_manager.plotter.renderer.RemoveActor(actor)
+                plotter.renderer.RemoveActor(actor)
+        self._calculating_text_actor = None
+        # Legacy cleanup: older versions stored the actor on the host
         with contextlib.suppress(AttributeError):
             if "_calculating_text_actor" in self.host.__dict__:
                 delattr(self.host, "_calculating_text_actor")
@@ -265,14 +264,15 @@ class ComputeManager:
             if (bg_qcolor.isValid() and bg_qcolor.toHsl().lightness() > 128)
             else "white"
         )
-        self._calculating_text_actor = self.host.view_3d_manager.plotter.add_text(
-            "Calculating...",
-            position="lower_right",
-            font_size=15,
-            color=text_color,
-            name="calculating_text",
-        )
-        self.host.view_3d_manager.plotter.render()
+        if self.host.view_3d_manager.plotter:
+            self._calculating_text_actor = self.host.view_3d_manager.plotter.add_text(
+                "Calculating...",
+                position="lower_right",
+                font_size=15,
+                color=text_color,
+                name="calculating_text",
+            )
+            self.host.view_3d_manager.plotter.render()
 
         options = {
             "conversion_mode": conversion_mode
@@ -391,7 +391,7 @@ class ComputeManager:
         msg = f"Error: {len(problems)} chemistry problem(s) found (e.g., hypervalency). Fix the 2D layout before converting."
         self.host.statusBar().showMessage(msg)
 
-        with contextlib.suppress(RuntimeError):
+        with contextlib.suppress(TypeError, RuntimeError):
             QMessageBox.critical(self.host, "Chemistry Problem", msg)
 
         for prob in problems:
@@ -477,7 +477,8 @@ class ComputeManager:
         self._remove_calculating_text()
         self._refresh_ui_state()
         self.host.edit_actions_manager.push_undo_state()
-        self.host.view_3d_manager.plotter.reset_camera()
+        if self.host.view_3d_manager.plotter:
+            self.host.view_3d_manager.plotter.reset_camera()
 
         # Record the successful optimization method from mol property or current setting
         try:

--- a/moleditpy/src/moleditpy/ui/compute_logic.py
+++ b/moleditpy/src/moleditpy/ui/compute_logic.py
@@ -37,8 +37,8 @@ class ComputeManager:
     """Independent manager for molecular computations, ported from MainWindowCompute mixin."""
 
     def __init__(self, host: MainWindow) -> None:
-        self._calculating_text_actor = None
-        self.original_atom_properties = {}
+        self._calculating_text_actor: Any = None
+        self.original_atom_properties: Dict[int, int] = {}
         self.host = host
         self.last_successful_optimization_method: Optional[str] = None
         self._active_calc_threads: List[QThread] = []

--- a/moleditpy/src/moleditpy/ui/compute_logic.py
+++ b/moleditpy/src/moleditpy/ui/compute_logic.py
@@ -66,7 +66,7 @@ class ComputeManager:
             with contextlib.suppress(AttributeError, RuntimeError, TypeError):
                 plotter.renderer.RemoveActor(actor)
         self._calculating_text_actor = None
-        # Legacy cleanup: older versions stored the actor on the host
+        # Legacy: older versions stored the actor on the host
         with contextlib.suppress(AttributeError):
             if "_calculating_text_actor" in self.host.__dict__:
                 delattr(self.host, "_calculating_text_actor")

--- a/moleditpy/src/moleditpy/ui/compute_logic.py
+++ b/moleditpy/src/moleditpy/ui/compute_logic.py
@@ -12,7 +12,7 @@ DOI: 10.5281/zenodo.17268532
 
 from __future__ import annotations
 import logging
-import contextlib
+from ..utils.suppress_log import suppress_log
 from typing import Any, Dict, List, Optional, Set, Tuple, Union, TYPE_CHECKING
 
 from PyQt6.QtCore import QThread, QTimer, QPoint
@@ -56,18 +56,18 @@ class ComputeManager:
             signal.disconnect()
         except RuntimeError:
             # Safe defensive fallback catching RuntimeError
-            pass
+            logging.debug("Suppressed non-critical error", exc_info=True)
 
     def _remove_calculating_text(self) -> None:
         """Safely remove the 'Calculating...' text actor from the plotter."""
         actor = getattr(self, "_calculating_text_actor", None)
         plotter = self.host.view_3d_manager.plotter
         if actor and plotter is not None and getattr(plotter, "renderer", None):
-            with contextlib.suppress(AttributeError, RuntimeError, TypeError):
+            with suppress_log(AttributeError, RuntimeError, TypeError):
                 plotter.renderer.RemoveActor(actor)
         self._calculating_text_actor = None
         # Legacy: older versions stored the actor on the host
-        with contextlib.suppress(AttributeError):
+        with suppress_log(AttributeError):
             if "_calculating_text_actor" in self.host.__dict__:
                 delattr(self.host, "_calculating_text_actor")
 
@@ -369,7 +369,7 @@ class ComputeManager:
         self.original_atom_properties = {}
         for i in range(mol.GetNumAtoms()):
             atom = mol.GetAtomWithIdx(i)
-            with contextlib.suppress(KeyError):
+            with suppress_log(KeyError):
                 self.original_atom_properties[i] = atom.GetIntProp("_original_atom_id")
 
         problems = Chem.DetectChemistryProblems(mol)
@@ -391,11 +391,11 @@ class ComputeManager:
         msg = f"Error: {len(problems)} chemistry problem(s) found (e.g., hypervalency). Fix the 2D layout before converting."
         self.host.statusBar().showMessage(msg)  # type: ignore[union-attr]
 
-        with contextlib.suppress(RuntimeError):
+        with suppress_log(RuntimeError):
             QMessageBox.critical(self.host, "Chemistry Problem", msg)
 
         for prob in problems:
-            with contextlib.suppress(AttributeError, KeyError, RuntimeError):
+            with suppress_log(AttributeError, KeyError, RuntimeError):
                 atom_idx = prob.GetAtomIdx()
                 rd_atom = mol.GetAtomWithIdx(atom_idx)
                 orig_id = rd_atom.GetIntProp("_original_atom_id")
@@ -426,7 +426,7 @@ class ComputeManager:
             thread.quit()
             thread.finished.connect(thread.deleteLater)
             worker.deleteLater()
-            with contextlib.suppress(ValueError, AttributeError):
+            with suppress_log(ValueError, AttributeError):
                 self._active_calc_threads.remove(thread)
 
         def _on_finished(result: Any) -> None:
@@ -494,7 +494,7 @@ class ComputeManager:
                 self.last_successful_optimization_method = "Unoptimized"
         except (AttributeError, TypeError):
             # Safe defensive fallback catching AttributeError, TypeError
-            pass
+            logging.debug("Suppressed non-critical error", exc_info=True)
 
         # Update 3D interactive features (hovers, menus)
         self.host.view_3d_manager.setup_3d_hover()
@@ -547,9 +547,9 @@ class ComputeManager:
                     return
             except (TypeError, RuntimeError):
                 # Safe defensive fallback catching TypeError, RuntimeError
-                pass
+                logging.debug("Suppressed non-critical error", exc_info=True)
 
-        with contextlib.suppress(TypeError, RuntimeError):
+        with suppress_log(TypeError, RuntimeError):
             QMessageBox.critical(self.host, "Calculation Error", msg)
 
     def create_atom_id_mapping(self) -> None:

--- a/moleditpy/src/moleditpy/ui/constrained_optimization_dialog.py
+++ b/moleditpy/src/moleditpy/ui/constrained_optimization_dialog.py
@@ -64,7 +64,7 @@ class ConstrainedOptimizationDialog(Dialog3DPickingMixin, QDialog):
         self.selected_atoms: list[int] = []  # Using a list because order matters
         self.constraints: list[Any] = []  # (type, atoms_indices, value)
         self.constraint_labels: list[Any] = []  # 3D label actors
-        self._opt_thread = None
+        self._opt_thread: Any = None
         self.init_ui()
         self.enable_picking()
 

--- a/moleditpy/src/moleditpy/ui/custom_interactor_style.py
+++ b/moleditpy/src/moleditpy/ui/custom_interactor_style.py
@@ -160,7 +160,9 @@ class CustomInteractorStyle(vtkInteractorStyleTrackballCamera):
                                 move_group_dialog.on_atom_picked(clicked_atom_idx)
                             except (AttributeError, RuntimeError):
                                 # Safe defensive fallback catching AttributeError, RuntimeError
-                                logging.debug("Suppressed non-critical error", exc_info=True)
+                                logging.debug(
+                                    "Suppressed non-critical error", exc_info=True
+                                )
 
                         QTimer.singleShot(0, _deferred_toggle)
                         self._suppress_next_left_button_up = True
@@ -221,7 +223,9 @@ class CustomInteractorStyle(vtkInteractorStyleTrackballCamera):
                             move_group_dialog.update_display()
                         except (AttributeError, RuntimeError):
                             # Safe defensive fallback catching AttributeError, RuntimeError
-                            logging.debug("Suppressed non-critical error", exc_info=True)
+                            logging.debug(
+                                "Suppressed non-critical error", exc_info=True
+                            )
 
                     QTimer.singleShot(0, _deferred_move_group_update)
                     return
@@ -270,7 +274,9 @@ class CustomInteractorStyle(vtkInteractorStyleTrackballCamera):
                                     )
                                 except (AttributeError, RuntimeError):
                                     # Safe defensive fallback catching AttributeError, RuntimeError
-                                    logging.debug("Suppressed non-critical error", exc_info=True)
+                                    logging.debug(
+                                        "Suppressed non-critical error", exc_info=True
+                                    )
 
                             QTimer.singleShot(0, _deferred_measure)
                             self._suppress_next_left_button_up = True
@@ -687,14 +693,19 @@ class CustomInteractorStyle(vtkInteractorStyleTrackballCamera):
                                         ValueError,
                                         TypeError,
                                     ):  # [VTK SYNC] atom_positions_3d update may race with VTK teardown; skip safely.
-                                        logging.debug("Suppressed non-critical error", exc_info=True)
+                                        logging.debug(
+                                            "Suppressed non-critical error",
+                                            exc_info=True,
+                                        )
                             except (
                                 AttributeError,
                                 RuntimeError,
                                 TypeError,
                                 ValueError,
                             ):  # [VTK SYNC] Outer drag-loop coordinate sync may race with VTK teardown; skip safely.
-                                logging.debug("Suppressed non-critical error", exc_info=True)
+                                logging.debug(
+                                    "Suppressed non-critical error", exc_info=True
+                                )
                         conf = mw.view_3d_manager.current_mol.GetConformer()
                         pos_count = (
                             len(mw.view_3d_manager.atom_positions_3d)

--- a/moleditpy/src/moleditpy/ui/custom_interactor_style.py
+++ b/moleditpy/src/moleditpy/ui/custom_interactor_style.py
@@ -58,7 +58,7 @@ class CustomInteractorStyle(vtkInteractorStyleTrackballCamera):
             self.StopState()
         except (AttributeError, RuntimeError):
             # Safe defensive fallback catching AttributeError, RuntimeError
-            pass
+            logging.debug("Suppressed non-critical error", exc_info=True)
 
         # Reset all custom flags
         self._is_dragging_atom = False
@@ -74,12 +74,12 @@ class CustomInteractorStyle(vtkInteractorStyleTrackballCamera):
                 mw.dragged_atom_info = None
             except (AttributeError, RuntimeError):
                 # Safe defensive fallback catching AttributeError, RuntimeError
-                pass
+                logging.debug("Suppressed non-critical error", exc_info=True)
             try:
                 mw.view_3d_manager.plotter.setCursor(Qt.CursorShape.ArrowCursor)
             except (AttributeError, RuntimeError):
                 # Safe defensive fallback catching AttributeError, RuntimeError
-                pass
+                logging.debug("Suppressed non-critical error", exc_info=True)
 
     def _stop_vtk_left_button_state(self) -> None:
         """Clear VTK's button/drag state after a custom-handled left click."""
@@ -87,7 +87,7 @@ class CustomInteractorStyle(vtkInteractorStyleTrackballCamera):
             self.StopState()
         except (AttributeError, RuntimeError):
             # Safe defensive fallback catching AttributeError, RuntimeError
-            pass
+            logging.debug("Suppressed non-critical error", exc_info=True)
 
     def on_left_button_down(self, obj: Any, event: Any) -> None:
         """
@@ -160,7 +160,7 @@ class CustomInteractorStyle(vtkInteractorStyleTrackballCamera):
                                 move_group_dialog.on_atom_picked(clicked_atom_idx)
                             except (AttributeError, RuntimeError):
                                 # Safe defensive fallback catching AttributeError, RuntimeError
-                                pass
+                                logging.debug("Suppressed non-critical error", exc_info=True)
 
                         QTimer.singleShot(0, _deferred_toggle)
                         self._suppress_next_left_button_up = True
@@ -221,7 +221,7 @@ class CustomInteractorStyle(vtkInteractorStyleTrackballCamera):
                             move_group_dialog.update_display()
                         except (AttributeError, RuntimeError):
                             # Safe defensive fallback catching AttributeError, RuntimeError
-                            pass
+                            logging.debug("Suppressed non-critical error", exc_info=True)
 
                     QTimer.singleShot(0, _deferred_move_group_update)
                     return
@@ -270,7 +270,7 @@ class CustomInteractorStyle(vtkInteractorStyleTrackballCamera):
                                     )
                                 except (AttributeError, RuntimeError):
                                     # Safe defensive fallback catching AttributeError, RuntimeError
-                                    pass
+                                    logging.debug("Suppressed non-critical error", exc_info=True)
 
                             QTimer.singleShot(0, _deferred_measure)
                             self._suppress_next_left_button_up = True
@@ -607,7 +607,7 @@ class CustomInteractorStyle(vtkInteractorStyleTrackballCamera):
                         move_group_dialog.update_display()
                     except (AttributeError, RuntimeError):
                         # Safe defensive fallback catching AttributeError, RuntimeError
-                        pass
+                        logging.debug("Suppressed non-critical error", exc_info=True)
 
                 QTimer.singleShot(0, _deferred_clear_move_group)
 
@@ -623,7 +623,7 @@ class CustomInteractorStyle(vtkInteractorStyleTrackballCamera):
                     mw.edit_3d_manager.clear_measurement_selection()
                 except (AttributeError, RuntimeError):
                     # Safe defensive fallback catching AttributeError, RuntimeError
-                    pass
+                    logging.debug("Suppressed non-critical error", exc_info=True)
 
             QTimer.singleShot(0, _deferred_clear_measurement)
 
@@ -687,14 +687,14 @@ class CustomInteractorStyle(vtkInteractorStyleTrackballCamera):
                                         ValueError,
                                         TypeError,
                                     ):  # [VTK SYNC] atom_positions_3d update may race with VTK teardown; skip safely.
-                                        pass
+                                        logging.debug("Suppressed non-critical error", exc_info=True)
                             except (
                                 AttributeError,
                                 RuntimeError,
                                 TypeError,
                                 ValueError,
                             ):  # [VTK SYNC] Outer drag-loop coordinate sync may race with VTK teardown; skip safely.
-                                pass
+                                logging.debug("Suppressed non-critical error", exc_info=True)
                         conf = mw.view_3d_manager.current_mol.GetConformer()
                         pos_count = (
                             len(mw.view_3d_manager.atom_positions_3d)

--- a/moleditpy/src/moleditpy/ui/custom_interactor_style.py
+++ b/moleditpy/src/moleditpy/ui/custom_interactor_style.py
@@ -109,7 +109,7 @@ class CustomInteractorStyle(vtkInteractorStyleTrackballCamera):
 
         # Check Move Group dialog
         # Check Move Group or Move Selected Atoms dialog
-        move_group_dialog = None
+        move_group_dialog: Any = None
         for widget in QApplication.topLevelWidgets():
             try:
                 if (
@@ -323,7 +323,7 @@ class CustomInteractorStyle(vtkInteractorStyleTrackballCamera):
         mw = self.main_window
 
         # Check if Move Group dialog or Move Selected Atoms dialog is open
-        move_group_dialog = None
+        move_group_dialog: Any = None
         try:
             for widget in QApplication.topLevelWidgets():
                 if (
@@ -384,7 +384,7 @@ class CustomInteractorStyle(vtkInteractorStyleTrackballCamera):
         mw = self.main_window
 
         # Move Group / Selected Atoms drag handling
-        move_group_dialog = None
+        move_group_dialog: Any = None
         try:
             for widget in QApplication.topLevelWidgets():
                 if (
@@ -480,7 +480,7 @@ class CustomInteractorStyle(vtkInteractorStyleTrackballCamera):
         mw = self.main_window
 
         # Finalize Move Group / Selected Atoms drag
-        move_group_dialog = None
+        move_group_dialog: Any = None
         try:
             for widget in QApplication.topLevelWidgets():
                 if (
@@ -798,7 +798,7 @@ class CustomInteractorStyle(vtkInteractorStyleTrackballCamera):
         mw = self.main_window
 
         # Finalize Move Group / Selected Atoms rotation
-        move_group_dialog = None
+        move_group_dialog: Any = None
         try:
             for widget in QApplication.topLevelWidgets():
                 if (

--- a/moleditpy/src/moleditpy/ui/dialog_3d_picking_mixin.py
+++ b/moleditpy/src/moleditpy/ui/dialog_3d_picking_mixin.py
@@ -83,7 +83,9 @@ class Dialog3DPickingMixin:
                                 self.on_atom_picked(int(closest_atom_idx))
                             except (AttributeError, RuntimeError):
                                 # Safe defensive fallback catching AttributeError, RuntimeError
-                                logging.debug("Suppressed non-critical error", exc_info=True)
+                                logging.debug(
+                                    "Suppressed non-critical error", exc_info=True
+                                )
 
                         from PyQt6.QtCore import QTimer
 
@@ -136,7 +138,9 @@ class Dialog3DPickingMixin:
                                 self.clear_selection()
                             except (AttributeError, RuntimeError):
                                 # Safe defensive fallback catching AttributeError, RuntimeError
-                                logging.debug("Suppressed non-critical error", exc_info=True)
+                                logging.debug(
+                                    "Suppressed non-critical error", exc_info=True
+                                )
 
                         from PyQt6.QtCore import QTimer
 

--- a/moleditpy/src/moleditpy/ui/dialog_3d_picking_mixin.py
+++ b/moleditpy/src/moleditpy/ui/dialog_3d_picking_mixin.py
@@ -83,7 +83,7 @@ class Dialog3DPickingMixin:
                                 self.on_atom_picked(int(closest_atom_idx))
                             except (AttributeError, RuntimeError):
                                 # Safe defensive fallback catching AttributeError, RuntimeError
-                                pass
+                                logging.debug("Suppressed non-critical error", exc_info=True)
 
                         from PyQt6.QtCore import QTimer
 
@@ -136,7 +136,7 @@ class Dialog3DPickingMixin:
                                 self.clear_selection()
                             except (AttributeError, RuntimeError):
                                 # Safe defensive fallback catching AttributeError, RuntimeError
-                                pass
+                                logging.debug("Suppressed non-critical error", exc_info=True)
 
                         from PyQt6.QtCore import QTimer
 
@@ -182,7 +182,7 @@ class Dialog3DPickingMixin:
                         plotter.remove_actor(label_actor)
                 except (AttributeError, RuntimeError, TypeError):
                     # Safe defensive fallback catching AttributeError, RuntimeError, TypeError
-                    pass
+                    logging.debug("Suppressed non-critical error", exc_info=True)
         self.selection_labels = []
 
     clear_selection_labels = clear_atom_labels
@@ -221,7 +221,7 @@ class Dialog3DPickingMixin:
                     plotter.camera_position = cam
                 except (AttributeError, RuntimeError, TypeError):
                     # Safe defensive fallback catching AttributeError, RuntimeError, TypeError
-                    pass
+                    logging.debug("Suppressed non-critical error", exc_info=True)
 
     def show_atom_labels_for(
         self, atoms_and_labels: list[tuple[int, str]], color: str = "yellow"
@@ -260,4 +260,4 @@ class Dialog3DPickingMixin:
                 plotter.camera_position = cam
             except (AttributeError, RuntimeError, TypeError):
                 # Safe defensive fallback catching AttributeError, RuntimeError, TypeError
-                pass
+                logging.debug("Suppressed non-critical error", exc_info=True)

--- a/moleditpy/src/moleditpy/ui/dihedral_dialog.py
+++ b/moleditpy/src/moleditpy/ui/dihedral_dialog.py
@@ -12,7 +12,7 @@ DOI: 10.5281/zenodo.17268532
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Optional, Sequence
+from typing import Any, TYPE_CHECKING, Optional, Sequence
 
 from PyQt6.QtCore import Qt
 from PyQt6.QtWidgets import (
@@ -50,18 +50,18 @@ class DihedralDialog(GeometryBaseDialog):
         parent: Optional[QWidget] = None,
     ) -> None:
         super().__init__(mol, main_window, parent)
-        self._baseline_positions = None
+        self._baseline_positions: Any = None
         self._snapshot_positions = None
-        self.apply_button = None
-        self.both_groups_radio = None
-        self.clear_button = None
-        self.dihedral_input = None
-        self.dihedral_label = None
-        self.dihedral_slider = None
+        self.apply_button: Any = None
+        self.both_groups_radio: Any = None
+        self.clear_button: Any = None
+        self.dihedral_input: Any = None
+        self.dihedral_label: Any = None
+        self.dihedral_slider: Any = None
         self.picker_connection = None
-        self.rotate_atom_radio = None
-        self.rotate_group_radio = None
-        self.selection_label = None
+        self.rotate_atom_radio: Any = None
+        self.rotate_group_radio: Any = None
+        self.selection_label: Any = None
         self.atom1_idx: Optional[int] = None
         self.atom2_idx: Optional[int] = None
         self.atom3_idx: Optional[int] = None

--- a/moleditpy/src/moleditpy/ui/dihedral_dialog.py
+++ b/moleditpy/src/moleditpy/ui/dihedral_dialog.py
@@ -11,6 +11,7 @@ DOI: 10.5281/zenodo.17268532
 """
 
 from __future__ import annotations
+import logging
 
 from typing import Any, TYPE_CHECKING, Optional, Sequence
 
@@ -266,7 +267,7 @@ class DihedralDialog(GeometryBaseDialog):
                 self.dihedral_slider.blockSignals(False)
             except (AttributeError, RuntimeError, ValueError, TypeError):
                 # Safe defensive fallback catching AttributeError, RuntimeError, ValueError, TypeError
-                pass
+                logging.debug("Suppressed non-critical error", exc_info=True)
         elif self.atom2_idx is None:
             symbol1 = self.mol.GetAtomWithIdx(self.atom1_idx).GetSymbol()
             self.selection_label.setText(f"Selected: {symbol1}({self.atom1_idx}) - ?")
@@ -327,7 +328,7 @@ class DihedralDialog(GeometryBaseDialog):
                     self.dihedral_slider.setEnabled(True)
             except (AttributeError, RuntimeError, TypeError):
                 # Safe defensive fallback catching AttributeError, RuntimeError, TypeError
-                pass
+                logging.debug("Suppressed non-critical error", exc_info=True)
 
             # Add labels
             self.add_selection_label(self.atom1_idx, "1")

--- a/moleditpy/src/moleditpy/ui/edit_3d_logic.py
+++ b/moleditpy/src/moleditpy/ui/edit_3d_logic.py
@@ -11,6 +11,7 @@ DOI: 10.5281/zenodo.17268532
 """
 
 from __future__ import annotations
+import logging
 
 # main_window_edit_3d.py
 # Mixin class separated from main_window.py
@@ -75,7 +76,7 @@ class Edit3DManager:
                     interactor_style.reset_interactor_state()
             except (AttributeError, RuntimeError):
                 # Safe defensive fallback catching AttributeError, RuntimeError
-                pass
+                logging.debug("Suppressed non-critical error", exc_info=True)
 
         # Update status message
         if checked:
@@ -95,7 +96,7 @@ class Edit3DManager:
                 # Suppress non-critical 3D edit/UI sync errors during bulk dialog teardown.
                 # If a dialog is already closed or its C++ object is gone, we ignore it.
                 # Safe defensive fallback catching AttributeError, RuntimeError
-                pass
+                logging.debug("Suppressed non-critical error", exc_info=True)
 
         self.active_3d_dialogs.clear()
 
@@ -129,7 +130,7 @@ class Edit3DManager:
         except (AttributeError, RuntimeError):
             # Suppress if the actor is already destroyed or not found.
             # Safe defensive fallback catching AttributeError, RuntimeError
-            pass
+            logging.debug("Suppressed non-critical error", exc_info=True)
 
         if not self.measurement_labels or not self.host.view_3d_manager.current_mol:
             return
@@ -176,7 +177,7 @@ class Edit3DManager:
         except (AttributeError, RuntimeError):
             # Suppress if the actor is already destroyed or not found.
             # Safe defensive fallback catching AttributeError, RuntimeError
-            pass
+            logging.debug("Suppressed non-critical error", exc_info=True)
 
         # Remove 2D labels
         self.clear_2d_measurement_labels()
@@ -191,7 +192,7 @@ class Edit3DManager:
             except (AttributeError, RuntimeError):
                 # Suppress if the actor is already destroyed or not found.
                 # Safe defensive fallback catching AttributeError, RuntimeError
-                pass
+                logging.debug("Suppressed non-critical error", exc_info=True)
 
         self.host.view_3d_manager.plotter.render()
 
@@ -265,7 +266,7 @@ class Edit3DManager:
                 except (AttributeError, RuntimeError):
                     # Scene access or removal failed; skip this item.
                     # Safe defensive fallback catching AttributeError, RuntimeError
-                    pass
+                    logging.debug("Suppressed non-critical error", exc_info=True)
             except (AttributeError, RuntimeError):
                 # If sip check itself fails, fall back to best-effort removal
                 try:
@@ -372,7 +373,7 @@ class Edit3DManager:
             except (AttributeError, RuntimeError, ValueError, TypeError):
                 # Suppress non-critical 3D edit/UI sync errors if the plotter or actor is already destroyed
                 # Safe defensive fallback catching AttributeError, RuntimeError, ValueError, TypeError
-                pass
+                logging.debug("Suppressed non-critical error", exc_info=True)
 
         if not measurement_lines:
             self.measurement_text_actor = None
@@ -431,7 +432,7 @@ class Edit3DManager:
         except (AttributeError, RuntimeError, ValueError, TypeError):
             # Suppress non-critical UI/rendering/measurement noise if the plotter or actor is already destroyed.
             # Safe defensive fallback catching AttributeError, RuntimeError, ValueError, TypeError
-            pass
+            logging.debug("Suppressed non-critical error", exc_info=True)
 
         if not self.selected_atoms_3d or not self.host.view_3d_manager.current_mol:
             self.host.view_3d_manager.plotter.render()

--- a/moleditpy/src/moleditpy/ui/edit_3d_logic.py
+++ b/moleditpy/src/moleditpy/ui/edit_3d_logic.py
@@ -30,7 +30,7 @@ from ..core.mol_geometry import (
     calculate_dihedral as _calculate_dihedral,
 )
 from ..utils.sip_isdeleted_safe import sip_isdeleted_safe
-from ..utils.constants import VDW_RADII
+from ..utils.constants import VDW_DISPLAY_RADII
 
 
 # --- Classes ---
@@ -448,7 +448,7 @@ class Edit3DManager:
         # Highlight with slightly larger radius
         selected_radii = np.array(
             [
-                VDW_RADII.get(
+                VDW_DISPLAY_RADII.get(
                     self.host.view_3d_manager.current_mol.GetAtomWithIdx(i).GetSymbol(),
                     0.4,
                 )

--- a/moleditpy/src/moleditpy/ui/edit_actions_logic.py
+++ b/moleditpy/src/moleditpy/ui/edit_actions_logic.py
@@ -275,7 +275,7 @@ class EditActionsManager:
 
             # Store atom data with relative positions and map IDs to new indices
             atom_id_to_idx_map = {}
-            fragment_atoms = []
+            fragment_atoms: List[Dict[str, Any]] = []
             for i, atom in enumerate(selected_atoms):
                 atom_id_to_idx_map[atom.atom_id] = i
                 fragment_atoms.append(
@@ -671,17 +671,17 @@ class EditActionsManager:
                         # Calculate gaps (including wrap-around)
                         gaps = []  # list of (gap_size, start_angle, end_angle)
                         for i in range(len(angs)):
-                            a1 = angs[i]
-                            a2 = angs[(i + 1) % len(angs)]
+                            ang_a = angs[i]
+                            ang_b = angs[(i + 1) % len(angs)]
                             if i == len(angs) - 1:
                                 # wrap-around gap
-                                gap = (a2 + 2.0 * math.pi) - a1
-                                start = a1
-                                end = a2 + 2.0 * math.pi
+                                gap = (ang_b + 2.0 * math.pi) - ang_a
+                                start = ang_a
+                                end = ang_b + 2.0 * math.pi
                             else:
-                                gap = a2 - a1
-                                start = a1
-                                end = a2
+                                gap = ang_b - ang_a
+                                start = ang_a
+                                end = ang_b
                             gaps.append((gap, start, end))
 
                         # Select largest gap and space hydrogens evenly

--- a/moleditpy/src/moleditpy/ui/edit_actions_logic.py
+++ b/moleditpy/src/moleditpy/ui/edit_actions_logic.py
@@ -42,7 +42,7 @@ from rdkit import Chem
 
 from .atom_item import AtomItem
 from .bond_item import BondItem
-from ..utils.constants import CLIPBOARD_MIME_TYPE
+from ..utils.constants import CLIPBOARD_MIME_TYPE, UNDO_STACK_MAX_DEPTH
 from ..core.molecular_data import MolecularData
 from ..utils.sip_isdeleted_safe import sip_isdeleted_safe
 
@@ -183,6 +183,9 @@ class EditActionsManager:
             # Deepcopy state via pickling or explicit get_current_state call
             state = copy.deepcopy(self.host.state_manager.get_current_state())
             self.undo_stack.append(state)
+            # Drop oldest entries beyond the cap
+            if len(self.undo_stack) > UNDO_STACK_MAX_DEPTH:
+                del self.undo_stack[: len(self.undo_stack) - UNDO_STACK_MAX_DEPTH]
 
             self.redo_stack.clear()
             # Record changes after initialization

--- a/moleditpy/src/moleditpy/ui/edit_actions_logic.py
+++ b/moleditpy/src/moleditpy/ui/edit_actions_logic.py
@@ -326,13 +326,13 @@ class EditActionsManager:
             cb = QApplication.clipboard()
             if cb is not None:
                 cb.setMimeData(mime_data)
-            self.host.statusBar().showMessage(
+            self.host.statusBar().showMessage(  # type: ignore[union-attr]
                 f"Copied {len(fragment_atoms)} atoms and {len(fragment_bonds)} bonds."
             )
 
         except (AttributeError, RuntimeError, ValueError, TypeError):
             logging.exception("Error during copy operation")
-            self.host.statusBar().showMessage("Error during copy operation.")
+            self.host.statusBar().showMessage("Error during copy operation.")  # type: ignore[union-attr]
 
     def cut_selection(self) -> None:
         """Cut selected items (copy then delete)"""
@@ -346,11 +346,11 @@ class EditActionsManager:
 
             if self.host.init_manager.scene.delete_items(set(selected_items)):
                 self.host.edit_actions_manager.push_undo_state()
-                self.host.statusBar().showMessage("Cut selection.", 2000)
+                self.host.statusBar().showMessage("Cut selection.", 2000)  # type: ignore[union-attr]
 
         except (AttributeError, RuntimeError, ValueError, TypeError):
             logging.exception("Error during cut operation")
-            self.host.statusBar().showMessage("Error during cut operation.")
+            self.host.statusBar().showMessage("Error during cut operation.")  # type: ignore[union-attr]
 
     def paste_from_clipboard(self) -> None:
         """Paste molecular fragment from clipboard"""
@@ -366,7 +366,7 @@ class EditActionsManager:
             try:
                 fragment_data = json.loads(bytes(byte_array.data()).decode("utf-8"))
             except (json.JSONDecodeError, UnicodeDecodeError, KeyError):
-                self.host.statusBar().showMessage(
+                self.host.statusBar().showMessage(  # type: ignore[union-attr]
                     "Error: Invalid clipboard data format"
                 )
                 return
@@ -404,14 +404,14 @@ class EditActionsManager:
                 )
 
             self.host.edit_actions_manager.push_undo_state()
-            self.host.statusBar().showMessage(
+            self.host.statusBar().showMessage(  # type: ignore[union-attr]
                 f"Pasted {len(fragment_data['atoms'])} atoms and {len(fragment_data['bonds'])} bonds.",
                 2000,
             )
 
         except (AttributeError, RuntimeError, ValueError, TypeError):
             logging.exception("Error during paste operation")
-            self.host.statusBar().showMessage("Error during paste operation.")
+            self.host.statusBar().showMessage("Error during paste operation.")  # type: ignore[union-attr]
         self.host.ui_manager.activate_select_mode()
         self.host.init_manager.scene.update_all_items()
 
@@ -441,7 +441,7 @@ class EditActionsManager:
                     continue
 
             if not hydrogen_map:
-                self.host.statusBar().showMessage(
+                self.host.statusBar().showMessage(  # type: ignore[union-attr]
                     "No hydrogen atoms found to remove.", 2000
                 )
                 return
@@ -524,18 +524,18 @@ class EditActionsManager:
             if removed_count > 0:
                 # Only push a single undo state once for the whole operation
                 self.host.edit_actions_manager.push_undo_state()
-                self.host.statusBar().showMessage(
+                self.host.statusBar().showMessage(  # type: ignore[union-attr]
                     f"Removed {removed_count} hydrogen atoms.", 2000
                 )
             else:
                 # If nothing removed but we attempted, show an informative message
                 if deleted_any:
                     # Deleted something but couldn't determine count reliably
-                    self.host.statusBar().showMessage(
+                    self.host.statusBar().showMessage(  # type: ignore[union-attr]
                         "Removed hydrogen atoms (count unknown).", 2000
                     )
                 else:
-                    self.host.statusBar().showMessage(
+                    self.host.statusBar().showMessage(  # type: ignore[union-attr]
                         "Failed to remove hydrogen atoms or none found."
                     )
 
@@ -543,7 +543,7 @@ class EditActionsManager:
             logging.exception("Error during hydrogen removal")
             with contextlib.suppress(AttributeError, RuntimeError, TypeError):
                 # Suppress transient errors during UI status reporting.
-                self.host.statusBar().showMessage("Error removing hydrogen atoms.")
+                self.host.statusBar().showMessage("Error removing hydrogen atoms.")  # type: ignore[union-attr]
 
     def add_hydrogen_atoms(self) -> None:
         """Compute and add explicit hydrogens in 2D view using RDKit."""
@@ -551,7 +551,7 @@ class EditActionsManager:
         try:
             mol = self.host.state_manager.data.to_rdkit_mol(use_2d_stereo=False)
             if not mol or mol.GetNumAtoms() == 0:
-                self.host.statusBar().showMessage(
+                self.host.statusBar().showMessage(  # type: ignore[union-attr]
                     "No molecule available to compute hydrogens.", 2000
                 )
                 return
@@ -722,7 +722,7 @@ class EditActionsManager:
             if added_count > 0:
                 self.host.init_manager.scene.update_all_items()
                 self.host.edit_actions_manager.push_undo_state()
-                self.host.statusBar().showMessage(
+                self.host.statusBar().showMessage(  # type: ignore[union-attr]
                     f"Added {added_count} hydrogen atoms.", 2000
                 )
                 with contextlib.suppress(AttributeError, RuntimeError, TypeError):
@@ -731,20 +731,20 @@ class EditActionsManager:
                     for it in added_items:
                         it.setSelected(True)
             else:
-                self.host.statusBar().showMessage(
+                self.host.statusBar().showMessage(  # type: ignore[union-attr]
                     "No implicit hydrogens found to add.", 2000
                 )
 
         except (AttributeError, RuntimeError, ValueError, TypeError):
             logging.exception("Error during hydrogen addition")
-            self.host.statusBar().showMessage("Error adding hydrogen atoms.")
+            self.host.statusBar().showMessage("Error adding hydrogen atoms.")  # type: ignore[union-attr]
 
     def update_edit_menu_actions(self) -> None:
         """Update edit menu based on selection and clipboard"""
         try:
             has_selection = len(self.host.init_manager.scene.selectedItems()) > 0
-            self.host.init_manager.cut_action.setEnabled(has_selection)
-            self.host.init_manager.copy_action.setEnabled(has_selection)
+            self.host.init_manager.cut_action.setEnabled(has_selection)  # type: ignore[union-attr]
+            self.host.init_manager.copy_action.setEnabled(has_selection)  # type: ignore[union-attr]
 
             clipboard = QApplication.clipboard()
             if clipboard is not None:
@@ -789,7 +789,7 @@ class EditActionsManager:
                 ]
 
             if not target_atoms:
-                self.host.statusBar().showMessage("No atoms to rotate.")
+                self.host.statusBar().showMessage("No atoms to rotate.")  # type: ignore[union-attr]
                 return
 
             # Calculate Center
@@ -824,13 +824,13 @@ class EditActionsManager:
             self.host.init_manager.scene.update_all_items()
 
             self.host.edit_actions_manager.push_undo_state()
-            self.host.statusBar().showMessage(
+            self.host.statusBar().showMessage(  # type: ignore[union-attr]
                 f"Rotated {len(target_atoms)} atoms by {angle_degrees} degrees."
             )
 
         except (AttributeError, RuntimeError, ValueError, TypeError):
             logging.exception("Error rotating molecule")
-            self.host.statusBar().showMessage("Error rotating molecule.")
+            self.host.statusBar().showMessage("Error rotating molecule.")  # type: ignore[union-attr]
 
     def select_all(self) -> None:
         """Select all atoms and bonds in the 2D scene."""
@@ -893,7 +893,7 @@ class EditActionsManager:
         self.host.ui_manager.enable_3d_features(False)
 
         # Redraw 3D plotter
-        self.host.view_3d_manager.plotter.render()
+        self.host.view_3d_manager.plotter.render()  # type: ignore[union-attr]
 
         # Update menu text and state
         self.host.view_3d_manager.update_atom_id_menu_text()
@@ -1108,14 +1108,14 @@ class EditActionsManager:
 
     def clean_up_2d_structure(self) -> None:
         """Run RDKit 2D coordinate cleanup and re-layout."""
-        self.host.statusBar().showMessage("Optimizing 2D structure...")
+        self.host.statusBar().showMessage("Optimizing 2D structure...")  # type: ignore[union-attr]
 
         # Clear existing problem flags
         self.host.init_manager.scene.clear_all_problem_flags()
 
         # Case: no atoms in 2D editor
         if not self.host.state_manager.data.atoms:
-            self.host.statusBar().showMessage("Error: No atoms to optimize.")
+            self.host.statusBar().showMessage("Error: No atoms to optimize.")  # type: ignore[union-attr]
             return
 
         mol = self.host.state_manager.data.to_rdkit_mol()
@@ -1130,7 +1130,7 @@ class EditActionsManager:
             new_positions = optimize_2d_coords(mol)
 
             if not new_positions:
-                self.host.statusBar().showMessage(
+                self.host.statusBar().showMessage(  # type: ignore[union-attr]
                     "Optimization failed to generate coordinates."
                 )
                 return
@@ -1180,11 +1180,11 @@ class EditActionsManager:
             # Request scene update and ring re-analysis
             self.host.init_manager.scene.update_all_items()
 
-            self.host.statusBar().showMessage("2D structure optimization successful.")
+            self.host.statusBar().showMessage("2D structure optimization successful.")  # type: ignore[union-attr]
             self.host.edit_actions_manager.push_undo_state()
 
         except (AttributeError, RuntimeError, ValueError) as e:
-            self.host.statusBar().showMessage(f"Error during 2D optimization: {e}")
+            self.host.statusBar().showMessage(f"Error during 2D optimization: {e}")  # type: ignore[union-attr]
         finally:
             self.host.init_manager.view_2d.setFocus()
 
@@ -1194,9 +1194,9 @@ class EditActionsManager:
             self.host.view_3d_manager.draw_molecule_3d(
                 self.host.view_3d_manager.current_mol
             )
-            self.host.statusBar().showMessage("Redraw complete.", 2000)
+            self.host.statusBar().showMessage("Redraw complete.", 2000)  # type: ignore[union-attr]
         else:
-            self.host.statusBar().showMessage("No 3D molecule to redraw.")
+            self.host.statusBar().showMessage("No 3D molecule to redraw.")  # type: ignore[union-attr]
 
     def resolve_overlapping_groups(self) -> None:
         """Detect and resolve overlapping atom groups."""
@@ -1235,7 +1235,7 @@ class EditActionsManager:
         )
 
         if not move_operations:
-            self.host.statusBar().showMessage("No overlapping atoms found.", 2000)
+            self.host.statusBar().showMessage("No overlapping atoms found.", 2000)  # type: ignore[union-attr]
             return
 
         # Step 4: Execute translations
@@ -1267,7 +1267,7 @@ class EditActionsManager:
 
         self.host.init_manager.scene.update()
         self.host.edit_actions_manager.push_undo_state()
-        self.host.statusBar().showMessage("Resolved overlapping groups.", 2000)
+        self.host.statusBar().showMessage("Resolved overlapping groups.", 2000)  # type: ignore[union-attr]
 
     def adjust_molecule_positions_to_avoid_collisions(
         self, mol: Chem.Mol, frags: List[List[int]]
@@ -1449,12 +1449,12 @@ class EditActionsManager:
             desc = f" ({source_desc})" if source_desc else ""
             # Suppress potential status bar or button state errors if the window is being closed or destroyed
             with contextlib.suppress(AttributeError, RuntimeError, TypeError):
-                self.host.statusBar().showMessage(
+                self.host.statusBar().showMessage(  # type: ignore[union-attr]
                     f"Molecule sanitization failed{desc}; file may be malformed."
                 )
             # Disable 3D optimization UI to prevent running on invalid molecules
             with contextlib.suppress(AttributeError, RuntimeError, TypeError):
-                self.host.init_manager.optimize_3d_button.setEnabled(False)
+                self.host.init_manager.optimize_3d_button.setEnabled(False)  # type: ignore[union-attr]
 
     def _clear_xyz_flags(self, mol: Optional[Any] = None) -> None:
         """Clear XYZ-derived markers from a molecule (or current_mol) and
@@ -1487,6 +1487,6 @@ class EditActionsManager:
         # Enable Optimize 3D unless sanitization failed
         with contextlib.suppress(AttributeError, RuntimeError, TypeError):
             # Suppress error if optimize_3d_button is partially destroyed.
-            self.host.init_manager.optimize_3d_button.setEnabled(
+            self.host.init_manager.optimize_3d_button.setEnabled(  # type: ignore[union-attr]
                 not getattr(self.host, "chem_check_failed", False)
             )

--- a/moleditpy/src/moleditpy/ui/edit_actions_logic.py
+++ b/moleditpy/src/moleditpy/ui/edit_actions_logic.py
@@ -11,7 +11,7 @@ DOI: 10.5281/zenodo.17268532
 """
 
 from __future__ import annotations
-import contextlib
+from ..utils.suppress_log import suppress_log
 import json
 import copy
 import logging
@@ -541,7 +541,7 @@ class EditActionsManager:
 
         except (AttributeError, RuntimeError, ValueError, TypeError):
             logging.exception("Error during hydrogen removal")
-            with contextlib.suppress(AttributeError, RuntimeError, TypeError):
+            with suppress_log(AttributeError, RuntimeError, TypeError):
                 # Suppress transient errors during UI status reporting.
                 self.host.statusBar().showMessage("Error removing hydrogen atoms.")  # type: ignore[union-attr]
 
@@ -725,7 +725,7 @@ class EditActionsManager:
                 self.host.statusBar().showMessage(  # type: ignore[union-attr]
                     f"Added {added_count} hydrogen atoms.", 2000
                 )
-                with contextlib.suppress(AttributeError, RuntimeError, TypeError):
+                with suppress_log(AttributeError, RuntimeError, TypeError):
                     # Suppress selection errors if the scene is being cleared or items are invalid.
                     self.host.init_manager.scene.clearSelection()
                     for it in added_items:
@@ -757,7 +757,7 @@ class EditActionsManager:
         except RuntimeError:
             # Suppress non-critical error
             # Safe defensive fallback catching RuntimeError
-            pass
+            logging.debug("Suppressed non-critical error", exc_info=True)
 
     def open_rotate_2d_dialog(self) -> None:
         """Open 2D rotation dialog"""
@@ -1013,7 +1013,7 @@ class EditActionsManager:
                     continue
 
                 # Suppress potential errors if the item is already destroyed by SIP during iteration
-                with contextlib.suppress(AttributeError, RuntimeError, TypeError):
+                with suppress_log(AttributeError, RuntimeError, TypeError):
                     if is_deleted_func is not None and is_deleted_func(item):
                         continue
 
@@ -1060,7 +1060,7 @@ class EditActionsManager:
                     continue
                 seen.add(oid)
                 if hasattr(it, "update"):
-                    with contextlib.suppress(AttributeError, RuntimeError, TypeError):
+                    with suppress_log(AttributeError, RuntimeError, TypeError):
                         # Suppress transient errors during item update.
                         it.update()
                 else:
@@ -1101,7 +1101,7 @@ class EditActionsManager:
                 QTimer.singleShot(0, _ui_closure)
             except (RuntimeError, TypeError):
                 # Fallback if QTimer fails (e.g. during app shutdown)
-                with contextlib.suppress(AttributeError, RuntimeError, TypeError):
+                with suppress_log(AttributeError, RuntimeError, TypeError):
                     _ui_closure()
         except (AttributeError, RuntimeError, TypeError, ValueError) as e:
             logging.exception(f"Unexpected error in update_implicit_hydrogens: {e}")
@@ -1168,7 +1168,7 @@ class EditActionsManager:
                     continue
                 if bond_item.scene():
                     # Suppress potential errors if the item is already destroyed during coordinate adjustment
-                    with contextlib.suppress(AttributeError, RuntimeError, TypeError):
+                    with suppress_log(AttributeError, RuntimeError, TypeError):
                         bond_item.update_position()
 
             # Run overlap resolution
@@ -1257,7 +1257,7 @@ class EditActionsManager:
                 if sip_isdeleted_safe(item):
                     continue
                 if item.scene():
-                    with contextlib.suppress(AttributeError, RuntimeError, TypeError):
+                    with suppress_log(AttributeError, RuntimeError, TypeError):
                         item.update_position()
             except (AttributeError, RuntimeError, TypeError) as e:
                 logging.debug(f"Bond position update suppressed: {e}")
@@ -1448,12 +1448,12 @@ class EditActionsManager:
             self.host.chem_check_failed = True
             desc = f" ({source_desc})" if source_desc else ""
             # Suppress potential status bar or button state errors if the window is being closed or destroyed
-            with contextlib.suppress(AttributeError, RuntimeError, TypeError):
+            with suppress_log(AttributeError, RuntimeError, TypeError):
                 self.host.statusBar().showMessage(  # type: ignore[union-attr]
                     f"Molecule sanitization failed{desc}; file may be malformed."
                 )
             # Disable 3D optimization UI to prevent running on invalid molecules
-            with contextlib.suppress(AttributeError, RuntimeError, TypeError):
+            with suppress_log(AttributeError, RuntimeError, TypeError):
                 self.host.init_manager.optimize_3d_button.setEnabled(False)  # type: ignore[union-attr]
 
     def _clear_xyz_flags(self, mol: Optional[Any] = None) -> None:
@@ -1470,22 +1470,22 @@ class EditActionsManager:
         target = mol if mol is not None else self.host.view_3d_manager.current_mol
         if target is not None:
             # Remove RDKit property _xyz_skip_checks
-            with contextlib.suppress(AttributeError, RuntimeError, TypeError):
+            with suppress_log(AttributeError, RuntimeError, TypeError):
                 # Suppress error if HasProp or ClearProp is unavailable.
                 if hasattr(target, "HasProp") and target.HasProp("_xyz_skip_checks"):
-                    with contextlib.suppress(AttributeError, RuntimeError, TypeError):
+                    with suppress_log(AttributeError, RuntimeError, TypeError):
                         target.ClearProp("_xyz_skip_checks")
             # Remove attribute-style markers
             target.__dict__.pop("_xyz_skip_checks", None)
             target.__dict__.pop("xyz_atom_data", None)
 
-        with contextlib.suppress(AttributeError, RuntimeError, TypeError):
+        with suppress_log(AttributeError, RuntimeError, TypeError):
             self.host.view_3d_manager.reset_zoom()
 
         self.host.is_xyz_derived = False
 
         # Enable Optimize 3D unless sanitization failed
-        with contextlib.suppress(AttributeError, RuntimeError, TypeError):
+        with suppress_log(AttributeError, RuntimeError, TypeError):
             # Suppress error if optimize_3d_button is partially destroyed.
             self.host.init_manager.optimize_3d_button.setEnabled(  # type: ignore[union-attr]
                 not getattr(self.host, "chem_check_failed", False)

--- a/moleditpy/src/moleditpy/ui/export_logic.py
+++ b/moleditpy/src/moleditpy/ui/export_logic.py
@@ -47,7 +47,7 @@ class ExportManager:
                     return str(name)
         except (AttributeError, RuntimeError, ValueError, TypeError):
             # Safe defensive fallback catching AttributeError, RuntimeError, ValueError, TypeError
-            pass
+            logging.debug("Suppressed non-critical error", exc_info=True)
         return "untitled"
 
     def _get_default_path(self, suffix: str = "") -> str:
@@ -59,7 +59,7 @@ class ExportManager:
                 return os.path.join(os.path.dirname(cur_path), basename)
         except (AttributeError, RuntimeError, ValueError, TypeError):
             # Safe defensive fallback catching AttributeError, RuntimeError, ValueError, TypeError
-            pass
+            logging.debug("Suppressed non-critical error", exc_info=True)
         return basename
 
     def export_stl(self) -> None:
@@ -519,7 +519,7 @@ class ExportManager:
                         except (AttributeError, RuntimeError, TypeError):
                             # Use default color on failure to avoid console noise during complex mesh export
                             # Safe defensive fallback catching AttributeError, RuntimeError, TypeError
-                            pass
+                            logging.debug("Suppressed non-critical error", exc_info=True)
 
                         # Create mesh copy
                         mesh_copy = mesh.copy()
@@ -565,7 +565,7 @@ class ExportManager:
                                     ValueError,
                                     TypeError,
                                 ):  # [PYVISTA] Mesh color extraction may fail on headless/incomplete meshes; fall through to default.
-                                    pass
+                                    logging.debug("Suppressed non-critical error", exc_info=True)
                             if colors is not None and colors.size > 0:
                                 # Normalize float colors to 0-255
                                 colors_arr = np.asarray(colors)
@@ -659,7 +659,7 @@ class ExportManager:
                         except (AttributeError, RuntimeError, ValueError, TypeError):
                             # Fallback: add single mesh on failure
                             # Safe defensive fallback catching AttributeError, RuntimeError, ValueError, TypeError
-                            pass
+                            logging.debug("Suppressed non-critical error", exc_info=True)
 
                         meshes_with_colors.append(
                             {
@@ -723,7 +723,7 @@ class ExportManager:
         except (AttributeError, RuntimeError, ValueError, TypeError):
             # Minimal risk; keep default brush
             # Safe defensive fallback catching AttributeError, RuntimeError, ValueError, TypeError
-            pass
+            logging.debug("Suppressed non-critical error", exc_info=True)
 
         try:
             all_items = list(self.host.init_manager.scene.items())
@@ -887,7 +887,7 @@ class ExportManager:
             try:
                 dpi = int(self.host.logicalDpiX())
             except (AttributeError, RuntimeError, TypeError, ValueError):
-                pass
+                logging.debug("Suppressed non-critical error", exc_info=True)
             generator.setResolution(dpi)
 
             # 4. Render

--- a/moleditpy/src/moleditpy/ui/export_logic.py
+++ b/moleditpy/src/moleditpy/ui/export_logic.py
@@ -519,7 +519,9 @@ class ExportManager:
                         except (AttributeError, RuntimeError, TypeError):
                             # Use default color on failure to avoid console noise during complex mesh export
                             # Safe defensive fallback catching AttributeError, RuntimeError, TypeError
-                            logging.debug("Suppressed non-critical error", exc_info=True)
+                            logging.debug(
+                                "Suppressed non-critical error", exc_info=True
+                            )
 
                         # Create mesh copy
                         mesh_copy = mesh.copy()
@@ -565,7 +567,9 @@ class ExportManager:
                                     ValueError,
                                     TypeError,
                                 ):  # [PYVISTA] Mesh color extraction may fail on headless/incomplete meshes; fall through to default.
-                                    logging.debug("Suppressed non-critical error", exc_info=True)
+                                    logging.debug(
+                                        "Suppressed non-critical error", exc_info=True
+                                    )
                             if colors is not None and colors.size > 0:
                                 # Normalize float colors to 0-255
                                 colors_arr = np.asarray(colors)
@@ -659,7 +663,9 @@ class ExportManager:
                         except (AttributeError, RuntimeError, ValueError, TypeError):
                             # Fallback: add single mesh on failure
                             # Safe defensive fallback catching AttributeError, RuntimeError, ValueError, TypeError
-                            logging.debug("Suppressed non-critical error", exc_info=True)
+                            logging.debug(
+                                "Suppressed non-critical error", exc_info=True
+                            )
 
                         meshes_with_colors.append(
                             {

--- a/moleditpy/src/moleditpy/ui/geometry_base_dialog.py
+++ b/moleditpy/src/moleditpy/ui/geometry_base_dialog.py
@@ -10,6 +10,7 @@ Repo: https://github.com/HiroYokoyama/python_molecular_editor
 DOI: 10.5281/zenodo.17268532
 """
 
+import logging
 from typing import TYPE_CHECKING, Optional, Union
 
 from PyQt6.QtWidgets import QLineEdit, QSlider, QWidget
@@ -55,7 +56,7 @@ class GeometryBaseDialog(BasePickingDialog):
             slider.blockSignals(False)
         except (ValueError, TypeError):
             # Safe defensive fallback catching ValueError, TypeError
-            pass
+            logging.debug("Suppressed non-critical error", exc_info=True)
 
     def on_slider_pressed(self) -> None:
         """Prepare for a slider drag operation by saving a geometry snapshot."""

--- a/moleditpy/src/moleditpy/ui/io_logic.py
+++ b/moleditpy/src/moleditpy/ui/io_logic.py
@@ -169,16 +169,13 @@ class IOManager:
 
         def _process(charge_val: int, use_rd_determine: bool = True) -> Any:
             if use_rd_determine:
-                try:
-                    from rdkit.Chem import rdDetermineBonds
+                from rdkit.Chem import rdDetermineBonds
 
-                    mol_copy = Chem.RWMol(mol)
-                    rdDetermineBonds.DetermineBonds(mol_copy, charge=charge_val)
-                    candidate = mol_copy.GetMol()
-                    _set_prop(candidate, "_xyz_charge", charge_val)
-                    return candidate
-                except (RuntimeError, ValueError, TypeError):
-                    raise
+                mol_copy = Chem.RWMol(mol)
+                rdDetermineBonds.DetermineBonds(mol_copy, charge=charge_val)
+                candidate = mol_copy.GetMol()
+                _set_prop(candidate, "_xyz_charge", charge_val)
+                return candidate
             else:
                 self.estimate_bonds_from_distances(mol)
                 candidate = mol.GetMol()
@@ -386,6 +383,7 @@ class IOManager:
 
                 self.host.set_has_unsaved_changes(False)
                 self.host.state_manager.update_window_title()
+                self.host.save_state_snapshot()
                 self.host.update_status_message(
                     f"Project saved to {self.host.get_current_file_path()}"
                 )
@@ -887,6 +885,8 @@ class IOManager:
             "MOL Files (*.mol);;All Files (*)",
         )
         if file_path:
+            if not file_path.lower().endswith(".mol"):
+                file_path += ".mol"
             try:
                 mol_block = Chem.MolToMolBlock(
                     self.host.view_3d_manager.current_mol, includeStereo=True

--- a/moleditpy/src/moleditpy/ui/io_logic.py
+++ b/moleditpy/src/moleditpy/ui/io_logic.py
@@ -16,6 +16,7 @@ import logging
 import os
 import json
 import pickle
+from ..utils.suppress_log import suppress_log
 from typing import Any, Optional, Tuple
 
 from PyQt6.QtCore import QPointF, QTimer
@@ -54,7 +55,7 @@ class IOManager:
                     return str(name)
         except (AttributeError, RuntimeError, ValueError, TypeError):
             # Safe defensive fallback catching AttributeError, RuntimeError, ValueError, TypeError
-            pass
+            logging.debug("Suppressed non-critical error", exc_info=True)
         return "untitled"
 
     def _get_default_path(self, suffix: str = "") -> str:
@@ -66,7 +67,7 @@ class IOManager:
                 return os.path.join(os.path.dirname(cur_path), basename)
         except (AttributeError, RuntimeError, ValueError, TypeError):
             # Safe defensive fallback catching AttributeError, RuntimeError, ValueError, TypeError
-            pass
+            logging.debug("Suppressed non-critical error", exc_info=True)
         return basename
 
     def _plotter_view_isometric(self) -> None:
@@ -177,7 +178,7 @@ class IOManager:
                     m.SetDoubleProp(key, val)
             except (RuntimeError, TypeError, ValueError):
                 # Safe defensive fallback catching RuntimeError, TypeError, ValueError
-                pass
+                logging.debug("Suppressed non-critical error", exc_info=True)
 
         def _process(charge_val: int, use_rd_determine: bool = True) -> Any:
             if use_rd_determine:
@@ -381,7 +382,7 @@ class IOManager:
                             bonds_added.append((i, j, distance))
                         except (RuntimeError, ValueError, TypeError):
                             # Safe defensive fallback catching RuntimeError, ValueError, TypeError
-                            pass
+                            logging.debug("Suppressed non-critical error", exc_info=True)
 
         return len(bonds_added)
 
@@ -812,10 +813,9 @@ class IOManager:
             self.host.set_atom_id_to_rdkit_idx_map({})
 
             # Determine is_xyz_derived: True only when bond estimation was skipped
-            import contextlib
 
             skip_flag = False
-            with contextlib.suppress(AttributeError, KeyError, RuntimeError, TypeError):
+            with suppress_log(AttributeError, KeyError, RuntimeError, TypeError):
                 if mol.HasProp("_xyz_skip_checks"):
                     skip_flag = bool(mol.GetIntProp("_xyz_skip_checks"))
             self.host.is_xyz_derived = skip_flag or (mol.GetNumBonds() == 0)
@@ -1048,7 +1048,7 @@ class IOManager:
             else:
                 mol.SetProp(prop_name, str(value))
         except (RuntimeError, ValueError, AttributeError, TypeError):
-            pass
+            logging.debug("Suppressed non-critical error", exc_info=True)
 
     def _get_mol_prop(self, mol: Chem.Mol, prop_name: str, default: Any = None) -> Any:
         """Get an RDKit molecule property safely, trying int/float/str in order."""
@@ -1067,9 +1067,8 @@ class IOManager:
 
 def _set_mol_prop_safe(mol: Chem.Mol, key: str, val: Any) -> None:
     """Module-level helper: set an int or float property on an RDKit mol silently."""
-    import contextlib
 
-    with contextlib.suppress(RuntimeError, TypeError, ValueError, AttributeError):
+    with suppress_log(RuntimeError, TypeError, ValueError, AttributeError):
         if isinstance(val, int):
             mol.SetIntProp(key, val)
         elif isinstance(val, float):

--- a/moleditpy/src/moleditpy/ui/io_logic.py
+++ b/moleditpy/src/moleditpy/ui/io_logic.py
@@ -292,6 +292,9 @@ class IOManager:
         layout = QVBoxLayout(dialog)
         line_edit = QLineEdit(dialog)
         line_edit.setText("0")
+        error_label = QLabel("", dialog)
+        error_label.setStyleSheet("color: red;")
+        error_label.setVisible(False)
         btn_box = QDialogButtonBox(
             QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel,
             parent=dialog,
@@ -302,9 +305,24 @@ class IOManager:
         hl.addWidget(skip_btn)
         layout.addWidget(QLabel("Enter total molecular charge:"))
         layout.addWidget(line_edit)
+        layout.addWidget(error_label)
         layout.addLayout(hl)
         result = {"accepted": False, "skip": False}
-        btn_box.accepted.connect(dialog.accept)
+
+        def _accept_if_valid() -> None:
+            # Validate inline: keep the dialog open and show the error in place
+            # instead of silently falling back to charge 0.
+            try:
+                int(float(line_edit.text().strip() or "0"))
+            except ValueError:
+                error_label.setText("Invalid charge: enter an integer (e.g. 0, -1, 2).")
+                error_label.setVisible(True)
+                line_edit.selectAll()
+                line_edit.setFocus()
+                return
+            dialog.accept()
+
+        btn_box.accepted.connect(_accept_if_valid)
         btn_box.rejected.connect(dialog.reject)
         skip_btn.clicked.connect(
             lambda: (result.update({"skip": True}), dialog.accept())  # type: ignore[func-returns-value]
@@ -317,6 +335,7 @@ class IOManager:
             val = int(float(line_edit.text().strip() or "0"))
             return val, True, False
         except ValueError:
+            # Unreachable via OK (validated inline); safe default for Skip path
             return 0, True, False
 
     def estimate_bonds_from_distances(self, mol: Chem.RWMol) -> int:
@@ -438,10 +457,12 @@ class IOManager:
         self.open_project_file()
 
     def open_project_file(self, file_path: Optional[str] = None) -> None:
-        """Open project file (.pmeprj or .pmeraw)."""
-        if not self.host.state_manager.check_unsaved_changes():
-            return None
+        """Open project file (.pmeprj or .pmeraw).
 
+        The unsaved-changes check happens in load_json_data / load_raw_data
+        so that direct calls to those methods (e.g. from plugins) are also
+        protected without double-prompting.
+        """
         if not file_path:
             default_dir = (
                 os.path.dirname(self.host.init_manager.current_file_path)
@@ -505,6 +526,9 @@ class IOManager:
 
     def load_json_data(self, file_path: Optional[str] = None) -> None:
         """Load PME Project (.pmeprj) file."""
+        if not self.host.state_manager.check_unsaved_changes():
+            return
+
         if not file_path:
             default_dir = (
                 os.path.dirname(self.host.init_manager.current_file_path)
@@ -967,6 +991,9 @@ class IOManager:
 
     def load_raw_data(self, file_path: Optional[str] = None) -> None:
         """Open a .pmeraw pickle project file."""
+        if not self.host.state_manager.check_unsaved_changes():
+            return
+
         if not file_path:
             default_dir = (
                 os.path.dirname(self.host.init_manager.current_file_path)

--- a/moleditpy/src/moleditpy/ui/io_logic.py
+++ b/moleditpy/src/moleditpy/ui/io_logic.py
@@ -69,6 +69,19 @@ class IOManager:
             pass
         return basename
 
+
+    def _plotter_view_isometric(self) -> None:
+        """Deferred camera reset; the plotter may be gone by the time it fires."""
+        plotter = self.host.view_3d_manager.plotter
+        if plotter:
+            plotter.view_isometric()
+
+    def _plotter_render(self) -> None:
+        """Deferred render; the plotter may be gone by the time it fires."""
+        plotter = self.host.view_3d_manager.plotter
+        if plotter:
+            plotter.render()
+
     def fix_mol_counts_line(self, line: str) -> str:
         """Ensure the MOL file counts line ends with a valid V2000 tag."""
         if "V3000" in line or "V2000" in line:
@@ -577,10 +590,8 @@ class IOManager:
             self.host.statusBar().showMessage(f"PME Project loaded from {file_path}")
 
             # Reset camera/zoom after drawing
-            QTimer.singleShot(
-                50, lambda: self.host.view_3d_manager.plotter.view_isometric()
-            )
-            QTimer.singleShot(100, lambda: self.host.view_3d_manager.plotter.render())
+            QTimer.singleShot(50, self._plotter_view_isometric)
+            QTimer.singleShot(100, self._plotter_render)
             QTimer.singleShot(100, self.host.view_3d_manager.fit_to_view)
 
         except FileNotFoundError:
@@ -817,10 +828,8 @@ class IOManager:
             self.host.view_3d_manager.draw_molecule_3d(mol)
 
             # Reset camera/zoom after drawing
-            QTimer.singleShot(
-                50, lambda: self.host.view_3d_manager.plotter.view_isometric()
-            )
-            QTimer.singleShot(100, lambda: self.host.view_3d_manager.plotter.render())
+            QTimer.singleShot(50, self._plotter_view_isometric)
+            QTimer.singleShot(100, self._plotter_render)
 
             self.host.ui_manager.enter_3d_viewer_mode()
 
@@ -880,10 +889,8 @@ class IOManager:
             self.host.view_3d_manager.draw_molecule_3d(mol)
 
             # Reset camera/zoom after drawing
-            QTimer.singleShot(
-                50, lambda: self.host.view_3d_manager.plotter.view_isometric()
-            )
-            QTimer.singleShot(100, lambda: self.host.view_3d_manager.plotter.render())
+            QTimer.singleShot(50, self._plotter_view_isometric)
+            QTimer.singleShot(100, self._plotter_render)
 
             self.host.ui_manager.enter_3d_viewer_mode()
             self.host.ui_manager.enable_3d_features(True)
@@ -1024,10 +1031,8 @@ class IOManager:
             self.host.statusBar().showMessage(f"Project loaded from {file_path}")
 
             # Reset camera/zoom after drawing
-            QTimer.singleShot(
-                50, lambda: self.host.view_3d_manager.plotter.view_isometric()
-            )
-            QTimer.singleShot(100, lambda: self.host.view_3d_manager.plotter.render())
+            QTimer.singleShot(50, self._plotter_view_isometric)
+            QTimer.singleShot(100, self._plotter_render)
 
         except FileNotFoundError:
             self.host.statusBar().showMessage(f"File not found: {file_path}")

--- a/moleditpy/src/moleditpy/ui/io_logic.py
+++ b/moleditpy/src/moleditpy/ui/io_logic.py
@@ -71,13 +71,13 @@ class IOManager:
 
 
     def _plotter_view_isometric(self) -> None:
-        """Deferred camera reset; the plotter may be gone by the time it fires."""
+        """Deferred camera reset (plotter may be gone when this fires)."""
         plotter = self.host.view_3d_manager.plotter
         if plotter:
             plotter.view_isometric()
 
     def _plotter_render(self) -> None:
-        """Deferred render; the plotter may be gone by the time it fires."""
+        """Deferred render (plotter may be gone when this fires)."""
         plotter = self.host.view_3d_manager.plotter
         if plotter:
             plotter.render()
@@ -323,8 +323,7 @@ class IOManager:
         result = {"accepted": False, "skip": False}
 
         def _accept_if_valid() -> None:
-            # Validate inline: keep the dialog open and show the error in place
-            # instead of silently falling back to charge 0.
+            # Invalid input: show inline error and keep the dialog open
             try:
                 int(float(line_edit.text().strip() or "0"))
             except ValueError:
@@ -348,7 +347,7 @@ class IOManager:
             val = int(float(line_edit.text().strip() or "0"))
             return val, True, False
         except ValueError:
-            # Unreachable via OK (validated inline); safe default for Skip path
+            # Unreachable via OK (validated inline)
             return 0, True, False
 
     def estimate_bonds_from_distances(self, mol: Chem.RWMol) -> int:
@@ -472,10 +471,7 @@ class IOManager:
     def open_project_file(self, file_path: Optional[str] = None) -> None:
         """Open project file (.pmeprj or .pmeraw).
 
-        The unsaved-changes check happens in load_json_data / load_raw_data
-        so that direct calls to those methods (e.g. from plugins) are also
-        protected without double-prompting.
-        """
+        Unsaved-changes check is done in load_json_data / load_raw_data."""
         if not file_path:
             default_dir = (
                 os.path.dirname(self.host.init_manager.current_file_path)

--- a/moleditpy/src/moleditpy/ui/io_logic.py
+++ b/moleditpy/src/moleditpy/ui/io_logic.py
@@ -69,7 +69,6 @@ class IOManager:
             pass
         return basename
 
-
     def _plotter_view_isometric(self) -> None:
         """Deferred camera reset (plotter may be gone when this fires)."""
         plotter = self.host.view_3d_manager.plotter

--- a/moleditpy/src/moleditpy/ui/io_logic.py
+++ b/moleditpy/src/moleditpy/ui/io_logic.py
@@ -307,7 +307,6 @@ class IOManager:
         line_edit.setText("0")
         error_label = QLabel("", dialog)
         error_label.setStyleSheet("color: red;")
-        error_label.setVisible(False)
         btn_box = QDialogButtonBox(
             QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel,
             parent=dialog,
@@ -328,7 +327,7 @@ class IOManager:
                 int(float(line_edit.text().strip() or "0"))
             except ValueError:
                 error_label.setText("Invalid charge: enter an integer (e.g. 0, -1, 2).")
-                error_label.setVisible(True)
+                dialog.adjustSize()
                 line_edit.selectAll()
                 line_edit.setFocus()
                 return
@@ -382,7 +381,9 @@ class IOManager:
                             bonds_added.append((i, j, distance))
                         except (RuntimeError, ValueError, TypeError):
                             # Safe defensive fallback catching RuntimeError, ValueError, TypeError
-                            logging.debug("Suppressed non-critical error", exc_info=True)
+                            logging.debug(
+                                "Suppressed non-critical error", exc_info=True
+                            )
 
         return len(bonds_added)
 

--- a/moleditpy/src/moleditpy/ui/main_window.py
+++ b/moleditpy/src/moleditpy/ui/main_window.py
@@ -229,7 +229,7 @@ class MainWindow(QMainWindow):
     def update_status_message(self, message: str, timeout: int = 0) -> None:
         """Show a message in the main window's status bar."""
         if self.statusBar():
-            self.statusBar().showMessage(message, timeout)
+            self.statusBar().showMessage(message, timeout)  # type: ignore[union-attr]
 
     def warning_message_box(self, title: str, message: str) -> None:
         """Show a modal warning dialog."""

--- a/moleditpy/src/moleditpy/ui/main_window.py
+++ b/moleditpy/src/moleditpy/ui/main_window.py
@@ -305,8 +305,8 @@ class MainWindow(QMainWindow):
         return self.state_manager.data  # type: ignore[return-value, no-any-return]
 
     @property
-    def scene(self) -> Optional[MoleculeScene]:
-        """Proxy for 2D scene (read)."""
+    def scene(self) -> Any:
+        """Proxy for 2D scene (read). A MoleculeScene once init completes."""
         return self.init_manager.scene
 
     @property

--- a/moleditpy/src/moleditpy/ui/main_window.py
+++ b/moleditpy/src/moleditpy/ui/main_window.py
@@ -35,7 +35,6 @@ from .main_window_init import MainInitManager
 from .string_importers import StringImporterManager
 from .ui_manager import UIManager
 from .view_3d_logic import View3DManager
-from .molecule_scene import MoleculeScene
 from ..core.molecular_data import MolecularData
 from .custom_qt_interactor import CustomQtInteractor
 

--- a/moleditpy/src/moleditpy/ui/main_window.py
+++ b/moleditpy/src/moleditpy/ui/main_window.py
@@ -251,7 +251,8 @@ class MainWindow(QMainWindow):
 
     def set_atom_id_to_rdkit_idx_map(self, mapping: Dict[int, int]) -> None:
         """Set 2D-to-3D atom ID mapping."""
-        self.view_3d_manager.atom_id_to_rdkit_idx_map = mapping
+        # Must live on MainWindow: compute_logic writes it, edit_3d_logic reads it
+        self.atom_id_to_rdkit_idx_map = mapping
 
     def save_state_snapshot(self) -> None:
         """Create a deep copy snapshot of the current state for undo/redo comparison."""

--- a/moleditpy/src/moleditpy/ui/main_window_init.py
+++ b/moleditpy/src/moleditpy/ui/main_window_init.py
@@ -193,10 +193,10 @@ class MainInitManager:
             logging.error(f"RDKit warm-up failed: {e}")
 
         self.host.state_manager.reset_undo_stack()
-        self.scene.selectionChanged.connect(
+        self.scene.selectionChanged.connect(  # type: ignore[attr-defined]
             self.host.edit_actions_manager.update_edit_menu_actions
         )
-        QApplication.clipboard().dataChanged.connect(
+        QApplication.clipboard().dataChanged.connect(  # type: ignore[union-attr]
             self.host.edit_actions_manager.update_edit_menu_actions
         )
 
@@ -220,7 +220,7 @@ class MainInitManager:
         # when opening a file or starting the application. This avoids
         # accidental focus landing on toolbar/buttons (e.g. Optimize 2D).
         try:
-            QTimer.singleShot(0, self.view_2d.setFocus)
+            QTimer.singleShot(0, self.view_2d.setFocus)  # type: ignore[attr-defined]
         except (AttributeError, RuntimeError, ValueError, TypeError) as e:
             logging.debug(
                 f"Suppressed exception: {e}"
@@ -240,7 +240,7 @@ class MainInitManager:
 
             # Set the icon for both the window and the application
             self.host.setWindowIcon(app_icon)
-            QApplication.instance().setWindowIcon(app_icon)
+            QApplication.instance().setWindowIcon(app_icon)  # type: ignore[union-attr]
         else:
             logging.warning(f"Warning: Icon file not found: {icon_path}")
 
@@ -455,8 +455,7 @@ class MainInitManager:
         # 1. Refresh related dialogs if open
         for w in QApplication.topLevelWidgets():
             with contextlib.suppress(AttributeError, RuntimeError, TypeError):
-                if isinstance(w, ColorSettingsDialog):
-                    w.refresh_ui()
+                # ColorSettingsDialog has no refresh method; reopening reflects the reset
                 if isinstance(w, SettingsDialog):
                     w.update_ui_from_settings(self.settings)
 
@@ -649,8 +648,8 @@ class MainInitManager:
                 plugin_menu.removeAction(action)
 
         # 2. Clear plugin-specific toolbars or buttons
-        self.plugin_toolbar.clear()
-        self.plugin_toolbar.hide()
+        self.plugin_toolbar.clear()  # type: ignore[union-attr]
+        self.plugin_toolbar.hide()  # type: ignore[union-attr]
 
     def _init_left_panel(self, left_layout: Any) -> None:
         """Initialize the left panel (2D view and buttons)."""
@@ -841,7 +840,7 @@ class MainInitManager:
                     lambda c, m=mode: self.host.ui_manager.set_mode(m)
                 )
                 self.mode_actions[mode] = action
-                self.tool_group.addAction(action)
+                self.tool_group.addAction(action)  # type: ignore[union-attr]
             toolbar.addAction(action)
         toolbar.addSeparator()
 
@@ -866,7 +865,7 @@ class MainInitManager:
             )
             self.mode_actions[mode] = action
             toolbar.addAction(action)
-            self.tool_group.addAction(action)
+            self.tool_group.addAction(action)  # type: ignore[union-attr]
         toolbar.addSeparator()
 
     def _add_charge_radical_actions(self, toolbar: QToolBar) -> None:
@@ -884,7 +883,7 @@ class MainInitManager:
             action.triggered.connect(lambda c, m=mode: self.host.ui_manager.set_mode(m))
             self.mode_actions[mode] = action
             toolbar.addAction(action)
-            self.tool_group.addAction(action)
+            self.tool_group.addAction(action)  # type: ignore[union-attr]
 
     def _add_template_actions(self, toolbar_bottom: QToolBar) -> None:
         """Add structural template actions (rings, etc.) to the bottom toolbar."""
@@ -904,7 +903,7 @@ class MainInitManager:
             action.triggered.connect(lambda c, m=mode: self.host.ui_manager.set_mode(m))
             self.mode_actions[mode] = action
             toolbar_bottom.addAction(action)
-            self.tool_group.addAction(action)
+            self.tool_group.addAction(action)  # type: ignore[union-attr]
 
         user_action = QAction("USER", self.host)
         user_action.setCheckable(True)
@@ -914,7 +913,7 @@ class MainInitManager:
         )
         self.mode_actions["template_user"] = user_action
         toolbar_bottom.addAction(user_action)
-        self.tool_group.addAction(user_action)
+        self.tool_group.addAction(user_action)  # type: ignore[union-attr]
 
     def _add_3d_edit_actions(self, toolbar: QToolBar) -> None:
         """Add 3D-specific selection and manipulation actions."""

--- a/moleditpy/src/moleditpy/ui/main_window_init.py
+++ b/moleditpy/src/moleditpy/ui/main_window_init.py
@@ -154,26 +154,26 @@ class MainInitManager:
         self.plugin_menubar_separator_added = False
         self.plugin_menu_manager = PluginMenuManager(self)
         self.active_worker_ids = set()
-        self.analysis_action = None
-        self.atom_index_base_0_action = None
-        self.atom_index_base_1_action = None
-        self.atom_index_base_menu = None
+        self.analysis_action: Any = None
+        self.atom_index_base_0_action: Any = None
+        self.atom_index_base_1_action: Any = None
+        self.atom_index_base_menu: Any = None
         self.conv_actions = None
-        self.edit_3d_action = None
+        self.edit_3d_action: Any = None
         self.halt_ids = set()
-        self.measurement_action = None
+        self.measurement_action: Any = None
         self.next_conversion_id = 1
-        self.opt3d_actions = None
+        self.opt3d_actions: Any = None
         self.opt3d_method_labels: dict = {}
-        self.paste_action = None
-        self.plugin_menu = None
-        self.show_atom_coords_action = None
-        self.show_atom_symbol_action = None
-        self.show_index_action = None
-        self.show_original_id_action = None
-        self.show_xyz_index_action = None
-        self.toggle_chiral_action = None
-        self.view_2d = None
+        self.paste_action: Any = None
+        self.plugin_menu: Any = None
+        self.show_atom_coords_action: Any = None
+        self.show_atom_symbol_action: Any = None
+        self.show_index_action: Any = None
+        self.show_original_id_action: Any = None
+        self.show_xyz_index_action: Any = None
+        self.toggle_chiral_action: Any = None
+        self.view_2d: Any = None
         self.init_ui()
         self.init_worker_thread()
         self.host.ui_manager.setup_3d_picker()

--- a/moleditpy/src/moleditpy/ui/main_window_init.py
+++ b/moleditpy/src/moleditpy/ui/main_window_init.py
@@ -65,7 +65,6 @@ except ImportError:
     winreg = None  # type: ignore[assignment]
 
 
-from .color_settings_dialog import ColorSettingsDialog
 from ..utils.constants import DEFAULT_CPK_COLORS, NUM_DASHES, VERSION
 from .custom_qt_interactor import CustomQtInteractor
 from ..core.molecular_data import MolecularData

--- a/moleditpy/src/moleditpy/ui/main_window_init.py
+++ b/moleditpy/src/moleditpy/ui/main_window_init.py
@@ -13,7 +13,7 @@ DOI: 10.5281/zenodo.17268532
 from __future__ import annotations
 
 import logging
-import contextlib
+from ..utils.suppress_log import suppress_log
 import json
 import math
 import os
@@ -303,13 +303,11 @@ class MainInitManager:
                     self.current_file_path = file_path
                     self.host.state_manager.update_window_title()
                     return  # Success
-                except (RuntimeError, TypeError, ValueError, AttributeError) as e:
-                    logging.warning(
-                        "Plugin opener failed for '%s': %s",
+                except Exception:  # plugins have full app access; any failure falls through to the next opener
+                    logging.exception(
+                        "Plugin opener failed for '%s'",
                         opener_info.get("plugin", "Unknown"),
-                        e,
                     )
-                    # If this opener fails, try the next one or fall through to default
                     continue
 
         if file_ext in ["mol", "sdf"]:
@@ -453,7 +451,7 @@ class MainInitManager:
         """Update all UI components to reflect the reset settings."""
         # 1. Refresh related dialogs if open
         for w in QApplication.topLevelWidgets():
-            with contextlib.suppress(AttributeError, RuntimeError, TypeError):
+            with suppress_log(AttributeError, RuntimeError, TypeError):
                 # ColorSettingsDialog has no refresh method; reopening reflects the reset
                 if isinstance(w, SettingsDialog):
                     w.update_ui_from_settings(self.settings)
@@ -475,7 +473,7 @@ class MainInitManager:
 
     def _sync_settings_to_menu_actions(self) -> None:
         """Synchronize menu action checked states with current settings."""
-        with contextlib.suppress(AttributeError, RuntimeError, TypeError):
+        with suppress_log(AttributeError, RuntimeError, TypeError):
             # Optimization actions
             if hasattr(self, "opt3d_actions"):
                 current_method = (
@@ -516,7 +514,7 @@ class MainInitManager:
                 bg_c = self.settings.get("background_color_2d", "#FFFFFF")
                 self.scene.setBackgroundBrush(QBrush(QColor(bg_c)))
                 for item in self.scene.items():
-                    with contextlib.suppress(AttributeError, RuntimeError, TypeError):
+                    with suppress_log(AttributeError, RuntimeError, TypeError):
                         if type(item).__name__ not in ("AtomItem", "BondItem"):
                             continue
                         if hasattr(item, "update_style"):
@@ -546,7 +544,7 @@ class MainInitManager:
         except (AttributeError, RuntimeError, ValueError, TypeError, IOError):
             # Use defaults on any error
             # Safe defensive fallback catching AttributeError, RuntimeError, ValueError, TypeError, IOError
-            pass
+            logging.debug("Suppressed non-critical error", exc_info=True)
 
         # 4.5 Save initial settings copy for change detection
         self.host.initial_settings = self.settings.copy()
@@ -773,13 +771,13 @@ class MainInitManager:
         self.host.addToolBar(self.toolbar)
 
         # Row 2: Templates
-        with contextlib.suppress(AttributeError):
+        with suppress_log(AttributeError):
             self.host.addToolBarBreak(Qt.ToolBarArea.TopToolBarArea)
         self.toolbar_bottom = QToolBar("Templates Toolbar")
         self.host.addToolBar(Qt.ToolBarArea.TopToolBarArea, self.toolbar_bottom)
 
         # Row 3: Plugins
-        with contextlib.suppress(AttributeError):
+        with suppress_log(AttributeError):
             self.host.addToolBarBreak(Qt.ToolBarArea.TopToolBarArea)
         self.plugin_toolbar = QToolBar("Plugin Toolbar")
         self.host.addToolBar(Qt.ToolBarArea.TopToolBarArea, self.plugin_toolbar)
@@ -1070,17 +1068,17 @@ class MainInitManager:
 
     def _get_icon_foreground_color(self) -> QColor:
         """Determine appropriate icon foreground color based on theme/settings."""
-        with contextlib.suppress(Exception):
+        with suppress_log(Exception):
             fg = self.settings.get("icon_foreground")
             if fg and QColor(fg).isValid():
                 return QColor(fg)
 
-        with contextlib.suppress(Exception):
+        with suppress_log(Exception):
             os_pref = detect_system_dark_mode()
             if os_pref is not None:
                 return QColor("#FFFFFF") if os_pref else QColor("#000000")
 
-        with contextlib.suppress(Exception):
+        with suppress_log(Exception):
             bg = QColor(self.settings.get("background_color", "#919191"))
             if bg.isValid():
                 lum = 0.2126 * bg.redF() + 0.7152 * bg.greenF() + 0.0722 * bg.blueF()

--- a/moleditpy/src/moleditpy/ui/main_window_init.py
+++ b/moleditpy/src/moleditpy/ui/main_window_init.py
@@ -83,7 +83,7 @@ class MainInitManager:
     ) -> None:
         self.host = host
         # Explicit declarations for Mypy
-        self.scene: Optional[MoleculeScene] = None
+        self.scene: Any = None  # MoleculeScene, created during init
         self.data: Optional[MolecularData] = None
         self.formula_label: Optional[QLabel] = None
         self.status_bar: Optional[Any] = None

--- a/moleditpy/src/moleditpy/ui/main_window_init.py
+++ b/moleditpy/src/moleditpy/ui/main_window_init.py
@@ -92,8 +92,8 @@ class MainInitManager:
         self.cut_action: Optional[QAction] = None
         self.copy_action: Optional[QAction] = None
         self.import_menu: Optional[QMenu] = None
-        self.toolbar: Optional[QToolBar] = None
-        self.toolbar_bottom: Optional[QToolBar] = None
+        self.toolbar: Any = None
+        self.toolbar_bottom: Any = None
         self.plugin_toolbar: Optional[QToolBar] = None
         self.tool_group: Optional[QActionGroup] = None
         self.other_atom_action: Optional[QAction] = None
@@ -383,14 +383,9 @@ class MainInitManager:
                         modules_to_update.append(mod)
 
             if not modules_to_update:
-                try:
-                    from . import constants as constants_mod
+                from ..utils import constants as constants_mod
 
-                    modules_to_update.append(constants_mod)
-                except ImportError:
-                    import moleditpy.utils.constants as constants_mod
-
-                    modules_to_update.append(constants_mod)
+                modules_to_update.append(constants_mod)
 
             for mod in modules_to_update:
                 mod.CPK_COLORS.clear()

--- a/moleditpy/src/moleditpy/ui/main_window_init.py
+++ b/moleditpy/src/moleditpy/ui/main_window_init.py
@@ -133,7 +133,7 @@ class MainInitManager:
         # Variable tracking the saved state
         self.host.set_has_unsaved_changes(False)
         self.settings_dirty = True
-        self.current_file_path = None
+        self.current_file_path: Optional[str] = None
         self.host.initialization_complete = False
         self.host.ih_update_counter = 0
 
@@ -153,14 +153,14 @@ class MainInitManager:
 
         self.plugin_menubar_separator_added = False
         self.plugin_menu_manager = PluginMenuManager(self)
-        self.active_worker_ids = set()
+        self.active_worker_ids: set[int] = set()
         self.analysis_action: Any = None
         self.atom_index_base_0_action: Any = None
         self.atom_index_base_1_action: Any = None
         self.atom_index_base_menu: Any = None
-        self.conv_actions = None
+        self.conv_actions: Any = None
         self.edit_3d_action: Any = None
-        self.halt_ids = set()
+        self.halt_ids: set[Any] = set()
         self.measurement_action: Any = None
         self.next_conversion_id = 1
         self.opt3d_actions: Any = None
@@ -272,9 +272,9 @@ class MainInitManager:
     def init_worker_thread(self) -> None:
         """Initialize shared state for managing background calculation workers."""
         # Initialize shared state for calculation runs.
-        self.halt_ids: set[Any] = set()
+        self.halt_ids = set()
         self.next_conversion_id = 1
-        self.active_worker_ids: set[int] = set()
+        self.active_worker_ids = set()
         self.host.reset_active_calc_threads()
 
     def load_command_line_file(self, file_path: str) -> None:

--- a/moleditpy/src/moleditpy/ui/mirror_dialog.py
+++ b/moleditpy/src/moleditpy/ui/mirror_dialog.py
@@ -93,7 +93,7 @@ class MirrorDialog(QDialog):
             return
 
         # Get the selected plane
-        plane_id = self.plane_group.checkedId()
+        plane_id = self.plane_group.checkedId()  # type: ignore[union-attr]
 
         try:
             conf = self.mol.GetConformer()

--- a/moleditpy/src/moleditpy/ui/molecular_scene_handler.py
+++ b/moleditpy/src/moleditpy/ui/molecular_scene_handler.py
@@ -469,7 +469,7 @@ class TemplateMixin:
                             used_indices.add(best_idx)
                     except (AttributeError, TypeError, IndexError):
                         # Safe defensive fallback catching AttributeError, TypeError, IndexError
-                        pass
+                        logging.debug("Suppressed non-critical error", exc_info=True)
 
                 # Map unmapped points to other unmapped nearby atoms in the scene
                 if (
@@ -1538,7 +1538,7 @@ class SceneQueryMixin:
                 # Suppress non-critical internal update counter increment errors.
                 # This counter is only used for UI throttling and is non-critical for data integrity.
                 # Safe defensive fallback catching AttributeError, RuntimeError, ValueError, TypeError
-                pass
+                logging.debug("Suppressed non-critical error", exc_info=True)
             # 4. Remove graphic items from the scene
             current_scene_items = set(self.items())
 

--- a/moleditpy/src/moleditpy/ui/molecular_scene_handler.py
+++ b/moleditpy/src/moleditpy/ui/molecular_scene_handler.py
@@ -35,7 +35,7 @@ class TemplateMixin:
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         self.template_context = {}
-        self.template_preview = None
+        self.template_preview: Any = None
         self.template_preview_points = []
         super().__init__(*args, **kwargs)
 

--- a/moleditpy/src/moleditpy/ui/molecular_scene_handler.py
+++ b/moleditpy/src/moleditpy/ui/molecular_scene_handler.py
@@ -33,10 +33,23 @@ class TemplateMixin:
     Because this is a Mixin, `self` refers directly to the MoleculeScene instance.
     """
 
+    # Provided by the composed MoleculeScene at runtime
+    atom_items: Any
+    create_atom: Any
+    create_bond: Any
+    data: Any
+    find_atom_near: Any
+    find_bond_between: Any
+    get_setting: Any
+    items: Any
+    mode: Any
+    removeItem: Any
+    views: Any
+
     def __init__(self, *args: Any, **kwargs: Any) -> None:
-        self.template_context = {}
+        self.template_context: Dict[str, Any] = {}
         self.template_preview: Any = None
-        self.template_preview_points = []
+        self.template_preview_points: List[Any] = []
         super().__init__(*args, **kwargs)
 
     def clear_template_preview(self) -> None:
@@ -55,7 +68,7 @@ class TemplateMixin:
                 except (RuntimeError, ValueError, TypeError) as e:
                     # Best-effort: ignore removal errors during teardown if underlying C++ object is already gone
                     logging.debug(f"Could not remove template preview item: {e}")
-        self.template_context: Dict[str, Any] = {}
+        self.template_context = {}
         self.template_preview.hide()
 
     def _calculate_6ring_rotation(
@@ -712,8 +725,34 @@ class KeyboardMixin:
     Because this is a Mixin, `self` refers directly to the MoleculeScene instance.
     """
 
+    # Provided by the composed MoleculeScene at runtime
+    _calculate_polygon_from_edge: Any
+    add_molecule_fragment: Any
+    atom_items: Any
+    clear: Any
+    create_atom: Any
+    create_bond: Any
+    data: Any
+    delete_items: Any
+    find_atom_near: Any
+    get_setting: Any
+    hovered_item: Any
+    key_to_bond_mode_map: Any
+    key_to_symbol_map: Any
+    key_to_symbol_map_shift: Any
+    mode: Any
+    reinitialize_items: Any
+    update_all_items: Any
+    update_bond_stereo: Any
+    views: Any
+    window: Any
+    itemAt: Any
+    selectedItems: Any
+    clearSelection: Any
+    removeItem: Any
+
     def __init__(self, *args: Any, **kwargs: Any) -> None:
-        self.initial_positions_in_event = {}
+        self.initial_positions_in_event: Dict[Any, QPointF] = {}
         self.placement_direction_clockwise = True
         self.start_atom = None
         self.start_pos = None
@@ -1244,7 +1283,7 @@ class KeyboardMixin:
                     self.temp_line = None
                     self.start_atom = None
                     self.start_pos = None
-                    self.initial_positions_in_event: Dict[Any, QPointF] = {}
+                    self.initial_positions_in_event = {}
                     event.accept()
                     return
 
@@ -1270,7 +1309,7 @@ class KeyboardMixin:
                     self.temp_line = None
                     self.start_atom = None
                     self.start_pos = None
-                    self.initial_positions_in_event: Dict[Any, QPointF] = {}
+                    self.initial_positions_in_event = {}
 
                     # Event handled
                     event.accept()
@@ -1341,8 +1380,20 @@ class SceneQueryMixin:
     Mixin class for spatial queries and basic item lifecycle.
     """
 
+    # Provided by the composed MoleculeScene at runtime
+    atom_items: Any
+    bond_items: Any
+    bond_order: Any
+    bond_stereo: Any
+    data: Any
+    items: Any
+    update_all_items: Any
+    window: Any
+    addItem: Any
+    removeItem: Any
+
     def __init__(self, *args: Any, **kwargs: Any) -> None:
-        self._deleted_items = []
+        self._deleted_items: List[Any] = []
         self._ih_update_counter = 0
         self.data_changed_in_event = False
         super().__init__(*args, **kwargs)
@@ -1510,7 +1561,7 @@ class SceneQueryMixin:
                             not hasattr(self, "_deleted_items")
                             or self._deleted_items is None
                         ):
-                            self._deleted_items: List[Any] = []
+                            self._deleted_items = []
                         self._deleted_items.append(item)
                     except (AttributeError, RuntimeError, ValueError, TypeError) as e:
                         logging.debug(

--- a/moleditpy/src/moleditpy/ui/molecule_scene.py
+++ b/moleditpy/src/moleditpy/ui/molecule_scene.py
@@ -49,7 +49,7 @@ class MoleculeScene(TemplateMixin, KeyboardMixin, SceneQueryMixin, QGraphicsScen
         self._deleted_items = []
         self.initial_positions_in_event = {}
         self.template_context = {}
-        self.template_preview = None
+        self.template_preview: Any = None
         self.template_preview_points = []
         self.was_selected_on_press = False
         self.mode: str = "select"

--- a/moleditpy/src/moleditpy/ui/molecule_scene.py
+++ b/moleditpy/src/moleditpy/ui/molecule_scene.py
@@ -187,15 +187,15 @@ class MoleculeScene(TemplateMixin, KeyboardMixin, SceneQueryMixin, QGraphicsScen
 
             # Update all bonds in this ring
             for bidx in b_ring:
-                bond_item = rdkit_bond_idx_to_item.get(bidx)
-                if bond_item:
-                    bond_item.is_in_ring = True
-                    item_id = id(bond_item)
+                ring_bond = rdkit_bond_idx_to_item.get(bidx)
+                if ring_bond:
+                    ring_bond.is_in_ring = True
+                    item_id = id(ring_bond)
                     if (
                         item_id not in bond_to_best_size
                         or ring_size < bond_to_best_size[item_id]
                     ):
-                        bond_item.ring_center = ring_center
+                        ring_bond.ring_center = ring_center
                         bond_to_best_size[item_id] = ring_size
 
     def update_all_items(self) -> None:

--- a/moleditpy/src/moleditpy/ui/molecule_scene.py
+++ b/moleditpy/src/moleditpy/ui/molecule_scene.py
@@ -316,7 +316,7 @@ class MoleculeScene(TemplateMixin, KeyboardMixin, SceneQueryMixin, QGraphicsScen
                 needs_update = True
         return needs_update
 
-    def mousePressEvent(self, event: QGraphicsSceneMouseEvent) -> None:
+    def mousePressEvent(self, event: QGraphicsSceneMouseEvent) -> None:  # type: ignore[override]
         """Handle mouse press to begin atom/bond creation or selection."""
         self.press_pos = event.scenePos()
         self.was_selected_on_press = False
@@ -341,9 +341,7 @@ class MoleculeScene(TemplateMixin, KeyboardMixin, SceneQueryMixin, QGraphicsScen
             return
 
         if event.button() == Qt.MouseButton.RightButton:
-            item: Optional[QGraphicsItem] = self.itemAt(
-                event.scenePos(), self.views()[0].transform()
-            )
+            item = self.itemAt(event.scenePos(), self.views()[0].transform())
             if not isinstance(item, (AtomItem, BondItem)):
                 return  # Do nothing if something other than the target is clicked
             data_changed = False
@@ -481,7 +479,7 @@ class MoleculeScene(TemplateMixin, KeyboardMixin, SceneQueryMixin, QGraphicsScen
         else:
             super().mousePressEvent(event)
 
-    def mouseMoveEvent(self, event: QGraphicsSceneMouseEvent) -> None:
+    def mouseMoveEvent(self, event: QGraphicsSceneMouseEvent) -> None:  # type: ignore[override]
         """Update the bond preview line or template ghost during mouse drag."""
         if not self.window.ui_manager.is_2d_editable:
             return
@@ -514,14 +512,14 @@ class MoleculeScene(TemplateMixin, KeyboardMixin, SceneQueryMixin, QGraphicsScen
             )
 
             if is_valid_snap_target:
-                end_point = target_atom.pos()
+                end_point = target_atom.pos()  # type: ignore[union-attr]
 
             self.temp_line.setLine(QLineF(start_point, end_point))
         else:
             # Even in template mode, hover events are propagated here
             super().mouseMoveEvent(event)
 
-    def mouseReleaseEvent(self, event: QGraphicsSceneMouseEvent) -> None:
+    def mouseReleaseEvent(self, event: QGraphicsSceneMouseEvent) -> None:  # type: ignore[override]
         """Finalize atom/bond creation or selection on mouse release."""
         if not self.window.ui_manager.is_2d_editable:
             return
@@ -820,7 +818,7 @@ class MoleculeScene(TemplateMixin, KeyboardMixin, SceneQueryMixin, QGraphicsScen
         # Clear template context but NOT the template data itself to allow multiple placements
         self.template_context = {}
 
-    def mouseDoubleClickEvent(self, event: QGraphicsSceneMouseEvent) -> None:
+    def mouseDoubleClickEvent(self, event: QGraphicsSceneMouseEvent) -> None:  # type: ignore[override]
         """Handle double click events."""
         item = self.itemAt(event.scenePos(), self.views()[0].transform())
 

--- a/moleditpy/src/moleditpy/ui/move_group_dialog.py
+++ b/moleditpy/src/moleditpy/ui/move_group_dialog.py
@@ -510,7 +510,7 @@ class MoveGroupDialog(BasePickingDialog):
                 plotter.camera_position = cam
             except (AttributeError, RuntimeError, TypeError):
                 # Safe defensive fallback catching AttributeError, RuntimeError, TypeError
-                pass
+                logging.debug("Suppressed non-critical error", exc_info=True)
 
         plotter.render()
 
@@ -526,7 +526,7 @@ class MoveGroupDialog(BasePickingDialog):
                 plotter.remove_actor("move_group_highlight")
             except (AttributeError, RuntimeError, ValueError, TypeError):
                 # Safe defensive fallback catching AttributeError, RuntimeError, ValueError, TypeError
-                pass
+                logging.debug("Suppressed non-critical error", exc_info=True)
 
         if self.highlight_actor:
             if plotter is not None:
@@ -534,7 +534,7 @@ class MoveGroupDialog(BasePickingDialog):
                     plotter.remove_actor(self.highlight_actor)
                 except (AttributeError, RuntimeError, ValueError, TypeError):
                     # Safe defensive fallback catching AttributeError, RuntimeError, ValueError, TypeError
-                    pass
+                    logging.debug("Suppressed non-critical error", exc_info=True)
             self.highlight_actor = None
 
         if plotter is not None:
@@ -542,7 +542,7 @@ class MoveGroupDialog(BasePickingDialog):
                 plotter.render()
             except (AttributeError, RuntimeError, ValueError, TypeError):
                 # Safe defensive fallback catching AttributeError, RuntimeError, ValueError, TypeError
-                pass
+                logging.debug("Suppressed non-critical error", exc_info=True)
 
     def reset_translation_inputs(self) -> None:
         """Reset all translation input fields to zero."""

--- a/moleditpy/src/moleditpy/ui/move_group_dialog.py
+++ b/moleditpy/src/moleditpy/ui/move_group_dialog.py
@@ -42,14 +42,14 @@ class MoveGroupDialog(BasePickingDialog):
         parent: Any = None,
     ) -> None:
         super().__init__(mol, main_window, parent)
-        self.clear_button = None
-        self.selection_label = None
-        self.x_rot_input = None
-        self.x_trans_input = None
-        self.y_rot_input = None
-        self.y_trans_input = None
-        self.z_rot_input = None
-        self.z_trans_input = None
+        self.clear_button: Any = None
+        self.selection_label: Any = None
+        self.x_rot_input: Any = None
+        self.x_trans_input: Any = None
+        self.y_rot_input: Any = None
+        self.y_trans_input: Any = None
+        self.z_rot_input: Any = None
+        self.z_trans_input: Any = None
         self.selected_atoms: set[int] = set()
         self.group_atoms: set[int] = set()  # All atoms connected to selected atoms
 

--- a/moleditpy/src/moleditpy/ui/move_group_dialog.py
+++ b/moleditpy/src/moleditpy/ui/move_group_dialog.py
@@ -28,7 +28,7 @@ from PyQt6.QtWidgets import (
 
 from .atom_picking import pick_atom_index_from_screen
 from .base_picking_dialog import BasePickingDialog
-from ..utils.constants import VDW_RADII
+from ..utils.constants import VDW_DISPLAY_RADII
 
 
 class MoveGroupDialog(BasePickingDialog):
@@ -481,7 +481,7 @@ class MoveGroupDialog(BasePickingDialog):
         ]
         selected_radii = np.array(
             [
-                VDW_RADII.get(self.mol.GetAtomWithIdx(i).GetSymbol(), 0.4) * 1.3
+                VDW_DISPLAY_RADII.get(self.mol.GetAtomWithIdx(i).GetSymbol(), 0.4) * 1.3
                 for i in selected_indices
             ]
         )

--- a/moleditpy/src/moleditpy/ui/move_selected_atoms_dialog.py
+++ b/moleditpy/src/moleditpy/ui/move_selected_atoms_dialog.py
@@ -10,7 +10,7 @@ Repo: https://github.com/HiroYokoyama/python_molecular_editor
 DOI: 10.5281/zenodo.17268532
 """
 
-from typing import Optional, Any
+from typing import Optional, Any, cast
 import logging
 import numpy as np
 import pyvista as pv
@@ -78,32 +78,32 @@ class MoveSelectedAtomsDialog(BasePickingDialog):
     @property
     def x_trans_input(self) -> QLineEdit:
         """Expose x_trans_input widget."""
-        return self.widgets["x_trans_input"]
+        return cast(QLineEdit, self.widgets["x_trans_input"])
 
     @property
     def y_trans_input(self) -> QLineEdit:
         """Expose y_trans_input widget."""
-        return self.widgets["y_trans_input"]
+        return cast(QLineEdit, self.widgets["y_trans_input"])
 
     @property
     def z_trans_input(self) -> QLineEdit:
         """Expose z_trans_input widget."""
-        return self.widgets["z_trans_input"]
+        return cast(QLineEdit, self.widgets["z_trans_input"])
 
     @property
     def x_rot_input(self) -> QLineEdit:
         """Expose x_rot_input widget."""
-        return self.widgets["x_rot_input"]
+        return cast(QLineEdit, self.widgets["x_rot_input"])
 
     @property
     def y_rot_input(self) -> QLineEdit:
         """Expose y_rot_input widget."""
-        return self.widgets["y_rot_input"]
+        return cast(QLineEdit, self.widgets["y_rot_input"])
 
     @property
     def z_rot_input(self) -> QLineEdit:
         """Expose z_rot_input widget."""
-        return self.widgets["z_rot_input"]
+        return cast(QLineEdit, self.widgets["z_rot_input"])
 
     def init_ui(self) -> None:
         """Initialize UI widgets and layout."""

--- a/moleditpy/src/moleditpy/ui/move_selected_atoms_dialog.py
+++ b/moleditpy/src/moleditpy/ui/move_selected_atoms_dialog.py
@@ -28,7 +28,7 @@ from PyQt6.QtWidgets import (
 
 from .atom_picking import pick_atom_index_from_screen
 from .base_picking_dialog import BasePickingDialog
-from ..utils.constants import VDW_RADII
+from ..utils.constants import VDW_DISPLAY_RADII
 
 
 class MoveSelectedAtomsDialog(BasePickingDialog):
@@ -509,7 +509,7 @@ class MoveSelectedAtomsDialog(BasePickingDialog):
         ]
         selected_radii = np.array(
             [
-                VDW_RADII.get(self.mol.GetAtomWithIdx(i).GetSymbol(), 0.4) * 1.3
+                VDW_DISPLAY_RADII.get(self.mol.GetAtomWithIdx(i).GetSymbol(), 0.4) * 1.3
                 for i in selected_indices
             ]
         )

--- a/moleditpy/src/moleditpy/ui/move_selected_atoms_dialog.py
+++ b/moleditpy/src/moleditpy/ui/move_selected_atoms_dialog.py
@@ -538,7 +538,7 @@ class MoveSelectedAtomsDialog(BasePickingDialog):
                 plotter.camera_position = cam
             except (AttributeError, RuntimeError, TypeError):
                 # Safe defensive fallback catching AttributeError, RuntimeError, TypeError
-                pass
+                logging.debug("Suppressed non-critical error", exc_info=True)
 
         plotter.render()
 
@@ -552,7 +552,7 @@ class MoveSelectedAtomsDialog(BasePickingDialog):
                 plotter.remove_actor("move_selected_atoms_highlight")
             except (AttributeError, RuntimeError, ValueError, TypeError):
                 # Safe defensive fallback catching AttributeError, RuntimeError, ValueError, TypeError
-                pass
+                logging.debug("Suppressed non-critical error", exc_info=True)
 
         if self.highlight_actor:
             if plotter is not None:
@@ -560,7 +560,7 @@ class MoveSelectedAtomsDialog(BasePickingDialog):
                     plotter.remove_actor(self.highlight_actor)
                 except (AttributeError, RuntimeError, ValueError, TypeError):
                     # Safe defensive fallback catching AttributeError, RuntimeError, ValueError, TypeError
-                    pass
+                    logging.debug("Suppressed non-critical error", exc_info=True)
             self.highlight_actor = None
 
         if plotter is not None:
@@ -568,7 +568,7 @@ class MoveSelectedAtomsDialog(BasePickingDialog):
                 plotter.render()
             except (AttributeError, RuntimeError, ValueError, TypeError):
                 # Safe defensive fallback catching AttributeError, RuntimeError, ValueError, TypeError
-                pass
+                logging.debug("Suppressed non-critical error", exc_info=True)
 
     def reset_translation_inputs(self) -> None:
         """Reset translation entry fields to 0.0."""

--- a/moleditpy/src/moleditpy/ui/periodic_table_dialog.py
+++ b/moleditpy/src/moleditpy/ui/periodic_table_dialog.py
@@ -196,5 +196,5 @@ class PeriodicTableDialog(QDialog):
     def on_button_clicked(self) -> None:
         """Emit element_selected with the button's symbol and accept the dialog."""
         b = self.sender()
-        self.element_selected.emit(b.text())
+        self.element_selected.emit(b.text())  # type: ignore[union-attr]
         self.accept()

--- a/moleditpy/src/moleditpy/ui/planarize_dialog.py
+++ b/moleditpy/src/moleditpy/ui/planarize_dialog.py
@@ -103,10 +103,12 @@ class PlanarizeDialog(BasePickingDialog):
         self.enable_picking()
 
     def on_atom_picked(self, atom_idx: int) -> None:
+        """Toggle atom selection and refresh 3D labels and the count display."""
         if atom_idx in self.selected_atoms:
             self.selected_atoms.remove(atom_idx)
         else:
             self.selected_atoms.add(atom_idx)
+        self.show_atom_labels()
         self.update_display()
 
     def clear_selection(self) -> None:

--- a/moleditpy/src/moleditpy/ui/planarize_dialog.py
+++ b/moleditpy/src/moleditpy/ui/planarize_dialog.py
@@ -12,7 +12,7 @@ DOI: 10.5281/zenodo.17268532
 
 import logging
 import numpy as np
-from typing import TYPE_CHECKING, Optional, Sequence
+from typing import Any, TYPE_CHECKING, Optional, Sequence
 
 from PyQt6.QtWidgets import (
     QHBoxLayout,
@@ -41,11 +41,11 @@ class PlanarizeDialog(BasePickingDialog):
         parent: Optional[QWidget] = None,
     ) -> None:
         super().__init__(mol, main_window, parent)
-        self.apply_button = None
-        self.clear_button = None
+        self.apply_button: Any = None
+        self.clear_button: Any = None
         self.picker_connection = None
-        self.select_all_button = None
-        self.selection_label = None
+        self.select_all_button: Any = None
+        self.selection_label: Any = None
         self.selected_atoms: set[int] = set()
 
         if preselected_atoms:

--- a/moleditpy/src/moleditpy/ui/plugin_menu_manager.py
+++ b/moleditpy/src/moleditpy/ui/plugin_menu_manager.py
@@ -188,9 +188,9 @@ class PluginMenuManager:
         if not hasattr(self._im, "plugin_toolbar"):
             return
 
-        self._im.plugin_toolbar.clear()
+        self._im.plugin_toolbar.clear()  # type: ignore[union-attr]
         if self._im.host.plugin_manager.toolbar_actions:
-            self._im.plugin_toolbar.show()
+            self._im.plugin_toolbar.show()  # type: ignore[union-attr]
             for action_def in self._im.host.plugin_manager.toolbar_actions:
                 action = QAction(action_def["text"], self._im.host)
                 action.triggered.connect(
@@ -202,9 +202,9 @@ class PluginMenuManager:
                     action.setIcon(QIcon(action_def["icon"]))
                 if action_def["tooltip"]:
                     action.setToolTip(action_def["tooltip"])
-                self._im.plugin_toolbar.addAction(action)
+                self._im.plugin_toolbar.addAction(action)  # type: ignore[union-attr]
         else:
-            self._im.plugin_toolbar.hide()
+            self._im.plugin_toolbar.hide()  # type: ignore[union-attr]
 
     # ------------------------------------------------------------------
     # Private helpers
@@ -459,5 +459,5 @@ class PluginMenuManager:
             if action.data() == "plugin_action":
                 plugin_menu.removeAction(action)
 
-        self._im.plugin_toolbar.clear()
-        self._im.plugin_toolbar.hide()
+        self._im.plugin_toolbar.clear()  # type: ignore[union-attr]
+        self._im.plugin_toolbar.hide()  # type: ignore[union-attr]

--- a/moleditpy/src/moleditpy/ui/plugin_menu_manager.py
+++ b/moleditpy/src/moleditpy/ui/plugin_menu_manager.py
@@ -52,7 +52,7 @@ class PluginMenuManager:
                         f"An error occurred in plugin '{plugin_name}':\n{exc}",
                     )
                 except Exception:
-                    pass
+                    logging.debug("Suppressed non-critical error", exc_info=True)
 
         return _safe
 

--- a/moleditpy/src/moleditpy/ui/settings_dialog.py
+++ b/moleditpy/src/moleditpy/ui/settings_dialog.py
@@ -41,7 +41,7 @@ class SettingsDialog(QDialog):
         self.tab_scene = None
         self.tab_stick = None
         self.tab_wf = None
-        self.tab_widget = None
+        self.tab_widget: Any = None
         self.setWindowTitle("Settings")
         self.setMinimumSize(650, 750)
         self.parent_window = parent

--- a/moleditpy/src/moleditpy/ui/settings_dialog.py
+++ b/moleditpy/src/moleditpy/ui/settings_dialog.py
@@ -34,13 +34,13 @@ class SettingsDialog(QDialog):
 
     def __init__(self, current_settings: Any, parent: Any = None) -> None:
         super().__init__(parent)
-        self.tab_2d = None
-        self.tab_bs = None
-        self.tab_cpk = None
-        self.tab_other = None
-        self.tab_scene = None
-        self.tab_stick = None
-        self.tab_wf = None
+        self.tab_2d: Any = None
+        self.tab_bs: Any = None
+        self.tab_cpk: Any = None
+        self.tab_other: Any = None
+        self.tab_scene: Any = None
+        self.tab_stick: Any = None
+        self.tab_wf: Any = None
         self.tab_widget: Any = None
         self.setWindowTitle("Settings")
         self.setMinimumSize(650, 750)

--- a/moleditpy/src/moleditpy/ui/settings_tabs/settings_2d_tab.py
+++ b/moleditpy/src/moleditpy/ui/settings_tabs/settings_2d_tab.py
@@ -35,15 +35,15 @@ class Settings2DTab(SettingsTabBase):
         self, default_settings: Mapping[str, Any], parent: Optional[QWidget] = None
     ) -> None:
         super().__init__(default_settings, parent)
-        self.atom_font_family_2d_combo = None
-        self.atom_font_bold_2d_btn = None
-        self.atom_font_italic_2d_btn = None
-        self.atom_font_underline_2d_btn = None
-        self.atom_use_bond_color_2d_checkbox = None
-        self.bg_color_2d_button = None
-        self.bond_cap_style_2d_combo = None
-        self.bond_color_2d_button = None
-        self.template_fusing_enabled_2d_checkbox = None
+        self.atom_font_family_2d_combo: Any = None
+        self.atom_font_bold_2d_btn: Any = None
+        self.atom_font_italic_2d_btn: Any = None
+        self.atom_font_underline_2d_btn: Any = None
+        self.atom_use_bond_color_2d_checkbox: Any = None
+        self.bg_color_2d_button: Any = None
+        self.bond_cap_style_2d_combo: Any = None
+        self.bond_color_2d_button: Any = None
+        self.template_fusing_enabled_2d_checkbox: Any = None
         self.current_bg_color_2d = default_settings["background_color_2d"]
         self.current_bond_color_2d = default_settings["bond_color_2d"]
         self._setup_ui()

--- a/moleditpy/src/moleditpy/ui/settings_tabs/settings_3d_tabs.py
+++ b/moleditpy/src/moleditpy/ui/settings_tabs/settings_3d_tabs.py
@@ -137,7 +137,7 @@ class SettingsModelTab(SettingsTabBase):
         self.info_text = info_text
         super().__init__(default_settings, parent)
         self.bond_color_button: Any = None
-        self.current_bond_color = None
+        self.current_bond_color: Any = None
         self.use_cpk_checkbox: Any = None
         self._setup_ui()
 

--- a/moleditpy/src/moleditpy/ui/settings_tabs/settings_3d_tabs.py
+++ b/moleditpy/src/moleditpy/ui/settings_tabs/settings_3d_tabs.py
@@ -33,10 +33,10 @@ class Settings3DSceneTab(SettingsTabBase):
         self, default_settings: Mapping[str, Any], parent: Optional[QWidget] = None
     ) -> None:
         super().__init__(default_settings, parent)
-        self.axes_checkbox = None
-        self.bg_button = None
-        self.light_checkbox = None
-        self.projection_combo = None
+        self.axes_checkbox: Any = None
+        self.bg_button: Any = None
+        self.light_checkbox: Any = None
+        self.projection_combo: Any = None
         self.current_bg_color = default_settings["background_color"]
         self._setup_ui()
 
@@ -136,9 +136,9 @@ class SettingsModelTab(SettingsTabBase):
         self.prefix = model_prefix
         self.info_text = info_text
         super().__init__(default_settings, parent)
-        self.bond_color_button = None
+        self.bond_color_button: Any = None
         self.current_bond_color = None
-        self.use_cpk_checkbox = None
+        self.use_cpk_checkbox: Any = None
         self._setup_ui()
 
     def _setup_ui(self) -> None:

--- a/moleditpy/src/moleditpy/ui/settings_tabs/settings_other_tab.py
+++ b/moleditpy/src/moleditpy/ui/settings_tabs/settings_other_tab.py
@@ -34,14 +34,14 @@ class SettingsOtherTab(SettingsTabBase):
         self, default_settings: Mapping[str, Any], parent: Optional[QWidget] = None
     ) -> None:
         super().__init__(default_settings, parent)
-        self.always_ask_charge_checkbox = None
-        self.aromatic_circle_checkbox = None
-        self.aromatic_torus_thickness_label = None
-        self.aromatic_torus_thickness_slider = None
-        self.kekule_3d_checkbox = None
-        self.skip_chem_checks_checkbox = None
-        self.log_to_file_checkbox = None
-        self.log_level_debug_checkbox = None
+        self.always_ask_charge_checkbox: Any = None
+        self.aromatic_circle_checkbox: Any = None
+        self.aromatic_torus_thickness_label: Any = None
+        self.aromatic_torus_thickness_slider: Any = None
+        self.kekule_3d_checkbox: Any = None
+        self.skip_chem_checks_checkbox: Any = None
+        self.log_to_file_checkbox: Any = None
+        self.log_level_debug_checkbox: Any = None
         self._setup_ui()
 
     def _setup_ui(self) -> None:

--- a/moleditpy/src/moleditpy/ui/settings_tabs/settings_tab_base.py
+++ b/moleditpy/src/moleditpy/ui/settings_tabs/settings_tab_base.py
@@ -77,24 +77,25 @@ class SettingsTabBase(QWidget):
             slider.valueChanged.connect(sync_spin)
             spin.valueChanged.connect(sync_slider)
         else:
-            spin = QDoubleSpinBox()
-            spin.setRange(min_val / scale, max_val / scale)
-            spin.setSingleStep(1.0 / scale)
-            spin.setDecimals(2)
-            spin.setValue(slider.value() / scale)
+            dspin = QDoubleSpinBox()
+            dspin.setRange(min_val / scale, max_val / scale)
+            dspin.setSingleStep(1.0 / scale)
+            dspin.setDecimals(2)
+            dspin.setValue(slider.value() / scale)
 
-            def sync_spin(val: int) -> None:
-                spin.blockSignals(True)
-                spin.setValue(val / scale)
-                spin.blockSignals(False)
+            def sync_dspin(val: int) -> None:
+                dspin.blockSignals(True)
+                dspin.setValue(val / scale)
+                dspin.blockSignals(False)
 
-            def sync_slider(val: float) -> None:
+            def sync_slider_f(val: float) -> None:
                 slider.blockSignals(True)
                 slider.setValue(int(round(val * scale)))
                 slider.blockSignals(False)
 
-            slider.valueChanged.connect(sync_spin)
-            spin.valueChanged.connect(sync_slider)
+            slider.valueChanged.connect(sync_dspin)
+            dspin.valueChanged.connect(sync_slider_f)
+            return slider, dspin
 
         return slider, spin
 

--- a/moleditpy/src/moleditpy/ui/translation_dialog.py
+++ b/moleditpy/src/moleditpy/ui/translation_dialog.py
@@ -46,17 +46,17 @@ class TranslationDialog(BasePickingDialog):
         self.selected_atoms = set()
 
         # Predefine widgets to satisfy pylint W0201
-        self.abs_selection_label = None
-        self.abs_x_input = None
-        self.abs_y_input = None
-        self.abs_z_input = None
-        self.move_mol_checkbox = None
-        self.abs_apply_btn = None
-        self.delta_selection_label = None
-        self.dx_input = None
-        self.dy_input = None
-        self.dz_input = None
-        self.apply_button = None
+        self.abs_selection_label: Any = None
+        self.abs_x_input: Any = None
+        self.abs_y_input: Any = None
+        self.abs_z_input: Any = None
+        self.move_mol_checkbox: Any = None
+        self.abs_apply_btn: Any = None
+        self.delta_selection_label: Any = None
+        self.dx_input: Any = None
+        self.dy_input: Any = None
+        self.dz_input: Any = None
+        self.apply_button: Any = None
 
         if preselected_atoms:
             self.selected_atoms.update(preselected_atoms)

--- a/moleditpy/src/moleditpy/ui/ui_manager.py
+++ b/moleditpy/src/moleditpy/ui/ui_manager.py
@@ -225,7 +225,7 @@ class UIManager(QObject):
                 self.host.set_settings_dirty(False)
         except (AttributeError, RuntimeError, TypeError, ValueError, OSError):
             # Safe defensive fallback catching AttributeError, RuntimeError, TypeError, ValueError, OSError
-            pass
+            logging.debug("Suppressed non-critical error", exc_info=True)
 
         # 2. Handle unsaved changes
         if self.host.state_manager.has_unsaved_changes:
@@ -258,7 +258,7 @@ class UIManager(QObject):
                         widget.close()
                     except (RuntimeError, TypeError):
                         # Safe defensive fallback catching RuntimeError, TypeError
-                        pass
+                        logging.debug("Suppressed non-critical error", exc_info=True)
 
             # Stop calculation threads
             active_threads = list(
@@ -270,10 +270,10 @@ class UIManager(QObject):
                     thr.wait(200)
                 except (RuntimeError, TypeError):
                     # Safe defensive fallback catching RuntimeError, TypeError
-                    pass
+                    logging.debug("Suppressed non-critical error", exc_info=True)
         except (AttributeError, RuntimeError, TypeError, ValueError):
             # Safe defensive fallback catching AttributeError, RuntimeError, TypeError, ValueError
-            pass
+            logging.debug("Suppressed non-critical error", exc_info=True)
 
         return True
 
@@ -306,7 +306,7 @@ class UIManager(QObject):
                     interactor_style.reset_interactor_state()
             except (AttributeError, RuntimeError):
                 # Safe defensive fallback catching AttributeError, RuntimeError
-                pass
+                logging.debug("Suppressed non-critical error", exc_info=True)
         self.host.init_manager.view_2d.setFocus()
 
     def _setup_3d_picker(self) -> None:
@@ -467,7 +467,7 @@ class UIManager(QObject):
             except (AttributeError, RuntimeError, TypeError, ValueError):
                 # Suppress non-critical 3D feature state update errors if widgets are not fully initialized
                 # Safe defensive fallback catching AttributeError, RuntimeError, TypeError, ValueError
-                pass
+                logging.debug("Suppressed non-critical error", exc_info=True)
 
         # Always enable these core 3D interactors
         for core_act in ["measurement_action", "edit_3d_action"]:

--- a/moleditpy/src/moleditpy/ui/user_template_dialog.py
+++ b/moleditpy/src/moleditpy/ui/user_template_dialog.py
@@ -41,9 +41,9 @@ class UserTemplateDialog(QDialog):
 
     def __init__(self, main_window: Any, parent: Any = None) -> None:
         super().__init__(parent)
-        self.delete_button = None
-        self.save_current_button = None
-        self.template_layout = None
+        self.delete_button: Any = None
+        self.save_current_button: Any = None
+        self.template_layout: Any = None
         self.template_widget = None
         self.main_window = main_window
         self.user_templates: List[Any] = []

--- a/moleditpy/src/moleditpy/ui/user_template_dialog.py
+++ b/moleditpy/src/moleditpy/ui/user_template_dialog.py
@@ -44,7 +44,7 @@ class UserTemplateDialog(QDialog):
         self.delete_button: Any = None
         self.save_current_button: Any = None
         self.template_layout: Any = None
-        self.template_widget = None
+        self.template_widget: Any = None
         self.main_window = main_window
         self.user_templates: List[Any] = []
         self.selected_template = None

--- a/moleditpy/src/moleditpy/ui/user_template_dialog.py
+++ b/moleditpy/src/moleditpy/ui/user_template_dialog.py
@@ -59,7 +59,7 @@ class UserTemplateDialog(QDialog):
 
         # Position window to the top-right of the parent
         if self.parent():
-            parent_geometry = self.parent().geometry()
+            parent_geometry = self.parent().geometry()  # type: ignore[union-attr]
             x = parent_geometry.right() - self.width() - 20
             y = parent_geometry.top() + 50
             self.move(x, y)

--- a/moleditpy/src/moleditpy/ui/view_3d_logic.py
+++ b/moleditpy/src/moleditpy/ui/view_3d_logic.py
@@ -110,7 +110,7 @@ class View3DManager:
         self.host.edit_3d_manager.clear_3d_selection()
 
         self.current_3d_style = style_name
-        self.host.statusBar().showMessage(f"3D style set to: {style_name}")
+        self.host.statusBar().showMessage(f"3D style set to: {style_name}")  # type: ignore[union-attr]
 
         # Redraw if molecule is displayed
         if self.current_mol:
@@ -164,7 +164,7 @@ class View3DManager:
             except (AttributeError, RuntimeError, TypeError, ValueError) as e:
                 # Kekulize failed; keep original and warn user
                 with contextlib.suppress(AttributeError, RuntimeError, TypeError):
-                    self.host.statusBar().showMessage(f"Kekulize failed: {e}")
+                    self.host.statusBar().showMessage(f"Kekulize failed: {e}")  # type: ignore[union-attr]
         return mol
 
     def _draw_standard_3d_style_body(
@@ -179,19 +179,19 @@ class View3DManager:
         self._3d_color_map.clear()
 
         # 1. Camera state and clear
-        camera_state = self.plotter.camera_position
+        camera_state = self.plotter.camera_position  # type: ignore[union-attr]
 
         # Force removal to prevent ghost actor residues
         old_axes_actor = getattr(self, "axes_actor", None)
         if old_axes_actor is not None:
             with contextlib.suppress(AttributeError, RuntimeError, TypeError):
-                self.plotter.remove_actor(old_axes_actor)
+                self.plotter.remove_actor(old_axes_actor)  # type: ignore[union-attr]
             self.axes_actor = None
 
-        self.plotter.clear()
+        self.plotter.clear()  # type: ignore[union-attr]
 
         # 2. Background color setting
-        self.plotter.set_background(
+        self.plotter.set_background(  # type: ignore[union-attr]
             self.host.get_settings().get("background_color", "#919191")
         )
 
@@ -199,7 +199,7 @@ class View3DManager:
         if mol is None or mol.GetNumAtoms() == 0:
             self.atom_actor = None
             self.current_mol = None
-            self.plotter.render()
+            self.plotter.render()  # type: ignore[union-attr]
             return
 
         # 4. Lighting setting
@@ -211,7 +211,7 @@ class View3DManager:
                 light_type="cameralight",
                 intensity=self.host.init_manager.settings.get("light_intensity", 1.2),
             )
-            self.plotter.add_light(light)
+            self.plotter.add_light(light)  # type: ignore[union-attr]
 
         # 5. Molecule drawing logic
         # Mutually exclusive: Kekulé display or Aromatic Circle display (Kekulé takes priority)
@@ -234,7 +234,7 @@ class View3DManager:
             except (AttributeError, RuntimeError, TypeError, ValueError) as e:
                 # Kekulize failed; keep original and warn user
                 with contextlib.suppress(AttributeError, RuntimeError, TypeError):
-                    self.host.statusBar().showMessage(f"Kekulize failed: {e}")
+                    self.host.statusBar().showMessage(f"Kekulize failed: {e}")  # type: ignore[union-attr]
                 mol_to_draw = mol
 
         # Use the original molecule's conformer (positions) to ensure coordinates
@@ -280,19 +280,19 @@ class View3DManager:
         self._add_3d_bond_cylinders(mol_to_draw, conf, col, current_style, mesh_props)
         self._add_3d_aromatic_rings(mol_to_draw, current_style, mesh_props)
         self._add_3d_labels(mol, mol_to_draw)
-        self.plotter.camera_position = camera_state
+        self.plotter.camera_position = camera_state  # type: ignore[union-attr]
 
         # Update projection mode and force render
         proj_mode = self.host.get_settings().get("projection_mode", "Perspective")
         if hasattr(self.plotter, "renderer") and hasattr(
-            self.plotter.renderer, "GetActiveCamera"
+            self.plotter.renderer, "GetActiveCamera"  # type: ignore[union-attr]
         ):
-            vcam = self.plotter.renderer.GetActiveCamera()
+            vcam = self.plotter.renderer.GetActiveCamera()  # type: ignore[union-attr]
             if vcam:
                 vcam.SetParallelProjection(proj_mode == "Orthographic")
                 try:
                     # Force a render so the change is visible immediately
-                    self.plotter.render()
+                    self.plotter.render()  # type: ignore[union-attr]
                 except (AttributeError, RuntimeError, TypeError) as e:
                     logging.error(f"Render failed: {e}")
 
@@ -525,11 +525,11 @@ class View3DManager:
             )
 
             if is_lighting_enabled:
-                self.atom_actor = self.plotter.add_mesh(
+                self.atom_actor = self.plotter.add_mesh(  # type: ignore[union-attr]
                     glyphs, scalars="colors", rgb=True, **mesh_props
                 )
             else:
-                self.atom_actor = self.plotter.add_mesh(
+                self.atom_actor = self.plotter.add_mesh(  # type: ignore[union-attr]
                     glyphs,
                     scalars="colors",
                     rgb=True,
@@ -867,7 +867,7 @@ class View3DManager:
                 )
 
                 # Add to plotter
-                self.plotter.add_mesh(tube, scalars="colors", rgb=True, **mesh_props)
+                self.plotter.add_mesh(tube, scalars="colors", rgb=True, **mesh_props)  # type: ignore[union-attr]
 
     def _add_3d_aromatic_rings(
         self, mol_to_draw: Any, current_style: str, mesh_props: Dict[str, Any]
@@ -1032,7 +1032,7 @@ class View3DManager:
                         else:
                             torus_color = [0.5, 0.5, 0.5]
 
-                    self.plotter.add_mesh(circle_line, color=torus_color, **mesh_props)
+                    self.plotter.add_mesh(circle_line, color=torus_color, **mesh_props)  # type: ignore[union-attr]
 
             except (AttributeError, RuntimeError, TypeError, ValueError) as e:
                 logging.error(f"Error rendering aromatic circles: {e}")
@@ -1054,12 +1054,12 @@ class View3DManager:
                         pts.append(coord)
                         labels.append(lbl if lbl is not None else "?")
                     try:
-                        self.plotter.remove_actor("chiral_labels")
+                        self.plotter.remove_actor("chiral_labels")  # type: ignore[union-attr]
                     except (AttributeError, RuntimeError, TypeError) as e:
                         logging.debug(
                             f"Suppressed exception: {e}"
                         )  # Suppress non-critical 3D label update errors
-                    self.plotter.add_point_labels(
+                    self.plotter.add_point_labels(  # type: ignore[union-attr]
                         np.array(pts),
                         labels,
                         font_size=20,
@@ -1074,7 +1074,7 @@ class View3DManager:
                         show_points=False,
                     )
             except (AttributeError, RuntimeError, TypeError, ValueError) as e:
-                self.host.statusBar().showMessage(f"3D chiral label drawing error: {e}")
+                self.host.statusBar().showMessage(f"3D chiral label drawing error: {e}")  # type: ignore[union-attr]
 
         # Also display E/Z labels
         if getattr(self, "show_chiral_labels", False):
@@ -1084,7 +1084,7 @@ class View3DManager:
                 # molecule to scan for bond stereochemistry.
                 self.show_ez_labels_3d(mol)
             except (AttributeError, RuntimeError, TypeError, ValueError) as e:
-                self.host.statusBar().showMessage(f"3D E/Z label drawing error: {e}")
+                self.host.statusBar().showMessage(f"3D E/Z label drawing error: {e}")  # type: ignore[union-attr]
 
     def _calculate_double_bond_offset(
         self, mol: Any, bond: Any, conf: Any
@@ -1185,10 +1185,10 @@ class View3DManager:
         # Remove existing E/Z labels
         if (
             hasattr(self.plotter, "renderer")
-            and "ez_labels" in self.plotter.renderer.actors
+            and "ez_labels" in self.plotter.renderer.actors  # type: ignore[union-attr]
         ):
             try:
-                self.plotter.remove_actor("ez_labels")
+                self.plotter.remove_actor("ez_labels")  # type: ignore[union-attr]
             except (AttributeError, RuntimeError, TypeError) as e:
                 logging.error(f"Failed to remove EZ labels: {e}")
 
@@ -1266,7 +1266,7 @@ class View3DManager:
                     labels.append(label)
 
         if pts and labels:
-            self.plotter.add_point_labels(
+            self.plotter.add_point_labels(  # type: ignore[union-attr]
                 np.array(pts),
                 labels,
                 font_size=18,
@@ -1289,11 +1289,11 @@ class View3DManager:
             self.draw_molecule_3d(self.current_mol)
 
         if checked:
-            self.host.statusBar().showMessage(
+            self.host.statusBar().showMessage(  # type: ignore[union-attr]
                 "Chiral labels: will be (re)computed after ConvertↁED."
             )
         else:
-            self.host.statusBar().showMessage("Chiral labels disabled.")
+            self.host.statusBar().showMessage("Chiral labels disabled.")  # type: ignore[union-attr]
 
     def update_chiral_labels(self) -> None:
         """Calculate chiral centers and set/clear R/S labels on 2D AtomItems.
@@ -1350,7 +1350,7 @@ class View3DManager:
                         item.chiral_label = label
 
         except (AttributeError, RuntimeError, TypeError, ValueError) as e:
-            self.host.statusBar().showMessage(f"Update chiral labels error: {e}")
+            self.host.statusBar().showMessage(f"Update chiral labels error: {e}")  # type: ignore[union-attr]
 
         # Finally redraw 2D scene
         self.host.init_manager.scene.update()
@@ -1381,7 +1381,7 @@ class View3DManager:
             base_menu = getattr(self.host.init_manager, "atom_index_base_menu", None)
             if base_menu is not None:
                 base_menu.setEnabled(False)
-            self.host.statusBar().showMessage("Atom info display disabled.")
+            self.host.statusBar().showMessage("Atom info display disabled.")  # type: ignore[union-attr]
         else:
             # Set new mode
             self.atom_info_display_mode = mode
@@ -1410,13 +1410,13 @@ class View3DManager:
                 "coords": "Coordinates",
                 "symbol": "Element Symbol",
             }
-            self.host.statusBar().showMessage(
+            self.host.statusBar().showMessage(  # type: ignore[union-attr]
                 f"Displaying: {mode_names.get(mode, mode)}"
             )
 
             # Display info for all atoms
             self.show_all_atom_info()
-            self.plotter.render()
+            self.plotter.render()  # type: ignore[union-attr]
 
     def set_atom_index_base(self, base: int) -> None:
         """Switch between 0-based and 1-based index display and refresh labels."""
@@ -1432,7 +1432,7 @@ class View3DManager:
         if self.atom_info_display_mode in {"rdkit_index", "original_id", "xyz_index"}:
             self.clear_all_atom_info_labels()
             self.show_all_atom_info()
-            self.plotter.render()
+            self.plotter.render()  # type: ignore[union-attr]
 
     def is_xyz_derived_molecule(self) -> bool:
         """Determine if the current molecule is derived from an XYZ file"""
@@ -1585,7 +1585,7 @@ class View3DManager:
         self.current_atom_info_labels = []
         try:
             if rdkit_positions:
-                a = self.plotter.add_point_labels(
+                a = self.plotter.add_point_labels(  # type: ignore[union-attr]
                     np.array(rdkit_positions),
                     rdkit_texts,
                     point_size=12,
@@ -1602,7 +1602,7 @@ class View3DManager:
                 self.current_atom_info_labels.append(a)
 
             if id_positions:
-                a = self.plotter.add_point_labels(
+                a = self.plotter.add_point_labels(  # type: ignore[union-attr]
                     np.array(id_positions),
                     id_texts,
                     point_size=12,
@@ -1619,7 +1619,7 @@ class View3DManager:
                 self.current_atom_info_labels.append(a)
 
             if xyz_positions:
-                a = self.plotter.add_point_labels(
+                a = self.plotter.add_point_labels(  # type: ignore[union-attr]
                     np.array(xyz_positions),
                     xyz_texts,
                     point_size=12,
@@ -1636,7 +1636,7 @@ class View3DManager:
                 self.current_atom_info_labels.append(a)
 
             if other_positions:
-                a = self.plotter.add_point_labels(
+                a = self.plotter.add_point_labels(  # type: ignore[union-attr]
                     np.array(other_positions),
                     other_texts,
                     point_size=12,
@@ -1659,7 +1659,7 @@ class View3DManager:
             if self.atom_label_legend_names:
                 for nm in self.atom_label_legend_names:
                     try:
-                        self.plotter.remove_actor(nm)
+                        self.plotter.remove_actor(nm)  # type: ignore[union-attr]
                     except (AttributeError, RuntimeError, TypeError) as e:
                         logging.debug(
                             f"Suppressed exception: {e}"
@@ -1691,7 +1691,7 @@ class View3DManager:
                 except (AttributeError, RuntimeError, TypeError):
                     x_offset = 0.0
                 try:
-                    actor = self.plotter.add_text(
+                    actor = self.plotter.add_text(  # type: ignore[union-attr]
                         label_text,
                         position=(0.0 + x_offset, y),
                         font_size=12,
@@ -1728,7 +1728,7 @@ class View3DManager:
                 if isinstance(self.current_atom_info_labels, (list, tuple)):
                     for a in list(self.current_atom_info_labels):
                         try:
-                            self.plotter.remove_actor(a)
+                            self.plotter.remove_actor(a)  # type: ignore[union-attr]
                         except (AttributeError, RuntimeError, TypeError) as e:
                             logging.debug(f"Failed to remove actor: {e}")
                 else:
@@ -1750,7 +1750,7 @@ class View3DManager:
             if self.atom_label_legend_names:
                 for nm in list(self.atom_label_legend_names):
                     try:
-                        self.plotter.remove_actor(nm)
+                        self.plotter.remove_actor(nm)  # type: ignore[union-attr]
                     except (AttributeError, RuntimeError, TypeError) as e:
                         logging.debug(
                             f"Suppressed exception: {e}"
@@ -1846,9 +1846,9 @@ class View3DManager:
             "projection_mode", "Perspective"
         )
         if hasattr(self.plotter, "renderer") and hasattr(
-            self.plotter.renderer, "GetActiveCamera"
+            self.plotter.renderer, "GetActiveCamera"  # type: ignore[union-attr]
         ):
-            cam = self.plotter.renderer.GetActiveCamera()
+            cam = self.plotter.renderer.GetActiveCamera()  # type: ignore[union-attr]
             if cam:
                 if proj_mode == "Orthographic":
                     cam.SetParallelProjection(True)
@@ -1857,12 +1857,12 @@ class View3DManager:
 
         # Enable renderer layers (for text overlay)
         # --- Background Color ---
-        self.plotter.set_background(
+        self.plotter.set_background(  # type: ignore[union-attr]
             self.host.init_manager.settings.get("background_color", "#919191")
         )
 
         # --- Renderer Layers ---
-        renderer = self.plotter.renderer
+        renderer = self.plotter.renderer  # type: ignore[union-attr]
         if renderer and hasattr(renderer, "SetNumberOfLayers"):
             try:
                 renderer.SetNumberOfLayers(2)  # Layer 0: 3D, Layer 1: 2D Overlay
@@ -1919,15 +1919,15 @@ class View3DManager:
                 # Add orientation marker widget
                 self.axes_widget = vtk.vtkOrientationMarkerWidget()
                 self.axes_widget.SetOrientationMarker(axes)
-                self.axes_widget.SetInteractor(self.plotter.interactor)
+                self.axes_widget.SetInteractor(self.plotter.interactor)  # type: ignore[union-attr]
                 self.axes_widget.SetViewport(0.0, 0.0, 0.2, 0.2)
                 self.axes_widget.SetEnabled(True)
                 self.axes_widget.InteractiveOff()
             else:
-                self.plotter.hide_axes()
+                self.plotter.hide_axes()  # type: ignore[union-attr]
 
             # Re-render to show axes
-            self.plotter.render()
+            self.plotter.render()  # type: ignore[union-attr]
         except (
             AttributeError,
             RuntimeError,
@@ -1937,7 +1937,7 @@ class View3DManager:
             logging.debug(f"Failed to toggle 3D axes: {e}")
 
             # Explicitly render to show change
-            self.plotter.render()
+            self.plotter.render()  # type: ignore[union-attr]
 
         if redraw:
             self.draw_molecule_3d(self.current_mol)
@@ -1945,7 +1945,7 @@ class View3DManager:
         # Do not reset camera on settings change (reset only once)
         if not getattr(self, "_camera_initialized", False):
             try:
-                self.plotter.reset_camera()
+                self.plotter.reset_camera()  # type: ignore[union-attr]
             except (AttributeError, RuntimeError, TypeError) as e:
                 logging.debug(
                     f"Suppressed exception: {e}"
@@ -1955,8 +1955,8 @@ class View3DManager:
 
         # Force plotter update
         try:
-            self.plotter.render()
-            self.plotter.update()
+            self.plotter.render()  # type: ignore[union-attr]
+            self.plotter.update()  # type: ignore[union-attr]
         except (AttributeError, RuntimeError, TypeError) as e:
             logging.debug(
                 f"Suppressed exception: {e}"

--- a/moleditpy/src/moleditpy/ui/view_3d_logic.py
+++ b/moleditpy/src/moleditpy/ui/view_3d_logic.py
@@ -32,7 +32,7 @@ from PyQt6.QtGui import QColor, QTransform
 from PyQt6.QtWidgets import QGraphicsView
 
 
-from ..utils.constants import CPK_COLORS_PV, VDW_RADII, pt
+from ..utils.constants import CPK_COLORS_PV, VDW_DISPLAY_RADII, pt
 from .template_preview_item import TemplatePreviewItem
 
 
@@ -345,7 +345,7 @@ class View3DManager:
             resolution = self.host.init_manager.settings.get(
                 "ball_stick_resolution", 16
             )
-            rad = np.array([VDW_RADII.get(s, 0.4) * atom_scale for s in sym])
+            rad = np.array([VDW_DISPLAY_RADII.get(s, 0.4) * atom_scale for s in sym])
 
         self.glyph_source = pv.PolyData(self.atom_positions_3d)
         self.glyph_source["colors"] = col

--- a/moleditpy/src/moleditpy/ui/view_3d_logic.py
+++ b/moleditpy/src/moleditpy/ui/view_3d_logic.py
@@ -285,8 +285,8 @@ class View3DManager:
         # Update projection mode and force render
         proj_mode = self.host.get_settings().get("projection_mode", "Perspective")
         if hasattr(self.plotter, "renderer") and hasattr(
-            self.plotter.renderer,
-            "GetActiveCamera",  # type: ignore[union-attr]
+            self.plotter.renderer,  # type: ignore[union-attr]
+            "GetActiveCamera",
         ):
             vcam = self.plotter.renderer.GetActiveCamera()  # type: ignore[union-attr]
             if vcam:
@@ -1847,8 +1847,8 @@ class View3DManager:
             "projection_mode", "Perspective"
         )
         if hasattr(self.plotter, "renderer") and hasattr(
-            self.plotter.renderer,
-            "GetActiveCamera",  # type: ignore[union-attr]
+            self.plotter.renderer,  # type: ignore[union-attr]
+            "GetActiveCamera",
         ):
             cam = self.plotter.renderer.GetActiveCamera()  # type: ignore[union-attr]
             if cam:

--- a/moleditpy/src/moleditpy/ui/view_3d_logic.py
+++ b/moleditpy/src/moleditpy/ui/view_3d_logic.py
@@ -12,7 +12,7 @@ DOI: 10.5281/zenodo.17268532
 
 from __future__ import annotations
 import logging
-import contextlib
+from ..utils.suppress_log import suppress_log
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 if TYPE_CHECKING:
@@ -84,7 +84,7 @@ class View3DManager:
     def cleanup(self) -> None:
         """Cleanup resources used by the 3D manager."""
         if self.plotter:
-            with contextlib.suppress(RuntimeError, OSError):
+            with suppress_log(RuntimeError, OSError):
                 self.plotter.clear()
                 self.plotter.close()
         self.current_mol = None
@@ -163,7 +163,7 @@ class View3DManager:
                 return mol_to_draw
             except (AttributeError, RuntimeError, TypeError, ValueError) as e:
                 # Kekulize failed; keep original and warn user
-                with contextlib.suppress(AttributeError, RuntimeError, TypeError):
+                with suppress_log(AttributeError, RuntimeError, TypeError):
                     self.host.statusBar().showMessage(f"Kekulize failed: {e}")  # type: ignore[union-attr]
         return mol
 
@@ -184,7 +184,7 @@ class View3DManager:
         # Force removal to prevent ghost actor residues
         old_axes_actor = getattr(self, "axes_actor", None)
         if old_axes_actor is not None:
-            with contextlib.suppress(AttributeError, RuntimeError, TypeError):
+            with suppress_log(AttributeError, RuntimeError, TypeError):
                 self.plotter.remove_actor(old_axes_actor)  # type: ignore[union-attr]
             self.axes_actor = None
 
@@ -233,7 +233,7 @@ class View3DManager:
                 Chem.Kekulize(mol_to_draw, clearAromaticFlags=True)
             except (AttributeError, RuntimeError, TypeError, ValueError) as e:
                 # Kekulize failed; keep original and warn user
-                with contextlib.suppress(AttributeError, RuntimeError, TypeError):
+                with suppress_log(AttributeError, RuntimeError, TypeError):
                     self.host.statusBar().showMessage(f"Kekulize failed: {e}")  # type: ignore[union-attr]
                 mol_to_draw = mol
 
@@ -264,7 +264,7 @@ class View3DManager:
                         ValueError,
                         KeyError,
                     ):  # [COLOR] QColor parse may fail on invalid hex; skip atom color override silently.
-                        pass
+                        logging.debug("Suppressed non-critical error", exc_info=True)
 
         # Define common mesh properties
         mesh_props = dict(
@@ -635,7 +635,7 @@ class View3DManager:
                         ValueError,
                         KeyError,
                     ):  # [COLOR] QColor parse may fail on invalid hex; skip bond color override silently.
-                        pass
+                        logging.debug("Suppressed non-critical error", exc_info=True)
 
                 # Determine effective uniform color for this bond
                 local_bs_bond_rgb = (
@@ -1261,7 +1261,7 @@ class View3DManager:
                                     label = "?"
                         except (KeyError, RuntimeError, TypeError):
                             # Safe defensive fallback catching KeyError, RuntimeError, TypeError
-                            pass
+                            logging.debug("Suppressed non-critical error", exc_info=True)
 
                     pts.append(center_pos)
                     labels.append(label)
@@ -1884,7 +1884,7 @@ class View3DManager:
                     self.axes_widget = None
                 except (AttributeError, RuntimeError):
                     # Safe defensive fallback catching AttributeError, RuntimeError
-                    pass
+                    logging.debug("Suppressed non-critical error", exc_info=True)
 
             if show_axes:
                 # Calculate contrast color from background for labels

--- a/moleditpy/src/moleditpy/ui/view_3d_logic.py
+++ b/moleditpy/src/moleditpy/ui/view_3d_logic.py
@@ -285,7 +285,8 @@ class View3DManager:
         # Update projection mode and force render
         proj_mode = self.host.get_settings().get("projection_mode", "Perspective")
         if hasattr(self.plotter, "renderer") and hasattr(
-            self.plotter.renderer, "GetActiveCamera"  # type: ignore[union-attr]
+            self.plotter.renderer,
+            "GetActiveCamera",  # type: ignore[union-attr]
         ):
             vcam = self.plotter.renderer.GetActiveCamera()  # type: ignore[union-attr]
             if vcam:
@@ -1846,7 +1847,8 @@ class View3DManager:
             "projection_mode", "Perspective"
         )
         if hasattr(self.plotter, "renderer") and hasattr(
-            self.plotter.renderer, "GetActiveCamera"  # type: ignore[union-attr]
+            self.plotter.renderer,
+            "GetActiveCamera",  # type: ignore[union-attr]
         ):
             cam = self.plotter.renderer.GetActiveCamera()  # type: ignore[union-attr]
             if cam:

--- a/moleditpy/src/moleditpy/ui/view_3d_logic.py
+++ b/moleditpy/src/moleditpy/ui/view_3d_logic.py
@@ -1261,7 +1261,9 @@ class View3DManager:
                                     label = "?"
                         except (KeyError, RuntimeError, TypeError):
                             # Safe defensive fallback catching KeyError, RuntimeError, TypeError
-                            logging.debug("Suppressed non-critical error", exc_info=True)
+                            logging.debug(
+                                "Suppressed non-critical error", exc_info=True
+                            )
 
                     pts.append(center_pos)
                     labels.append(label)

--- a/moleditpy/src/moleditpy/ui/view_3d_logic.py
+++ b/moleditpy/src/moleditpy/ui/view_3d_logic.py
@@ -40,8 +40,8 @@ class View3DManager:
     """Independent manager for 3D rendering logic, ported from MainWindowView3d mixin."""
 
     def __init__(self, host: MainWindow) -> None:
-        self._plugin_bond_color_overrides = {}
-        self._plugin_color_overrides = {}
+        self._plugin_bond_color_overrides: Dict[int, Any] = {}
+        self._plugin_color_overrides: Dict[int, Any] = {}
         self.host = host
         # State variables previously held by mixin
         self._drawing_3d: bool = False
@@ -72,9 +72,9 @@ class View3DManager:
         ``self.plotter`` if the owning host carries a
         different (mock) ``view_3d_manager`` instance.
         """
-        val = getattr(self, "_plotter_val", None)
+        val: Optional[CustomQtInteractor] = getattr(self, "_plotter_val", None)
         if val is not None:
-            return val  # type: ignore[return-value]
+            return val
         return None
 
     @plotter.setter

--- a/moleditpy/src/moleditpy/ui/zoomable_view.py
+++ b/moleditpy/src/moleditpy/ui/zoomable_view.py
@@ -77,8 +77,8 @@ class ZoomableView(QGraphicsView):
                 event.pos()
             )  # Record start point in viewport coordinates
             # Record current scrollbar values
-            self._pan_start_scroll_h = self.horizontalScrollBar().value()
-            self._pan_start_scroll_v = self.verticalScrollBar().value()
+            self._pan_start_scroll_h = self.horizontalScrollBar().value()  # type: ignore[union-attr]
+            self._pan_start_scroll_v = self.verticalScrollBar().value()  # type: ignore[union-attr]
             self.setCursor(Qt.CursorShape.ClosedHandCursor)
             event.accept()
         else:
@@ -93,10 +93,10 @@ class ZoomableView(QGraphicsView):
                 QPointF(event.pos()) - self._pan_start_pos
             )  # Calculate mouse movement delta
             # Update scroll position by subtracting movement delta from start position
-            self.horizontalScrollBar().setValue(
+            self.horizontalScrollBar().setValue(  # type: ignore[union-attr]
                 int(self._pan_start_scroll_h - delta.x())
             )
-            self.verticalScrollBar().setValue(int(self._pan_start_scroll_v - delta.y()))
+            self.verticalScrollBar().setValue(int(self._pan_start_scroll_v - delta.y()))  # type: ignore[union-attr]
             event.accept()
         else:
             super().mouseMoveEvent(event)
@@ -104,13 +104,13 @@ class ZoomableView(QGraphicsView):
     def mouseReleaseEvent(self, event: Optional[QMouseEvent]) -> None:
         """End panning mode and restore cursor when the relevant button is released"""
         # Check if the middle or left button used for panning was released
-        is_middle_button_release = event.button() == Qt.MouseButton.MiddleButton
-        is_left_button_release = event.button() == Qt.MouseButton.LeftButton
+        is_middle_button_release = event.button() == Qt.MouseButton.MiddleButton  # type: ignore[union-attr]
+        is_left_button_release = event.button() == Qt.MouseButton.LeftButton  # type: ignore[union-attr]
 
         if self._is_panning and (is_middle_button_release or is_left_button_release):
             self._is_panning = False
             # Restore cursor based on the current scene mode
-            current_mode = self.scene().mode if self.scene() else "select"
+            current_mode = self.scene().mode if self.scene() else "select"  # type: ignore[union-attr]
             if current_mode == "select":
                 self.setCursor(Qt.CursorShape.ArrowCursor)
             elif current_mode.startswith(("atom", "bond", "template")):
@@ -119,7 +119,7 @@ class ZoomableView(QGraphicsView):
                 self.setCursor(Qt.CursorShape.CrossCursor)
             else:
                 self.setCursor(Qt.CursorShape.ArrowCursor)
-            event.accept()
+            event.accept()  # type: ignore[union-attr]
         else:
             super().mouseReleaseEvent(event)
 

--- a/moleditpy/src/moleditpy/ui/zoomable_view.py
+++ b/moleditpy/src/moleditpy/ui/zoomable_view.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 from typing import Optional
 
 from PyQt6.QtCore import QEvent, QPointF, Qt
-from PyQt6.QtGui import QMouseEvent, QWheelEvent
+from PyQt6.QtGui import QMouseEvent, QWheelEvent, QNativeGestureEvent
 from PyQt6.QtWidgets import QGraphicsScene, QGraphicsView, QWidget
 
 
@@ -127,7 +127,7 @@ class ZoomableView(QGraphicsView):
         """Handle native gestures (like pinch zoom on trackpads)"""
         if event is None:
             return super().viewportEvent(event)
-        if event.type() == QEvent.Type.NativeGesture:
+        if isinstance(event, QNativeGestureEvent):
             # Detect pinch zoom gestures
             if event.gestureType() == Qt.NativeGestureType.ZoomNativeGesture:
                 # event.value() returns the scale factor delta

--- a/moleditpy/src/moleditpy/ui/zoomable_view.py
+++ b/moleditpy/src/moleditpy/ui/zoomable_view.py
@@ -12,7 +12,7 @@ DOI: 10.5281/zenodo.17268532
 
 from __future__ import annotations
 
-from typing import Optional
+from typing import Optional, cast
 
 from PyQt6.QtCore import QEvent, QPointF, Qt
 from PyQt6.QtGui import QMouseEvent, QWheelEvent, QNativeGestureEvent
@@ -127,12 +127,13 @@ class ZoomableView(QGraphicsView):
         """Handle native gestures (like pinch zoom on trackpads)"""
         if event is None:
             return super().viewportEvent(event)
-        if isinstance(event, QNativeGestureEvent):
+        if event.type() == QEvent.Type.NativeGesture:
+            gesture = cast(QNativeGestureEvent, event)
             # Detect pinch zoom gestures
-            if event.gestureType() == Qt.NativeGestureType.ZoomNativeGesture:
-                # event.value() returns the scale factor delta
+            if gesture.gestureType() == Qt.NativeGestureType.ZoomNativeGesture:
+                # gesture.value() returns the scale factor delta
                 # (positive for zoom-in, negative for zoom-out)
-                factor = 1.0 + event.value()
+                factor = 1.0 + gesture.value()
 
                 # Apply scaling if within limits
                 self.scale(factor, factor)

--- a/moleditpy/src/moleditpy/utils/constants.py
+++ b/moleditpy/src/moleditpy/utils/constants.py
@@ -205,7 +205,13 @@ DEFAULT_CPK_COLORS = {
 
 
 pt = Chem.GetPeriodicTable()
-VDW_RADII = {pt.GetElementSymbol(i): pt.GetRvdw(i) * 0.3 for i in range(1, 119)}
+# Display radii for 3D rendering: true van der Waals radii scaled by 0.3.
+# NOT physical vdW radii — do not use for chemistry/geometry calculations.
+VDW_DISPLAY_RADII = {
+    pt.GetElementSymbol(i): pt.GetRvdw(i) * 0.3 for i in range(1, 119)
+}
+# Backward-compatible alias (deprecated; kept for external plugins)
+VDW_RADII = VDW_DISPLAY_RADII
 
 # Covalent radii (Angstrom) for bond estimation
 COVALENT_RADII = {

--- a/moleditpy/src/moleditpy/utils/constants.py
+++ b/moleditpy/src/moleditpy/utils/constants.py
@@ -12,6 +12,7 @@ DOI: 10.5281/zenodo.17268532
 
 # --- Constants ---
 
+import logging
 import os
 from PyQt6.QtGui import QColor, QFont
 from rdkit import Chem
@@ -24,9 +25,9 @@ def _get_version() -> str:
         try:
             return version("MoleditPy")
         except PackageNotFoundError:  # [OPTIONAL] Package not installed in editable mode; fall through to pyproject.toml.
-            pass
+            logging.debug("Suppressed non-critical error", exc_info=True)
     except ImportError:
-        pass
+        logging.debug("Suppressed non-critical error", exc_info=True)
 
     try:
         # Fallback: Parse pyproject.toml directly
@@ -42,7 +43,7 @@ def _get_version() -> str:
     except (
         Exception
     ):  # [FALLBACK] pyproject.toml may not exist in installed wheels; return "Unknown".
-        pass
+        logging.debug("Suppressed non-critical error", exc_info=True)
 
     return "Unknown"
 

--- a/moleditpy/src/moleditpy/utils/constants.py
+++ b/moleditpy/src/moleditpy/utils/constants.py
@@ -86,6 +86,9 @@ EZ_LABEL_BOX_SIZE = 28
 SNAP_DISTANCE = 14.0
 SUM_TOLERANCE = 0.1
 
+# Max undo entries; each holds a full state deep-copy, oldest are dropped
+UNDO_STACK_MAX_DEPTH = 100
+
 # Misc drawing
 NUM_DASHES = 8
 HOVER_PEN_WIDTH = 8
@@ -205,10 +208,9 @@ DEFAULT_CPK_COLORS = {
 
 
 pt = Chem.GetPeriodicTable()
-# Display radii for 3D rendering: true van der Waals radii scaled by 0.3.
-# NOT physical vdW radii — do not use for chemistry/geometry calculations.
+# 0.3-scaled vdW radii for 3D display only — not physical values
 VDW_DISPLAY_RADII = {pt.GetElementSymbol(i): pt.GetRvdw(i) * 0.3 for i in range(1, 119)}
-# Backward-compatible alias (deprecated; kept for external plugins)
+# Deprecated alias kept for external plugins
 VDW_RADII = VDW_DISPLAY_RADII
 
 # Covalent radii (Angstrom) for bond estimation

--- a/moleditpy/src/moleditpy/utils/constants.py
+++ b/moleditpy/src/moleditpy/utils/constants.py
@@ -207,9 +207,7 @@ DEFAULT_CPK_COLORS = {
 pt = Chem.GetPeriodicTable()
 # Display radii for 3D rendering: true van der Waals radii scaled by 0.3.
 # NOT physical vdW radii — do not use for chemistry/geometry calculations.
-VDW_DISPLAY_RADII = {
-    pt.GetElementSymbol(i): pt.GetRvdw(i) * 0.3 for i in range(1, 119)
-}
+VDW_DISPLAY_RADII = {pt.GetElementSymbol(i): pt.GetRvdw(i) * 0.3 for i in range(1, 119)}
 # Backward-compatible alias (deprecated; kept for external plugins)
 VDW_RADII = VDW_DISPLAY_RADII
 

--- a/moleditpy/src/moleditpy/utils/sip_isdeleted_safe.py
+++ b/moleditpy/src/moleditpy/utils/sip_isdeleted_safe.py
@@ -16,7 +16,7 @@ try:
     _sip_isdeleted = getattr(_sip, "isdeleted", None)
 except ImportError:
     try:
-        import sip as _sip
+        import sip as _sip  # type: ignore[no-redef]
 
         _sip_isdeleted = getattr(_sip, "isdeleted", None)
     except ImportError:

--- a/moleditpy/src/moleditpy/utils/suppress_log.py
+++ b/moleditpy/src/moleditpy/utils/suppress_log.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+"""
+MoleditPy — A Python-based molecular editing software
+
+Author: Hiromichi Yokoyama
+License: GPL-3.0 license
+Repo: https://github.com/HiroYokoyama/python_molecular_editor
+DOI: 10.5281/zenodo.17268532
+"""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+from typing import Any, Iterator
+
+
+@contextlib.contextmanager
+def suppress_log(*exceptions: Any, note: str = "") -> Iterator[None]:
+    """Like contextlib.suppress, but logs the suppressed exception at DEBUG level.
+
+    Drop-in replacement for best-effort blocks: same suppression semantics,
+    but never silent — the full traceback lands in the debug log so hidden
+    failures (e.g. calls to renamed methods) remain diagnosable.
+    """
+    try:
+        yield
+    except exceptions:
+        logging.debug("Suppressed%s", f" ({note})" if note else "", exc_info=True)

--- a/moleditpy/src/moleditpy/utils/system_utils.py
+++ b/moleditpy/src/moleditpy/utils/system_utils.py
@@ -45,8 +45,16 @@ def detect_system_theme() -> Optional[str]:
                 val, _ = winreg.QueryValueEx(k, "AppsUseLightTheme")
                 return "dark" if int(val) == 0 else "light"
 
-        # macOS fallback
+        # macOS: AppleInterfaceStyle is "Dark" when dark mode is on and the
+        # key is absent (non-zero exit) in light mode.
         if platform.system() == "Darwin":
+            p = subprocess.run(
+                ["defaults", "read", "-g", "AppleInterfaceStyle"],
+                capture_output=True,
+                text=True,
+            )
+            if p.returncode == 0 and "dark" in p.stdout.strip().lower():
+                return "dark"
             return "light"
 
         # Linux / GNOME

--- a/moleditpy/src/moleditpy/utils/system_utils.py
+++ b/moleditpy/src/moleditpy/utils/system_utils.py
@@ -11,8 +11,7 @@ DOI: 10.5281/zenodo.17268532
 """
 
 from __future__ import annotations
-
-import contextlib
+from .suppress_log import suppress_log
 import platform
 import subprocess
 from typing import Optional
@@ -35,7 +34,7 @@ def detect_system_dark_mode() -> Optional[bool]:
 
 def detect_system_theme() -> Optional[str]:
     """Return the OS's preferred theme setting as 'dark', 'light', or None."""
-    with contextlib.suppress(AttributeError, RuntimeError, OSError, FileNotFoundError):
+    with suppress_log(AttributeError, RuntimeError, OSError, FileNotFoundError):
         # Windows
         if platform.system() == "Windows" and winreg is not None:
             with winreg.OpenKey(

--- a/moleditpy/src/moleditpy/utils/system_utils.py
+++ b/moleditpy/src/moleditpy/utils/system_utils.py
@@ -45,8 +45,7 @@ def detect_system_theme() -> Optional[str]:
                 val, _ = winreg.QueryValueEx(k, "AppsUseLightTheme")
                 return "dark" if int(val) == 0 else "light"
 
-        # macOS: AppleInterfaceStyle is "Dark" when dark mode is on and the
-        # key is absent (non-zero exit) in light mode.
+        # macOS: AppleInterfaceStyle reads "Dark", or errors in light mode
         if platform.system() == "Darwin":
             p = subprocess.run(
                 ["defaults", "read", "-g", "AppleInterfaceStyle"],

--- a/mypy.ini
+++ b/mypy.ini
@@ -35,3 +35,8 @@ ignore_missing_imports = True
 
 [mypy-openbabel.*]
 ignore_missing_imports = True
+
+# tifffile uses PEP 695 syntax that mypy can't parse under python_version 3.9
+[mypy-tifffile.*]
+follow_imports = skip
+ignore_missing_imports = True

--- a/tests/assertion_catalog.md
+++ b/tests/assertion_catalog.md
@@ -2852,6 +2852,19 @@ _RuntimeError during MolToMolBlock shows error on status bar._
 - host.statusBar_mock.showMessage.assert_called()
 - assert 'error' in msg.lower()
 
+### TestSave3DAsMolExtension.test_missing_extension_is_appended
+_No description provided._
+
+- assert not out_no_ext.exists()
+- assert (tmp_path / 'bare_name.mol').exists()
+
+### TestPromptForChargeInlineValidation.test_invalid_charge_blocks_accept_and_shows_error
+_No description provided._
+
+- dlg.accept.assert_not_called()
+- MockLabel.return_value.setVisible.assert_called_with(True)
+- dlg.accept.assert_called_once()
+
 ## tests/unit/test_items_visual.py
 
 ### test_atom_item_visual_states
@@ -3373,6 +3386,41 @@ _Verify E/Z stereo double bond maps to STEREOZ in RDKit._
 - assert mol is not None
 - assert double_bond.GetBondType() == Chem.BondType.DOUBLE
 - assert double_bond.GetStereo() == Chem.BondStereo.STEREOZ
+
+### test_add_bond_stereo_over_existing_reversed_key_updates_in_place
+_Adding a directional stereo bond over an existing sorted-key bond_
+
+- assert (key1, status1) == ((a, b), 'created')
+- assert status2 == 'updated'
+- assert key2 == (b, a)
+- assert len(data.bonds) == 1
+- assert data.bonds[b, a]['stereo'] == 1
+- assert data.adjacency_list[a].count(b) == 1
+- assert data.adjacency_list[b].count(a) == 1
+
+### test_add_bond_plain_over_existing_stereo_reversed_key_updates_in_place
+_Demoting a directional stereo bond back to a plain bond (sorted key)_
+
+- assert key1 == (b, a)
+- assert status2 == 'updated'
+- assert key2 == (a, b)
+- assert len(data.bonds) == 1
+- assert data.bonds[a, b]['order'] == 2
+- assert data.bonds[a, b]['stereo'] == 0
+
+### test_to_mol_block_fallback_handles_float_bond_order
+_Aromatic 1.5 bond order must map to V2000 code 4, not crash on '{:d}'._
+
+- assert mol_block is not None
+- assert bond_line[:12] == f'{1:3d}{2:3d}{4:3d}{0:3d}'
+
+### test_to_mol_block_fallback_skips_positionless_atoms_consistently
+_Atoms without a position are excluded from counts and bond indices._
+
+- assert mol_block is not None
+- assert counts[:6] == f'{2:3d}{1:3d}'
+- assert 'O' in atom_lines[0] and 'N' in atom_lines[1]
+- assert bond_line[:6] == f'{1:3d}{2:3d}'
 
 ## tests/unit/test_molecule_scene_behavior.py
 
@@ -4751,6 +4799,24 @@ _invoke_document_reset_handlers logs an error when a handler raises._
 _get_plugin_info_safe returns Unknown version for non-constant AST nodes and OSError._
 
 - assert info['version'] == 'Unknown'
+
+### test_install_zip_single_file_gets_wrapper_folder
+_A ZIP whose only entry is one top-level .py file is a flat ZIP:_
+
+- assert success
+- assert (plugin_dir / 'solo' / 'myplugin.py').exists()
+- assert not (plugin_dir / 'myplugin.py').exists()
+
+### test_install_zip_single_folder_stays_nested
+_A ZIP with one top-level folder still extracts directly (Case A)._
+
+- assert success
+- assert (plugin_dir / 'MyPlugin' / '__init__.py').exists()
+
+### test_discover_plugins_skips_dot_directories
+_Plugins inside hidden directories like .git must not be loaded._
+
+- assert all((p['name'] != 'Sneaky' for p in plugins))
 
 ## tests/unit/test_plugin_manager_window.py
 
@@ -6154,8 +6220,13 @@ _OSError in winreg must be suppressed and return None._
 
 - assert detect_system_theme() is None
 
-### TestMacOSTheme.test_macos_always_light
-_macOS always returns light theme._
+### TestMacOSTheme.test_macos_dark_mode
+_AppleInterfaceStyle == Dark -> dark theme._
+
+- assert detect_system_theme() == 'dark'
+
+### TestMacOSTheme.test_macos_light_mode
+_Missing AppleInterfaceStyle key (non-zero exit) -> light theme._
 
 - assert detect_system_theme() == 'light'
 

--- a/tests/assertion_catalog.md
+++ b/tests/assertion_catalog.md
@@ -2204,6 +2204,13 @@ __clear_xyz_flags(mol=None) uses the current_mol from the view manager._
 __clear_xyz_flags does not raise when reset_zoom is absent._
 
 
+### test_push_undo_state_caps_stack_depth
+_The undo stack drops its oldest entries beyond UNDO_STACK_MAX_DEPTH._
+
+- assert len(mgr.undo_stack) == UNDO_STACK_MAX_DEPTH
+- assert mgr.undo_stack[-1]['_next_atom_id'] == UNDO_STACK_MAX_DEPTH + 24
+- assert mgr.undo_stack[0]['_next_atom_id'] == 25
+
 ## tests/unit/test_export_logic.py
 
 ### test_create_multi_material_obj_advanced

--- a/tests/coverage_report.md
+++ b/tests/coverage_report.md
@@ -1,17 +1,17 @@
 # MoleditPy Coverage Report
 
-- **Overall Project Coverage**: **82.36%**
+- **Overall Project Coverage**: **82.40%**
 
 ### Coverage Breakdown
 
 | File | Stmts | Miss | Cover |
 | :--- | :--- | :--- | :--- |
 | moleditpy\src\moleditpy\__init__.py                     |      6 |      2 |   66.7% |
-| moleditpy\src\moleditpy\main.py                         |    112 |     33 |   70.5% |
-| moleditpy\src\moleditpy\core\mol_geometry.py            |    260 |     19 |   92.7% |
-| moleditpy\src\moleditpy\core\molecular_data.py          |    245 |     29 |   88.2% |
+| moleditpy\src\moleditpy\main.py                         |    113 |     33 |   70.8% |
+| moleditpy\src\moleditpy\core\mol_geometry.py            |    262 |     20 |   92.4% |
+| moleditpy\src\moleditpy\core\molecular_data.py          |    258 |     29 |   88.8% |
 | moleditpy\src\moleditpy\plugins\plugin_interface.py     |    233 |      6 |   97.4% |
-| moleditpy\src\moleditpy\plugins\plugin_manager.py       |    374 |     10 |   97.3% |
+| moleditpy\src\moleditpy\plugins\plugin_manager.py       |    375 |      8 |   97.9% |
 | moleditpy\src\moleditpy\plugins\plugin_manager_window.py |    186 |      2 |   98.9% |
 | moleditpy\src\moleditpy\ui\__init__.py                  |      7 |      3 |   57.1% |
 | moleditpy\src\moleditpy\ui\about_dialog.py              |     64 |     13 |   79.7% |
@@ -25,7 +25,7 @@
 | moleditpy\src\moleditpy\ui\base_picking_dialog.py       |     80 |      4 |   95.0% |
 | moleditpy\src\moleditpy\ui\bond_item.py                 |    362 |     56 |   84.5% |
 | moleditpy\src\moleditpy\ui\bond_length_dialog.py        |    237 |     17 |   92.8% |
-| moleditpy\src\moleditpy\ui\calculation_worker.py        |    581 |    102 |   82.4% |
+| moleditpy\src\moleditpy\ui\calculation_worker.py        |    582 |    102 |   82.5% |
 | moleditpy\src\moleditpy\ui\color_settings_dialog.py     |    166 |     13 |   92.2% |
 | moleditpy\src\moleditpy\ui\compute_logic.py             |    387 |     89 |   77.0% |
 | moleditpy\src\moleditpy\ui\constrained_optimization_dialog.py |    472 |    120 |   74.6% |
@@ -38,12 +38,12 @@
 | moleditpy\src\moleditpy\ui\edit_actions_logic.py        |    813 |    199 |   75.5% |
 | moleditpy\src\moleditpy\ui\export_logic.py              |    520 |    153 |   70.6% |
 | moleditpy\src\moleditpy\ui\geometry_base_dialog.py      |     51 |      1 |   98.0% |
-| moleditpy\src\moleditpy\ui\io_logic.py                  |    657 |    118 |   82.0% |
+| moleditpy\src\moleditpy\ui\io_logic.py                  |    673 |    119 |   82.3% |
 | moleditpy\src\moleditpy\ui\main_window.py               |    196 |     14 |   92.9% |
 | moleditpy\src\moleditpy\ui\main_window_init.py          |   1052 |    112 |   89.4% |
 | moleditpy\src\moleditpy\ui\mirror_dialog.py             |     72 |      7 |   90.3% |
 | moleditpy\src\moleditpy\ui\molecular_scene_handler.py   |    952 |    161 |   83.1% |
-| moleditpy\src\moleditpy\ui\molecule_scene.py            |    614 |    126 |   79.5% |
+| moleditpy\src\moleditpy\ui\molecule_scene.py            |    614 |    128 |   79.2% |
 | moleditpy\src\moleditpy\ui\move_group_dialog.py         |    386 |    130 |   66.3% |
 | moleditpy\src\moleditpy\ui\move_selected_atoms_dialog.py |    461 |     75 |   83.7% |
 | moleditpy\src\moleditpy\ui\periodic_table_dialog.py     |     37 |      2 |   94.6% |
@@ -54,7 +54,7 @@
 | moleditpy\src\moleditpy\ui\template_preview_item.py     |    102 |      3 |   97.1% |
 | moleditpy\src\moleditpy\ui\template_preview_view.py     |     46 |      4 |   91.3% |
 | moleditpy\src\moleditpy\ui\translation_dialog.py        |    276 |     21 |   92.4% |
-| moleditpy\src\moleditpy\ui\ui_manager.py                |    368 |    100 |   72.8% |
+| moleditpy\src\moleditpy\ui\ui_manager.py                |    368 |     98 |   73.4% |
 | moleditpy\src\moleditpy\ui\user_template_dialog.py      |    360 |     79 |   78.1% |
 | moleditpy\src\moleditpy\ui\view_3d_logic.py             |   1007 |    259 |   74.3% |
 | moleditpy\src\moleditpy\ui\zoomable_view.py             |     81 |      2 |   97.5% |
@@ -62,11 +62,11 @@
 | moleditpy\src\moleditpy\ui\settings_tabs\settings_3d_tabs.py |    142 |      0 |  100.0% |
 | moleditpy\src\moleditpy\ui\settings_tabs\settings_other_tab.py |     89 |      0 |  100.0% |
 | moleditpy\src\moleditpy\ui\settings_tabs\settings_tab_base.py |     56 |      0 |  100.0% |
-| moleditpy\src\moleditpy\utils\constants.py              |     55 |      0 |  100.0% |
+| moleditpy\src\moleditpy\utils\constants.py              |     56 |      0 |  100.0% |
 | moleditpy\src\moleditpy\utils\default_settings.py       |      1 |      0 |  100.0% |
 | moleditpy\src\moleditpy\utils\sip_isdeleted_safe.py     |     19 |      0 |  100.0% |
-| moleditpy\src\moleditpy\utils\system_utils.py           |     36 |      0 |  100.0% |
-| **TOTAL** | **15822** | **2791** | **82.36%** |
+| moleditpy\src\moleditpy\utils\system_utils.py           |     39 |      0 |  100.0% |
+| **TOTAL** | **15860** | **2791** | **82.40%** |
 
 ## Test Suite Status
 - **Unit tests**: PASSED

--- a/tests/coverage_report.md
+++ b/tests/coverage_report.md
@@ -1,13 +1,13 @@
 # MoleditPy Coverage Report
 
-- **Overall Project Coverage**: **82.40%**
+- **Overall Project Coverage**: **82.49%**
 
 ### Coverage Breakdown
 
 | File | Stmts | Miss | Cover |
 | :--- | :--- | :--- | :--- |
 | moleditpy\src\moleditpy\__init__.py                     |      6 |      2 |   66.7% |
-| moleditpy\src\moleditpy\main.py                         |    113 |     33 |   70.8% |
+| moleditpy\src\moleditpy\main.py                         |    114 |     33 |   71.1% |
 | moleditpy\src\moleditpy\core\mol_geometry.py            |    262 |     20 |   92.4% |
 | moleditpy\src\moleditpy\core\molecular_data.py          |    258 |     29 |   88.8% |
 | moleditpy\src\moleditpy\plugins\plugin_interface.py     |    233 |      6 |   97.4% |
@@ -23,11 +23,11 @@
 | moleditpy\src\moleditpy\ui\atom_item.py                 |    324 |     39 |   88.0% |
 | moleditpy\src\moleditpy\ui\atom_picking.py              |    167 |     44 |   73.7% |
 | moleditpy\src\moleditpy\ui\base_picking_dialog.py       |     80 |      4 |   95.0% |
-| moleditpy\src\moleditpy\ui\bond_item.py                 |    362 |     56 |   84.5% |
+| moleditpy\src\moleditpy\ui\bond_item.py                 |    366 |     56 |   84.7% |
 | moleditpy\src\moleditpy\ui\bond_length_dialog.py        |    237 |     17 |   92.8% |
 | moleditpy\src\moleditpy\ui\calculation_worker.py        |    582 |    102 |   82.5% |
-| moleditpy\src\moleditpy\ui\color_settings_dialog.py     |    166 |     13 |   92.2% |
-| moleditpy\src\moleditpy\ui\compute_logic.py             |    387 |     89 |   77.0% |
+| moleditpy\src\moleditpy\ui\color_settings_dialog.py     |    165 |     13 |   92.1% |
+| moleditpy\src\moleditpy\ui\compute_logic.py             |    391 |     89 |   77.2% |
 | moleditpy\src\moleditpy\ui\constrained_optimization_dialog.py |    472 |    120 |   74.6% |
 | moleditpy\src\moleditpy\ui\custom_interactor_style.py   |    470 |    247 |   47.4% |
 | moleditpy\src\moleditpy\ui\custom_qt_interactor.py      |     44 |     35 |   20.5% |
@@ -35,14 +35,14 @@
 | moleditpy\src\moleditpy\ui\dialog_logic.py              |    229 |     25 |   89.1% |
 | moleditpy\src\moleditpy\ui\dihedral_dialog.py           |    267 |     32 |   88.0% |
 | moleditpy\src\moleditpy\ui\edit_3d_logic.py             |    220 |     32 |   85.5% |
-| moleditpy\src\moleditpy\ui\edit_actions_logic.py        |    813 |    199 |   75.5% |
+| moleditpy\src\moleditpy\ui\edit_actions_logic.py        |    815 |    199 |   75.6% |
 | moleditpy\src\moleditpy\ui\export_logic.py              |    520 |    153 |   70.6% |
 | moleditpy\src\moleditpy\ui\geometry_base_dialog.py      |     51 |      1 |   98.0% |
-| moleditpy\src\moleditpy\ui\io_logic.py                  |    673 |    119 |   82.3% |
-| moleditpy\src\moleditpy\ui\main_window.py               |    196 |     14 |   92.9% |
-| moleditpy\src\moleditpy\ui\main_window_init.py          |   1052 |    112 |   89.4% |
+| moleditpy\src\moleditpy\ui\io_logic.py                  |    681 |    119 |   82.5% |
+| moleditpy\src\moleditpy\ui\main_window.py               |    195 |     14 |   92.8% |
+| moleditpy\src\moleditpy\ui\main_window_init.py          |   1045 |    107 |   89.8% |
 | moleditpy\src\moleditpy\ui\mirror_dialog.py             |     72 |      7 |   90.3% |
-| moleditpy\src\moleditpy\ui\molecular_scene_handler.py   |    952 |    161 |   83.1% |
+| moleditpy\src\moleditpy\ui\molecular_scene_handler.py   |    997 |    161 |   83.9% |
 | moleditpy\src\moleditpy\ui\molecule_scene.py            |    614 |    128 |   79.2% |
 | moleditpy\src\moleditpy\ui\move_group_dialog.py         |    386 |    130 |   66.3% |
 | moleditpy\src\moleditpy\ui\move_selected_atoms_dialog.py |    461 |     75 |   83.7% |
@@ -54,19 +54,19 @@
 | moleditpy\src\moleditpy\ui\template_preview_item.py     |    102 |      3 |   97.1% |
 | moleditpy\src\moleditpy\ui\template_preview_view.py     |     46 |      4 |   91.3% |
 | moleditpy\src\moleditpy\ui\translation_dialog.py        |    276 |     21 |   92.4% |
-| moleditpy\src\moleditpy\ui\ui_manager.py                |    368 |     98 |   73.4% |
+| moleditpy\src\moleditpy\ui\ui_manager.py                |    368 |    100 |   72.8% |
 | moleditpy\src\moleditpy\ui\user_template_dialog.py      |    360 |     79 |   78.1% |
 | moleditpy\src\moleditpy\ui\view_3d_logic.py             |   1007 |    259 |   74.3% |
-| moleditpy\src\moleditpy\ui\zoomable_view.py             |     81 |      2 |   97.5% |
+| moleditpy\src\moleditpy\ui\zoomable_view.py             |     82 |      2 |   97.6% |
 | moleditpy\src\moleditpy\ui\settings_tabs\settings_2d_tab.py |    144 |      0 |  100.0% |
 | moleditpy\src\moleditpy\ui\settings_tabs\settings_3d_tabs.py |    142 |      0 |  100.0% |
 | moleditpy\src\moleditpy\ui\settings_tabs\settings_other_tab.py |     89 |      0 |  100.0% |
-| moleditpy\src\moleditpy\ui\settings_tabs\settings_tab_base.py |     56 |      0 |  100.0% |
-| moleditpy\src\moleditpy\utils\constants.py              |     56 |      0 |  100.0% |
+| moleditpy\src\moleditpy\ui\settings_tabs\settings_tab_base.py |     57 |      0 |  100.0% |
+| moleditpy\src\moleditpy\utils\constants.py              |     57 |      0 |  100.0% |
 | moleditpy\src\moleditpy\utils\default_settings.py       |      1 |      0 |  100.0% |
 | moleditpy\src\moleditpy\utils\sip_isdeleted_safe.py     |     19 |      0 |  100.0% |
 | moleditpy\src\moleditpy\utils\system_utils.py           |     39 |      0 |  100.0% |
-| **TOTAL** | **15860** | **2791** | **82.40%** |
+| **TOTAL** | **15918** | **2788** | **82.49%** |
 
 ## Test Suite Status
 - **Unit tests**: PASSED

--- a/tests/coverage_report.md
+++ b/tests/coverage_report.md
@@ -1,6 +1,6 @@
 # MoleditPy Coverage Report
 
-- **Overall Project Coverage**: **82.49%**
+- **Overall Project Coverage**: **82.64%**
 
 ### Coverage Breakdown
 
@@ -9,7 +9,7 @@
 | moleditpy\src\moleditpy\__init__.py                     |      6 |      2 |   66.7% |
 | moleditpy\src\moleditpy\main.py                         |    114 |     33 |   71.1% |
 | moleditpy\src\moleditpy\core\mol_geometry.py            |    262 |     20 |   92.4% |
-| moleditpy\src\moleditpy\core\molecular_data.py          |    258 |     29 |   88.8% |
+| moleditpy\src\moleditpy\core\molecular_data.py          |    258 |     28 |   89.1% |
 | moleditpy\src\moleditpy\plugins\plugin_interface.py     |    233 |      6 |   97.4% |
 | moleditpy\src\moleditpy\plugins\plugin_manager.py       |    375 |      8 |   97.9% |
 | moleditpy\src\moleditpy\plugins\plugin_manager_window.py |    186 |      2 |   98.9% |
@@ -19,7 +19,7 @@
 | moleditpy\src\moleditpy\ui\alignment_dialog.py          |    148 |     11 |   92.6% |
 | moleditpy\src\moleditpy\ui\analysis_window.py           |    117 |     25 |   78.6% |
 | moleditpy\src\moleditpy\ui\angle_dialog.py              |    263 |     28 |   89.4% |
-| moleditpy\src\moleditpy\ui\app_state.py                 |    334 |     68 |   79.6% |
+| moleditpy\src\moleditpy\ui\app_state.py                 |    334 |     62 |   81.4% |
 | moleditpy\src\moleditpy\ui\atom_item.py                 |    324 |     39 |   88.0% |
 | moleditpy\src\moleditpy\ui\atom_picking.py              |    167 |     44 |   73.7% |
 | moleditpy\src\moleditpy\ui\base_picking_dialog.py       |     80 |      4 |   95.0% |
@@ -38,12 +38,12 @@
 | moleditpy\src\moleditpy\ui\edit_actions_logic.py        |    815 |    199 |   75.6% |
 | moleditpy\src\moleditpy\ui\export_logic.py              |    520 |    153 |   70.6% |
 | moleditpy\src\moleditpy\ui\geometry_base_dialog.py      |     51 |      1 |   98.0% |
-| moleditpy\src\moleditpy\ui\io_logic.py                  |    681 |    119 |   82.5% |
+| moleditpy\src\moleditpy\ui\io_logic.py                  |    681 |    113 |   83.4% |
 | moleditpy\src\moleditpy\ui\main_window.py               |    195 |     14 |   92.8% |
 | moleditpy\src\moleditpy\ui\main_window_init.py          |   1045 |    107 |   89.8% |
 | moleditpy\src\moleditpy\ui\mirror_dialog.py             |     72 |      7 |   90.3% |
 | moleditpy\src\moleditpy\ui\molecular_scene_handler.py   |    997 |    161 |   83.9% |
-| moleditpy\src\moleditpy\ui\molecule_scene.py            |    614 |    128 |   79.2% |
+| moleditpy\src\moleditpy\ui\molecule_scene.py            |    614 |    118 |   80.8% |
 | moleditpy\src\moleditpy\ui\move_group_dialog.py         |    386 |    130 |   66.3% |
 | moleditpy\src\moleditpy\ui\move_selected_atoms_dialog.py |    461 |     75 |   83.7% |
 | moleditpy\src\moleditpy\ui\periodic_table_dialog.py     |     37 |      2 |   94.6% |
@@ -54,7 +54,7 @@
 | moleditpy\src\moleditpy\ui\template_preview_item.py     |    102 |      3 |   97.1% |
 | moleditpy\src\moleditpy\ui\template_preview_view.py     |     46 |      4 |   91.3% |
 | moleditpy\src\moleditpy\ui\translation_dialog.py        |    276 |     21 |   92.4% |
-| moleditpy\src\moleditpy\ui\ui_manager.py                |    368 |    100 |   72.8% |
+| moleditpy\src\moleditpy\ui\ui_manager.py                |    368 |     98 |   73.4% |
 | moleditpy\src\moleditpy\ui\user_template_dialog.py      |    360 |     79 |   78.1% |
 | moleditpy\src\moleditpy\ui\view_3d_logic.py             |   1007 |    259 |   74.3% |
 | moleditpy\src\moleditpy\ui\zoomable_view.py             |     82 |      2 |   97.6% |
@@ -66,7 +66,7 @@
 | moleditpy\src\moleditpy\utils\default_settings.py       |      1 |      0 |  100.0% |
 | moleditpy\src\moleditpy\utils\sip_isdeleted_safe.py     |     19 |      0 |  100.0% |
 | moleditpy\src\moleditpy\utils\system_utils.py           |     39 |      0 |  100.0% |
-| **TOTAL** | **15918** | **2788** | **82.49%** |
+| **TOTAL** | **15918** | **2763** | **82.64%** |
 
 ## Test Suite Status
 - **Unit tests**: PASSED

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -80,3 +80,13 @@ Ethane (2 C, 1 bond) is the minimal molecule that exercises the full
 - **pytest-qt** — `qtbot` fixture (used to satisfy the `app` fixture dependency)
 - **Open Babel** *(optional)* — required only for `test_ethane_conversion_obabel`;
   the test is automatically skipped when absent
+
+## Workflow Test Files (added 2026-07)
+
+| File | Covers |
+|---|---|
+| `test_project_roundtrip.py` | .pmeprj / .pmeraw save→clear→load round-trips, Save-As extension, unsaved-changes prompt |
+| `test_export_files.py` | 2D MOL, 3D MOL, XYZ export — extension appending + RDKit re-parse validation |
+| `test_import_workflows.py` | SMILES / MOL-file / XYZ import, invalid-input safety, 3D viewer mode switch |
+| `test_undo_redo_workflow.py` | draw→undo→redo cycles, bond-data restoration, undo history depth cap |
+| `test_plugin_workflow.py` | real PluginManager install/discover (.py and single-file ZIP), plugin state persistence through project save/load |

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -150,6 +150,9 @@ class _DummyPlotterBase:
     def reset_camera(self):
         pass
 
+    def view_isometric(self):
+        pass
+
     def add_light(self, *a, **k):
         return _mock.MagicMock()
 
@@ -255,6 +258,9 @@ def window(app, qtbot, monkeypatch):
             self.custom_3d_styles = {}
             self.document_reset_handlers = []
 
+        def invoke_document_reset_handlers(self):
+            pass
+
         def discover_plugins(self, parent=None):
             return []
 
@@ -283,6 +289,7 @@ def window(app, qtbot, monkeypatch):
             self.add_point_labels = _mock.MagicMock(return_value=["labels"])
             self.clear = _mock.MagicMock()
             self.reset_camera = _mock.MagicMock()
+            self.view_isometric = _mock.MagicMock()
             self.render = _mock.MagicMock()
             self.set_background = _mock.MagicMock()
             self.setAcceptDrops = _mock.MagicMock()

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -233,9 +233,17 @@ def app():
 
 
 @pytest.fixture
-def window(app, qtbot, monkeypatch):
+def window(app, qtbot, monkeypatch, tmp_path):
     """Real MainWindow, headless, using the platform-appropriate package."""
     from PyQt6.QtWidgets import QWidget, QMessageBox, QFileDialog
+
+    # Sandbox the home dir so tests never read/write the real ~/.moleditpy
+    # (settings.json, plugins). MainInitManager and PluginManager both build
+    # their paths from expanduser("~").
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    monkeypatch.setenv("HOME", str(fake_home))
+    monkeypatch.setenv("USERPROFILE", str(fake_home))
 
     monkeypatch.setattr(
         f"{_PKG}.ui.main_window_init.MainInitManager.init_worker_thread",

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -195,7 +195,7 @@ pyv.Box = _mock.MagicMock
 pvqt.BackgroundPlotter = _DummyPlotterBase
 
 # QtInteractor must be a QWidget subclass so it can be embedded in the splitter
-from PyQt6.QtWidgets import QWidget as _QWidget
+from PyQt6.QtWidgets import QWidget as _QWidget  # noqa: E402
 
 
 class _DummyQtInteractor(_QWidget):

--- a/tests/e2e/test_ethane_gui.py
+++ b/tests/e2e/test_ethane_gui.py
@@ -10,7 +10,6 @@ operation) and interact with it the same way a user would:
 The conversion uses real RDKit embedding + MMFF optimisation — no mocked results.
 """
 
-import sys
 import platform
 import pytest
 import numpy as np

--- a/tests/e2e/test_export_files.py
+++ b/tests/e2e/test_export_files.py
@@ -1,0 +1,100 @@
+# -*- coding: utf-8 -*-
+"""E2E file export tests: 2D MOL, 3D MOL, and XYZ through the real IOManager.
+
+Each test drives the real save function with the file dialog patched to a
+tmp_path target (with NO extension, to also cover extension appending), then
+re-reads the produced file with RDKit / plain parsing to prove it is valid.
+"""
+
+import importlib.util
+
+import pytest
+from PyQt6.QtCore import QPointF, Qt
+from rdkit import Chem
+
+_PKG = (
+    "moleditpy_linux"
+    if importlib.util.find_spec("moleditpy_linux") is not None
+    else "moleditpy"
+)
+
+
+def _draw_ethane(window):
+    scene = window.init_manager.scene
+    c1 = scene.create_atom("C", QPointF(0, 0))
+    c2 = scene.create_atom("C", QPointF(50, 0))
+    scene.create_bond(scene.atom_items[c1], scene.atom_items[c2])
+    return c1, c2
+
+
+def _convert_to_3d(window, qtbot):
+    qtbot.mouseClick(window.init_manager.convert_button, Qt.MouseButton.LeftButton)
+    qtbot.waitUntil(
+        lambda: window.view_3d_manager.current_mol is not None, timeout=5000
+    )
+
+
+def _patch_save_dialog(monkeypatch, target):
+    monkeypatch.setattr(
+        f"{_PKG}.ui.io_logic.QFileDialog.getSaveFileName",
+        lambda *a, **k: (str(target), None),
+        raising=True,
+    )
+
+
+@pytest.mark.gui
+def test_save_as_mol_2d(window, tmp_path, monkeypatch):
+    """2D MOL export appends .mol, is RDKit-parseable, and carries the header."""
+    _draw_ethane(window)
+    _patch_save_dialog(monkeypatch, tmp_path / "out")
+
+    window.io_manager.save_as_mol()
+
+    saved = tmp_path / "out.mol"
+    assert saved.exists()
+    text = saved.read_text(encoding="utf-8")
+    assert "MoleditPy" in text
+    mol = Chem.MolFromMolFile(str(saved))
+    assert mol is not None
+    assert sum(1 for a in mol.GetAtoms() if a.GetSymbol() == "C") == 2
+
+
+@pytest.mark.gui
+def test_save_3d_as_mol_appends_extension(window, qtbot, tmp_path, monkeypatch):
+    """3D MOL export appends .mol and produces a parseable 3D structure."""
+    _draw_ethane(window)
+    _convert_to_3d(window, qtbot)
+    _patch_save_dialog(monkeypatch, tmp_path / "bare_name")
+
+    window.io_manager.save_3d_as_mol()
+
+    saved = tmp_path / "bare_name.mol"
+    assert saved.exists()
+    mol = Chem.MolFromMolFile(str(saved), removeHs=False)
+    assert mol is not None
+    assert mol.GetNumConformers() == 1
+    conf = mol.GetConformer()
+    zs = [abs(conf.GetAtomPosition(i).z) for i in range(mol.GetNumAtoms())]
+    assert any(z > 1e-4 for z in zs), "expected non-planar 3D coordinates"
+
+
+@pytest.mark.gui
+def test_save_as_xyz(window, qtbot, tmp_path, monkeypatch):
+    """XYZ export appends .xyz with count, chrg/mult comment, and 4-field rows."""
+    _draw_ethane(window)
+    _convert_to_3d(window, qtbot)
+    _patch_save_dialog(monkeypatch, tmp_path / "structure")
+
+    window.io_manager.save_as_xyz()
+
+    saved = tmp_path / "structure.xyz"
+    assert saved.exists()
+    lines = saved.read_text(encoding="utf-8").strip().splitlines()
+    num_atoms = int(lines[0])
+    assert num_atoms == window.view_3d_manager.current_mol.GetNumAtoms()
+    assert "chrg =" in lines[1] and "mult =" in lines[1]
+    assert len(lines) == 2 + num_atoms
+    for row in lines[2:]:
+        parts = row.split()
+        assert len(parts) == 4
+        float(parts[1]), float(parts[2]), float(parts[3])  # coordinates parse

--- a/tests/e2e/test_import_workflows.py
+++ b/tests/e2e/test_import_workflows.py
@@ -1,0 +1,89 @@
+# -*- coding: utf-8 -*-
+"""E2E import workflow tests: SMILES, MOL file, and XYZ through the real app.
+
+Each test uses the real importer managers on a live MainWindow and asserts
+the resulting document state (2D scene data or 3D viewer mode).
+"""
+
+import importlib.util
+
+import pytest
+from PyQt6.QtWidgets import QMessageBox
+from rdkit import Chem
+from rdkit.Chem import AllChem
+
+_PKG = (
+    "moleditpy_linux"
+    if importlib.util.find_spec("moleditpy_linux") is not None
+    else "moleditpy"
+)
+
+WATER_XYZ = """3
+water test
+O    0.000000    0.000000    0.117300
+H    0.000000    0.757200   -0.469200
+H    0.000000   -0.757200   -0.469200
+"""
+
+
+@pytest.mark.gui
+def test_smiles_import_creates_scene_atoms(window, qtbot):
+    """Importing ethanol SMILES adds 3 heavy atoms and 2 bonds to the 2D data."""
+    window.string_importer_manager.load_from_smiles("CCO")
+    qtbot.wait(150)  # drain deferred fit_to_view timer while window is alive
+
+    assert len(window.data.atoms) == 3
+    assert len(window.data.bonds) == 2
+    symbols = sorted(d["symbol"] for d in window.data.atoms.values())
+    assert symbols == ["C", "C", "O"]
+    assert window.state_manager.has_unsaved_changes is True
+
+
+@pytest.mark.gui
+def test_invalid_smiles_does_not_crash_or_modify(window):
+    """An invalid SMILES leaves the document untouched and raises nothing."""
+    window.string_importer_manager.load_from_smiles("not_a_smiles((")
+
+    assert len(window.data.atoms) == 0
+    assert len(window.data.bonds) == 0
+
+
+@pytest.mark.gui
+def test_mol_file_import(window, qtbot, tmp_path):
+    """Importing a benzene MOL file yields 6 kekulized ring atoms and bonds."""
+    mol = Chem.MolFromSmiles("c1ccccc1")
+    AllChem.Compute2DCoords(mol)
+    path = tmp_path / "benzene.mol"
+    path.write_text(Chem.MolToMolBlock(mol), encoding="utf-8")
+
+    window.io_manager.load_mol_file(str(path))
+    qtbot.wait(150)  # drain deferred fit_to_view timer while window is alive
+
+    assert len(window.data.atoms) == 6
+    assert len(window.data.bonds) == 6
+    orders = sorted(b["order"] for b in window.data.bonds.values())
+    assert orders == [1, 1, 1, 2, 2, 2]  # kekulized benzene
+
+
+@pytest.mark.gui
+def test_xyz_load_enters_viewer_mode(window, qtbot, tmp_path, monkeypatch):
+    """Loading an XYZ file produces a 3-atom 3D mol and switches to viewer mode."""
+    path = tmp_path / "water.xyz"
+    path.write_text(WATER_XYZ, encoding="utf-8")
+
+    # Avoid both the unsaved-changes prompt and the charge dialog
+    monkeypatch.setattr(
+        f"{_PKG}.ui.app_state.QMessageBox.question",
+        lambda *a, **k: QMessageBox.StandardButton.No,
+        raising=True,
+    )
+    window.init_manager.settings["skip_chemistry_checks"] = True
+
+    window.io_manager.load_xyz_for_3d_viewing(str(path))
+    qtbot.wait(200)
+
+    mol = window.view_3d_manager.current_mol
+    assert mol is not None
+    assert mol.GetNumAtoms() == 3
+    assert sorted(a.GetSymbol() for a in mol.GetAtoms()) == ["H", "H", "O"]
+    assert window.ui_manager.is_2d_editable is False

--- a/tests/e2e/test_plugin_workflow.py
+++ b/tests/e2e/test_plugin_workflow.py
@@ -1,0 +1,101 @@
+# -*- coding: utf-8 -*-
+"""E2E plugin workflow tests using the REAL PluginManager.
+
+Covers install -> discover -> initialize for .py and .zip plugins against a
+temporary plugin directory, and plugin state persistence through the project
+save/load cycle on a live MainWindow.
+"""
+
+import importlib
+import importlib.util
+import textwrap
+import zipfile
+
+import pytest
+
+_PKG = (
+    "moleditpy_linux"
+    if importlib.util.find_spec("moleditpy_linux") is not None
+    else "moleditpy"
+)
+PluginManager = importlib.import_module(f"{_PKG}.plugins.plugin_manager").PluginManager
+
+PLUGIN_SRC = textwrap.dedent(
+    """\
+    PLUGIN_NAME = "E2E Test Plugin"
+    PLUGIN_VERSION = "1.0"
+
+    def initialize(context):
+        context.add_menu_action("E2E/Test", lambda: None, text="E2E Action")
+    """
+)
+
+
+def _make_pm(tmp_path):
+    pm = PluginManager(main_window=None)
+    pm.plugin_dir = str(tmp_path / "plugins")
+    return pm
+
+
+def test_install_and_discover_py_plugin(tmp_path):
+    """A .py plugin installs, loads, and registers its menu action."""
+    src = tmp_path / "e2e_plugin.py"
+    src.write_text(PLUGIN_SRC, encoding="utf-8")
+
+    pm = _make_pm(tmp_path)
+    ok, msg = pm.install_plugin(str(src))
+    assert ok, msg
+
+    plugins = pm.discover_plugins()
+    match = [p for p in plugins if p["name"] == "E2E Test Plugin"]
+    assert len(match) == 1
+    assert match[0]["status"] == "Loaded"
+    assert match[0]["version"] == "1.0"
+    assert any(a["path"] == "E2E/Test" for a in pm.menu_actions)
+
+
+def test_zip_single_file_install_gets_wrapper_folder(tmp_path):
+    """A ZIP containing only one .py file extracts into a wrapper folder."""
+    zip_path = tmp_path / "soloplugin.zip"
+    with zipfile.ZipFile(zip_path, "w") as zf:
+        zf.writestr("solo.py", PLUGIN_SRC)
+
+    pm = _make_pm(tmp_path)
+    ok, msg = pm.install_plugin(str(zip_path))
+    assert ok, msg
+
+    extracted = tmp_path / "plugins" / "soloplugin" / "solo.py"
+    assert extracted.exists()
+    plugins = pm.discover_plugins()
+    assert any(p["name"] == "E2E Test Plugin" for p in plugins)
+
+
+@pytest.mark.gui
+def test_plugin_state_persists_through_project_save_load(window):
+    """Plugin save/load handlers round-trip data through create/load_json_data."""
+    pm = PluginManager(main_window=window)
+    window.plugin_manager = pm
+
+    received = {}
+    pm.register_save_handler("StatefulPlugin", lambda: {"counter": 42})
+    pm.register_load_handler("StatefulPlugin", received.update)
+
+    json_data = window.state_manager.create_json_data()
+    assert json_data["plugins"]["StatefulPlugin"] == {"counter": 42}
+
+    window.state_manager.load_from_json_data(json_data)
+    assert received == {"counter": 42}
+
+
+@pytest.mark.gui
+def test_missing_plugin_state_preserved_on_resave(window):
+    """State from an absent plugin survives a load + save cycle unchanged."""
+    pm = PluginManager(main_window=window)
+    window.plugin_manager = pm
+
+    json_data = window.state_manager.create_json_data()
+    json_data["plugins"] = {"AbsentPlugin": {"keep": "me"}}
+
+    window.state_manager.load_from_json_data(json_data)  # no handler registered
+    resaved = window.state_manager.create_json_data()
+    assert resaved["plugins"]["AbsentPlugin"] == {"keep": "me"}

--- a/tests/e2e/test_project_roundtrip.py
+++ b/tests/e2e/test_project_roundtrip.py
@@ -1,0 +1,157 @@
+# -*- coding: utf-8 -*-
+"""E2E project save/load round-trip tests: real MainWindow, real IOManager.
+
+Covers the .pmeprj (JSON) and .pmeraw (pickle) project formats end-to-end:
+draw -> save -> clear -> load -> verify nothing is lost, plus the
+unsaved-changes prompt and Save-As extension handling.
+"""
+
+import importlib.util
+import json
+
+import pytest
+from PyQt6.QtCore import QPointF
+from PyQt6.QtWidgets import QMessageBox
+
+_PKG = (
+    "moleditpy_linux"
+    if importlib.util.find_spec("moleditpy_linux") is not None
+    else "moleditpy"
+)
+
+
+def _draw_ethanol_like(window):
+    """Draw a small 3-atom test molecule (C-C-O with a double bond)."""
+    scene = window.init_manager.scene
+    c1 = scene.create_atom("C", QPointF(0, 0))
+    c2 = scene.create_atom("C", QPointF(50, 0))
+    o1 = scene.create_atom("O", QPointF(100, 0))
+    scene.create_bond(scene.atom_items[c1], scene.atom_items[c2], bond_order=1)
+    scene.create_bond(scene.atom_items[c2], scene.atom_items[o1], bond_order=2)
+    return c1, c2, o1
+
+
+def _snapshot(window):
+    atoms = {
+        aid: (d["symbol"], d.get("charge", 0), tuple(d["pos"]))
+        for aid, d in window.data.atoms.items()
+    }
+    bonds = {
+        tuple(sorted(k)): (v["order"], v.get("stereo", 0))
+        for k, v in window.data.bonds.items()
+    }
+    return atoms, bonds, window.data.next_atom_id
+
+
+def _patch_unsaved_prompt(monkeypatch, button):
+    monkeypatch.setattr(
+        f"{_PKG}.ui.app_state.QMessageBox.question",
+        lambda *a, **k: button,
+        raising=True,
+    )
+
+
+@pytest.mark.gui
+def test_pmeprj_roundtrip(window, qtbot, tmp_path, monkeypatch):
+    """Draw -> serialize -> clear -> load .pmeprj -> identical document."""
+    _draw_ethanol_like(window)
+    atoms_before, bonds_before, next_id_before = _snapshot(window)
+
+    json_data = window.state_manager.create_json_data()
+    path = tmp_path / "roundtrip.pmeprj"
+    path.write_text(json.dumps(json_data), encoding="utf-8")
+
+    window.edit_actions_manager.clear_all(skip_check=True)
+    assert window.data.atoms == {}
+
+    _patch_unsaved_prompt(monkeypatch, QMessageBox.StandardButton.No)
+    window.io_manager.open_project_file(str(path))
+    qtbot.wait(200)  # let deferred QTimer plotter calls fire (None-guarded)
+
+    atoms_after, bonds_after, next_id_after = _snapshot(window)
+    assert set(atoms_after) == set(atoms_before)
+    for aid, (sym, chg, pos) in atoms_before.items():
+        sym2, chg2, pos2 = atoms_after[aid]
+        assert (sym2, chg2) == (sym, chg)
+        assert pos2 == pytest.approx(pos)
+    assert bonds_after == bonds_before
+    assert next_id_after == next_id_before
+    assert window.state_manager.has_unsaved_changes is False
+
+
+@pytest.mark.gui
+def test_pmeprj_save_via_dialog_appends_extension(window, tmp_path, monkeypatch):
+    """Save As with a bare filename creates <name>.pmeprj and clears dirty flag."""
+    _draw_ethanol_like(window)
+    target = tmp_path / "noext"
+    monkeypatch.setattr(
+        f"{_PKG}.ui.io_logic.QFileDialog.getSaveFileName",
+        lambda *a, **k: (str(target), None),
+        raising=True,
+    )
+
+    window.io_manager.save_project_as()
+
+    saved = tmp_path / "noext.pmeprj"
+    assert saved.exists()
+    data = json.loads(saved.read_text(encoding="utf-8"))
+    assert data["format"] == "PME Project"
+    assert len(data["2d_structure"]["atoms"]) == 3
+    assert window.state_manager.has_unsaved_changes is False
+
+
+@pytest.mark.gui
+def test_pmeraw_roundtrip(window, qtbot, tmp_path, monkeypatch):
+    """Draw -> Save as .pmeraw (pickle) via dialog -> clear -> load -> identical."""
+    _draw_ethanol_like(window)
+    atoms_before, bonds_before, next_id_before = _snapshot(window)
+
+    target = tmp_path / "raw_project"
+    monkeypatch.setattr(
+        f"{_PKG}.ui.io_logic.QFileDialog.getSaveFileName",
+        lambda *a, **k: (str(target), None),
+        raising=True,
+    )
+    window.io_manager.save_raw_data()
+    saved = tmp_path / "raw_project.pmeraw"
+    assert saved.exists()
+
+    window.edit_actions_manager.clear_all(skip_check=True)
+    assert window.data.atoms == {}
+
+    _patch_unsaved_prompt(monkeypatch, QMessageBox.StandardButton.No)
+    window.io_manager.load_raw_data(str(saved))
+    qtbot.wait(200)
+
+    atoms_after, bonds_after, next_id_after = _snapshot(window)
+    assert set(atoms_after) == set(atoms_before)
+    assert bonds_after == bonds_before
+    assert next_id_after == next_id_before
+
+
+@pytest.mark.gui
+def test_load_cancelled_on_unsaved_changes_keeps_document(
+    window, qtbot, tmp_path, monkeypatch
+):
+    """Cancelling the unsaved-changes prompt aborts the load, keeping the doc."""
+    # Prepare a valid project file first (1-atom document)
+    scene = window.init_manager.scene
+    scene.create_atom("N", QPointF(0, 0))
+    path = tmp_path / "other.pmeprj"
+    path.write_text(
+        json.dumps(window.state_manager.create_json_data()), encoding="utf-8"
+    )
+
+    # Now build a different unsaved document
+    window.edit_actions_manager.clear_all(skip_check=True)
+    _draw_ethanol_like(window)
+    window.state_manager.has_unsaved_changes = True
+    atoms_before, bonds_before, _ = _snapshot(window)
+
+    _patch_unsaved_prompt(monkeypatch, QMessageBox.StandardButton.Cancel)
+    window.io_manager.open_project_file(str(path))
+    qtbot.wait(100)
+
+    atoms_after, bonds_after, _ = _snapshot(window)
+    assert atoms_after == atoms_before
+    assert bonds_after == bonds_before

--- a/tests/e2e/test_undo_redo_workflow.py
+++ b/tests/e2e/test_undo_redo_workflow.py
@@ -1,0 +1,90 @@
+# -*- coding: utf-8 -*-
+"""E2E undo/redo workflow tests through the real StateManager/EditActionsManager.
+
+Covers full user cycles: draw -> undo -> redo, bond-data restoration, and the
+undo-history depth cap.
+"""
+
+import importlib
+import importlib.util
+
+import pytest
+from PyQt6.QtCore import QPointF
+
+_PKG = (
+    "moleditpy_linux"
+    if importlib.util.find_spec("moleditpy_linux") is not None
+    else "moleditpy"
+)
+UNDO_STACK_MAX_DEPTH = importlib.import_module(
+    f"{_PKG}.utils.constants"
+).UNDO_STACK_MAX_DEPTH
+
+
+@pytest.mark.gui
+def test_draw_undo_redo_cycle(window):
+    """Two draw steps can be fully undone and redone with exact atom counts."""
+    mgr = window.edit_actions_manager
+    mgr.reset_history()  # empty baseline entry
+
+    scene = window.init_manager.scene
+    scene.create_atom("C", QPointF(0, 0))
+    mgr.push_undo_state()
+    scene.create_atom("O", QPointF(50, 0))
+    mgr.push_undo_state()
+    assert len(window.data.atoms) == 2
+
+    mgr.undo()
+    assert len(window.data.atoms) == 1
+    mgr.undo()
+    assert len(window.data.atoms) == 0
+    mgr.undo()  # at stack floor: no-op
+    assert len(window.data.atoms) == 0
+
+    mgr.redo()
+    assert len(window.data.atoms) == 1
+    mgr.redo()
+    assert len(window.data.atoms) == 2
+    symbols = sorted(d["symbol"] for d in window.data.atoms.values())
+    assert symbols == ["C", "O"]
+
+
+@pytest.mark.gui
+def test_undo_restores_bond_order(window):
+    """Undoing a bond-order change restores the original order."""
+    mgr = window.edit_actions_manager
+    scene = window.init_manager.scene
+    c1 = scene.create_atom("C", QPointF(0, 0))
+    c2 = scene.create_atom("C", QPointF(50, 0))
+    scene.create_bond(scene.atom_items[c1], scene.atom_items[c2], bond_order=1)
+    mgr.reset_history()
+
+    key = next(iter(window.data.bonds))
+    assert window.data.bonds[key]["order"] == 1
+
+    window.data.add_bond(c1, c2, order=2)
+    mgr.push_undo_state()
+    assert window.data.bonds[key]["order"] == 2
+
+    mgr.undo()
+    key_after = next(iter(window.data.bonds))
+    assert window.data.bonds[key_after]["order"] == 1
+    assert len(window.data.bonds) == 1
+
+
+@pytest.mark.gui
+def test_undo_stack_capped_e2e(window):
+    """The undo history never exceeds UNDO_STACK_MAX_DEPTH entries."""
+    mgr = window.edit_actions_manager
+    scene = window.init_manager.scene
+    aid = scene.create_atom("C", QPointF(0, 0))
+    mgr.reset_history()
+
+    for i in range(1, UNDO_STACK_MAX_DEPTH + 6):
+        window.data.set_atom_pos(aid, (float(i), 0.0))
+        mgr.push_undo_state()
+
+    assert len(mgr.undo_stack) == UNDO_STACK_MAX_DEPTH
+    # Newest state is the last position pushed
+    newest = mgr.undo_stack[-1]["atoms"][aid]["pos"]
+    assert tuple(newest) == pytest.approx((float(UNDO_STACK_MAX_DEPTH + 5), 0.0))

--- a/tests/pylint-score.txt
+++ b/tests/pylint-score.txt
@@ -1,1 +1,1 @@
-Your code has been rated at 9.38/10
+Your code has been rated at 9.36/10

--- a/tests/run_all_tests.py
+++ b/tests/run_all_tests.py
@@ -91,7 +91,9 @@ def sync_linux_for_e2e(base_dir):
     """Sync moleditpy → moleditpy-linux before running e2e tests on Linux."""
     sync_script = os.path.join(base_dir, "scripts", "sync_linux_version.py")
     if not os.path.exists(sync_script):
-        print("  [SKIP] sync_linux_version.py not found — skipping Linux sync", flush=True)
+        print(
+            "  [SKIP] sync_linux_version.py not found — skipping Linux sync", flush=True
+        )
         return
     print("\n>>> Syncing Linux version before E2E tests...", flush=True)
     result = subprocess.run(
@@ -102,12 +104,19 @@ def sync_linux_for_e2e(base_dir):
     )
     print(result.stdout, end="", flush=True)
     if result.returncode != 0:
-        print(f"  Warning: sync_linux_version.py exited {result.returncode}", flush=True)
+        print(
+            f"  Warning: sync_linux_version.py exited {result.returncode}", flush=True
+        )
         print(result.stderr, end="", flush=True)
 
 
 def run_suite(
-    name, path, env_vars=None, extra_args=None, enable_cov=True, exitfirst=False,
+    name,
+    path,
+    env_vars=None,
+    extra_args=None,
+    enable_cov=True,
+    exitfirst=False,
     cov_source=None,
 ):
     """Run a test suite in a separate process for isolation."""
@@ -363,7 +372,8 @@ if __name__ == "__main__":
         try:
             # E2E uses moleditpy_linux on Linux, moleditpy elsewhere
             e2e_cov = (
-                "moleditpy_linux" if name == "E2E" and platform.system() == "Linux"
+                "moleditpy_linux"
+                if name == "E2E" and platform.system() == "Linux"
                 else None
             )
             ret_code = run_suite(

--- a/tests/unit/test_compute_logic.py
+++ b/tests/unit/test_compute_logic.py
@@ -820,9 +820,11 @@ def test_check_chemistry_problems_fallback(mock_parser_host):
 
     compute = DummyCompute(mock_parser_host)
 
-    # Setup a problematic atom: Carbon with 5 bonds
+    # Setup a problematic atom: Carbon with total bond order 5
     pos = QPointF(0, 0)
     compute.data.add_atom("C", pos)
+    for i in range(4):
+        compute.data.add_atom("C", QPointF(50.0 * (i + 1), 0))
 
     # Use Mock item to avoid Qt crash
     mock_item = MagicMock()
@@ -830,14 +832,13 @@ def test_check_chemistry_problems_fallback(mock_parser_host):
     mock_item.pos.return_value = pos
     compute.host.init_manager.scene.atom_items[0] = mock_item
 
-    # Mock bonds to have count 5
+    # Bonds sum to order 5 on atom 0 (2+1+1+1)
     compute.data.bonds = {
         (0, 1): {"order": 2},
         (0, 2): {"order": 1},
         (0, 3): {"order": 1},
         (0, 4): {"order": 1},
     }
-    # Total bond count = 2+1+1+1 = 5
 
     compute.check_chemistry_problems_fallback()
     assert mock_item.has_problem == True

--- a/tests/unit/test_compute_logic.py
+++ b/tests/unit/test_compute_logic.py
@@ -1144,3 +1144,65 @@ def test_on_calculation_error_uff_fallback_temporary(mock_parser_host):
             mock_optimize.assert_called_once_with("UFF_RDKIT")
             # Check if persistent method remains unchanged
             assert compute.optimization_method == "MMFF_RDKIT"
+
+
+# =============================================================================
+# Plugin-registered optimization methods (register_optimization_method)
+# =============================================================================
+
+
+def _mol_with_conformer():
+    mol = Chem.AddHs(Chem.MolFromSmiles("C"))
+    AllChem.EmbedMolecule(mol)
+    return mol
+
+
+def _compute_with_plugin_method(mock_parser_host, callback):
+    compute = DummyCompute(mock_parser_host)
+    mock_parser_host.view_3d_manager.current_mol = _mol_with_conformer()
+    mock_parser_host.plugin_manager.optimization_methods = {
+        "MYOPT": {"plugin": "P", "callback": callback, "label": "My Optimizer"}
+    }
+    return compute
+
+
+def test_plugin_optimization_method_invoked(mock_parser_host):
+    """A plugin-registered method is dispatched with the current mol."""
+    calls = []
+    compute = _compute_with_plugin_method(
+        mock_parser_host, lambda mol: calls.append(mol) or True
+    )
+
+    compute.optimize_3d_structure("MYOPT")
+
+    assert calls == [mock_parser_host.view_3d_manager.current_mol]
+    mock_parser_host.view_3d_manager.draw_molecule_3d.assert_called_once()
+    mock_parser_host.edit_actions_manager.push_undo_state.assert_called_once()
+    assert compute.last_successful_optimization_method == "My Optimizer"
+
+
+def test_plugin_optimization_failure_is_isolated(mock_parser_host):
+    """A raising plugin callback is caught, logged, and reported via status."""
+
+    def _boom(mol):
+        raise RuntimeError("plugin exploded")
+
+    compute = _compute_with_plugin_method(mock_parser_host, _boom)
+    compute.optimize_3d_structure("MYOPT")  # must not raise
+
+    mock_parser_host.view_3d_manager.draw_molecule_3d.assert_not_called()
+    messages = [
+        str(c[0][0])
+        for c in mock_parser_host.update_status_message.call_args_list
+        if c[0]
+    ]
+    assert any("failed" in m for m in messages)
+
+
+def test_plugin_optimization_false_return_reports_failure(mock_parser_host):
+    """A callback returning False reports failure without redrawing."""
+    compute = _compute_with_plugin_method(mock_parser_host, lambda mol: False)
+    compute.optimize_3d_structure("MYOPT")
+
+    mock_parser_host.view_3d_manager.draw_molecule_3d.assert_not_called()
+    assert compute.last_successful_optimization_method is None

--- a/tests/unit/test_compute_logic.py
+++ b/tests/unit/test_compute_logic.py
@@ -308,6 +308,9 @@ def test_trigger_conversion_chemistry_problems(mock_parser_host):
     with (
         patch("rdkit.Chem.DetectChemistryProblems", return_value=[problem]),
         patch.object(compute.data, "to_rdkit_mol", return_value=mol),
+        # Patch the modal dialog: the MagicMock host is not a valid QWidget
+        # parent, so the real QMessageBox.critical would raise TypeError.
+        patch("moleditpy.ui.compute_logic.QMessageBox.critical"),
     ):
         compute.trigger_conversion()
         all_messages = [

--- a/tests/unit/test_edit_actions.py
+++ b/tests/unit/test_edit_actions.py
@@ -524,3 +524,32 @@ class TestEditActionsExtended:
 
         mol = Chem.MolFromSmiles("C")
         manager._clear_xyz_flags(mol)
+
+
+def test_push_undo_state_caps_stack_depth(monkeypatch):
+    """The undo stack drops its oldest entries beyond UNDO_STACK_MAX_DEPTH."""
+    from moleditpy.utils.constants import UNDO_STACK_MAX_DEPTH
+
+    host = MagicMock()
+    host.is_restoring_state = False
+    host.view_3d_manager.current_mol = None
+    host.state_manager.data.atoms = {}
+    host.state_manager.data.bonds = {}
+
+    mgr = EditActionsManager(host)
+    monkeypatch.setattr(mgr, "update_implicit_hydrogens", lambda: None)
+    monkeypatch.setattr(mgr, "update_undo_redo_actions", lambda: None)
+
+    for i in range(UNDO_STACK_MAX_DEPTH + 25):
+        host.state_manager.data.next_atom_id = i
+        host.state_manager.get_current_state.return_value = {
+            "atoms": {},
+            "bonds": {},
+            "_next_atom_id": i,
+        }
+        mgr.push_undo_state()
+
+    assert len(mgr.undo_stack) == UNDO_STACK_MAX_DEPTH
+    # Newest state kept, oldest dropped
+    assert mgr.undo_stack[-1]["_next_atom_id"] == UNDO_STACK_MAX_DEPTH + 24
+    assert mgr.undo_stack[0]["_next_atom_id"] == 25

--- a/tests/unit/test_geometry.py
+++ b/tests/unit/test_geometry.py
@@ -332,3 +332,58 @@ def test_resolve_2d_overlaps():
     assert len(moves) > 0
     # One fragment should be planned to move
     assert len(moves[0][0]) == 1
+
+
+# =============================================================================
+# identify_valence_problems — RDKit-backed detection (red-box flagging)
+# =============================================================================
+
+
+def _data_with_center(sym, nbonds, charge=0, radical=0, order=1):
+    from moleditpy.core.molecular_data import MolecularData
+
+    d = MolecularData()
+    center = d.add_atom(sym, (0, 0), charge=charge, radical=radical)
+    for i in range(nbonds):
+        c = d.add_atom("C", (50 * (i + 1), 0))
+        d.add_bond(center, c, order=order)
+    return d, center
+
+
+@pytest.mark.parametrize(
+    "sym,nbonds,charge,radical",
+    [
+        ("N", 3, 0, 1),  # trimethylamine radical (reported bug)
+        ("N", 5, 1, 0),  # charged hypervalent N+
+        ("S", 7, 0, 0),  # beyond expanded octet
+        ("B", 5, 0, 0),
+        ("O", 2, 0, 1),  # oxygen radical with full valence
+        ("C", 4, 0, 1),  # carbon radical with full valence
+        ("C", 5, 0, 0),
+        ("O", 3, 0, 0),
+    ],
+)
+def test_identify_valence_problems_flags_invalid(sym, nbonds, charge, radical):
+    """Hypervalent/radical-overloaded atoms are flagged for any element."""
+    from moleditpy.core.mol_geometry import identify_valence_problems
+
+    d, center = _data_with_center(sym, nbonds, charge=charge, radical=radical)
+    assert center in identify_valence_problems(d.atoms, d.bonds)
+
+
+@pytest.mark.parametrize(
+    "sym,nbonds,charge,radical",
+    [
+        ("N", 3, 0, 0),  # trimethylamine
+        ("N", 4, 1, 0),  # ammonium-like
+        ("S", 6, 0, 0),  # valid expanded octet
+        ("C", 3, 0, 1),  # methyl-like radical
+        ("O", 2, 0, 0),
+    ],
+)
+def test_identify_valence_problems_accepts_valid(sym, nbonds, charge, radical):
+    """Chemically valid atoms (incl. charges/radicals) are not flagged."""
+    from moleditpy.core.mol_geometry import identify_valence_problems
+
+    d, center = _data_with_center(sym, nbonds, charge=charge, radical=radical)
+    assert center not in identify_valence_problems(d.atoms, d.bonds)

--- a/tests/unit/test_io_manager.py
+++ b/tests/unit/test_io_manager.py
@@ -536,12 +536,17 @@ class TestPromptForChargeInlineValidation:
             validator = MockBox.return_value.accepted.connect.call_args[0][0]
 
             dlg.accept.reset_mock()
-            MockLabel.return_value.setVisible.reset_mock()
+            MockLabel.return_value.setText.reset_mock()
 
-            # Invalid text: dialog stays open, error label shown
+            # Invalid text: dialog stays open, error message set inline
             validator()
             dlg.accept.assert_not_called()
-            MockLabel.return_value.setVisible.assert_called_with(True)
+            msgs = [
+                str(c[0][0])
+                for c in MockLabel.return_value.setText.call_args_list
+                if c[0]
+            ]
+            assert any("Invalid charge" in m for m in msgs)
 
             # Valid text: dialog accepts
             le.text.return_value = "-2"

--- a/tests/unit/test_io_manager.py
+++ b/tests/unit/test_io_manager.py
@@ -483,3 +483,67 @@ class TestSave3DAsMol:
         host.statusBar_mock.showMessage.assert_called()
         msg = host.statusBar_mock.showMessage.call_args[0][0]
         assert "error" in msg.lower()
+
+
+# ===========================================================================
+# Regression tests for code-review fixes
+# ===========================================================================
+
+
+class TestSave3DAsMolExtension:
+    """save_3d_as_mol must append .mol when the user omits the extension."""
+
+    def test_missing_extension_is_appended(self, qapp, tmp_path):
+        host = DummyHost()
+        io = IOManager(host)
+        mol = Chem.MolFromSmiles("CCO")
+        AllChem.EmbedMolecule(mol, AllChem.ETKDGv3())
+        host.view_3d_manager.current_mol = mol
+
+        out_no_ext = tmp_path / "bare_name"
+        with patch(
+            "moleditpy.ui.io_logic.QFileDialog.getSaveFileName",
+            return_value=(str(out_no_ext), None),
+        ):
+            io.save_3d_as_mol()
+
+        assert not out_no_ext.exists()
+        assert (tmp_path / "bare_name.mol").exists()
+
+
+class TestPromptForChargeInlineValidation:
+    """Invalid input must keep the dialog open with an inline error message,
+    not silently fall back to charge 0."""
+
+    def test_invalid_charge_blocks_accept_and_shows_error(self, qapp):
+        io = IOManager(DummyHost())
+        le = MagicMock()
+        le.text.return_value = "abc"
+        with (
+            patch("moleditpy.ui.io_logic.QDialog") as MockDlg,
+            patch("moleditpy.ui.io_logic.QLineEdit", return_value=le),
+            patch("moleditpy.ui.io_logic.QVBoxLayout"),
+            patch("moleditpy.ui.io_logic.QHBoxLayout"),
+            patch("moleditpy.ui.io_logic.QLabel") as MockLabel,
+            patch("moleditpy.ui.io_logic.QDialogButtonBox") as MockBox,
+            patch("moleditpy.ui.io_logic.QPushButton"),
+        ):
+            dlg = MockDlg.return_value
+            dlg.exec.return_value = MockDlg.DialogCode.Rejected
+            io.prompt_for_charge()
+
+            # The OK handler was connected to the inline validator
+            validator = MockBox.return_value.accepted.connect.call_args[0][0]
+
+            dlg.accept.reset_mock()
+            MockLabel.return_value.setVisible.reset_mock()
+
+            # Invalid text: dialog stays open, error label shown
+            validator()
+            dlg.accept.assert_not_called()
+            MockLabel.return_value.setVisible.assert_called_with(True)
+
+            # Valid text: dialog accepts
+            le.text.return_value = "-2"
+            validator()
+            dlg.accept.assert_called_once()

--- a/tests/unit/test_molecular_data.py
+++ b/tests/unit/test_molecular_data.py
@@ -418,3 +418,95 @@ def test_to_rdkit_mol_ez_stereo():
 
     assert double_bond.GetBondType() == Chem.BondType.DOUBLE
     assert double_bond.GetStereo() == Chem.BondStereo.STEREOZ
+
+
+# =============================================================================
+# Reversed-key bond handling (stereo direction vs. sorted non-stereo keys)
+# =============================================================================
+
+
+def test_add_bond_stereo_over_existing_reversed_key_updates_in_place():
+    """Adding a directional stereo bond over an existing sorted-key bond
+    must re-key the entry, not create a duplicate for the same atom pair."""
+    data = MolecularData()
+    a = data.add_atom("C", QPointF(0, 0))
+    b = data.add_atom("C", QPointF(10, 0))
+
+    key1, status1 = data.add_bond(a, b, order=1, stereo=0)  # stored as (a, b)
+    assert (key1, status1) == ((a, b), "created")
+
+    # Wedge drawn from b to a: directional key (b, a)
+    key2, status2 = data.add_bond(b, a, order=1, stereo=1)
+    assert status2 == "updated"
+    assert key2 == (b, a)
+    assert len(data.bonds) == 1
+    assert data.bonds[(b, a)]["stereo"] == 1
+    # Adjacency must not be duplicated either
+    assert data.adjacency_list[a].count(b) == 1
+    assert data.adjacency_list[b].count(a) == 1
+
+
+def test_add_bond_plain_over_existing_stereo_reversed_key_updates_in_place():
+    """Demoting a directional stereo bond back to a plain bond (sorted key)
+    must also re-key instead of duplicating."""
+    data = MolecularData()
+    a = data.add_atom("C", QPointF(0, 0))
+    b = data.add_atom("C", QPointF(10, 0))
+
+    key1, _ = data.add_bond(b, a, order=1, stereo=1)  # directional (b, a)
+    assert key1 == (b, a)
+
+    key2, status2 = data.add_bond(a, b, order=2, stereo=0)  # sorted (a, b)
+    assert status2 == "updated"
+    assert key2 == (a, b)
+    assert len(data.bonds) == 1
+    assert data.bonds[(a, b)]["order"] == 2
+    assert data.bonds[(a, b)]["stereo"] == 0
+
+
+# =============================================================================
+# Manual MOL block fallback robustness
+# =============================================================================
+
+
+def _force_manual_fallback(monkeypatch, data):
+    """Make to_rdkit_mol fail so to_mol_block uses the manual writer."""
+    monkeypatch.setattr(
+        type(data), "to_rdkit_mol", lambda self, use_2d_stereo=True: None
+    )
+
+
+def test_to_mol_block_fallback_handles_float_bond_order(monkeypatch):
+    """Aromatic 1.5 bond order must map to V2000 code 4, not crash on '{:d}'."""
+    data = MolecularData()
+    a = data.add_atom("C", QPointF(0, 0))
+    b = data.add_atom("C", QPointF(75, 0))
+    data.add_bond(a, b, order=1.5)
+    _force_manual_fallback(monkeypatch, data)
+
+    mol_block = data.to_mol_block()
+    assert mol_block is not None
+    bond_line = mol_block.splitlines()[4 + 2]  # header(3) + counts + 2 atoms
+    assert bond_line[:12] == f"{1:3d}{2:3d}{4:3d}{0:3d}"
+
+
+def test_to_mol_block_fallback_skips_positionless_atoms_consistently(monkeypatch):
+    """Atoms without a position are excluded from counts and bond indices."""
+    data = MolecularData()
+    a = data.add_atom("C", QPointF(0, 0))
+    b = data.add_atom("O", QPointF(75, 0))
+    c = data.add_atom("N", QPointF(150, 0))
+    data.atoms[a]["pos"] = None  # simulate corrupted/missing position
+    data.add_bond(b, c, order=1)
+    _force_manual_fallback(monkeypatch, data)
+
+    mol_block = data.to_mol_block()
+    assert mol_block is not None
+    lines = mol_block.splitlines()
+    counts = lines[3]
+    assert counts[:6] == f"{2:3d}{1:3d}"  # 2 atoms written, 1 bond
+    atom_lines = lines[4:6]
+    assert "O" in atom_lines[0] and "N" in atom_lines[1]
+    bond_line = lines[6]
+    # Bond must reference the re-numbered atoms 1-2, not the original 2-3
+    assert bond_line[:6] == f"{1:3d}{2:3d}"

--- a/tests/unit/test_move_selected_atoms_dialog.py
+++ b/tests/unit/test_move_selected_atoms_dialog.py
@@ -769,10 +769,10 @@ def test_show_atom_labels_camera_restore(qapp):
 def test_box_selection_toggle_button(qapp):
     """Test that the Box Selection toggle enables/disables rectangle picking."""
     from moleditpy.ui.move_selected_atoms_dialog import MoveSelectedAtomsDialog
-    
+
     mol = _ethane()
     mw = _make_main_window(mol)
-    
+
     with (
         patch.object(MoveSelectedAtomsDialog, "show_atom_labels"),
         patch.object(MoveSelectedAtomsDialog, "clear_atom_labels"),
@@ -783,15 +783,15 @@ def test_box_selection_toggle_button(qapp):
         plotter.disable_picking = MagicMock()
         plotter.interactor = MagicMock()
         plotter.interactor.GetInteractorStyle.return_value = "mock_style"
-        
+
         btn = dlg.widgets["box_select_btn"]
-        
+
         # Turn ON
         btn.setChecked(True)
         dlg.toggle_box_selection(True)
         plotter.enable_rectangle_picking.assert_called_once()
         assert dlg.original_style == "mock_style"
-        
+
         # Turn OFF
         btn.setChecked(False)
         dlg.toggle_box_selection(False)
@@ -803,37 +803,39 @@ def test_box_selection_click_to_reset(qapp):
     from moleditpy.ui.move_selected_atoms_dialog import MoveSelectedAtomsDialog
     from PyQt6.QtCore import QEvent, QPoint, Qt
     from PyQt6.QtGui import QMouseEvent
-    
+
     mol = _ethane()
     mw = _make_main_window(mol)
-    
+
     with (
         patch.object(MoveSelectedAtomsDialog, "show_atom_labels"),
         patch.object(MoveSelectedAtomsDialog, "clear_atom_labels"),
     ):
         dlg = MoveSelectedAtomsDialog(mol, mw)
         dlg.selected_atoms.add(0)
-        
+
         btn = dlg.widgets["box_select_btn"]
         btn.setChecked(True)
-        # We don't actually need to call toggle_box_selection(True) 
+        # We don't actually need to call toggle_box_selection(True)
         # since we are manually passing the event to eventFilter.
-        
+
         class MockEvent:
             def __init__(self, t, p):
                 self._t = t
                 self._p = p
+
             def type(self):
                 return self._t
+
             def pos(self):
                 return self._p
-        
+
         press_ev = MockEvent(QEvent.Type.MouseButtonPress, QPoint(100, 100))
         release_ev = MockEvent(QEvent.Type.MouseButtonRelease, QPoint(100, 100))
-        
+
         # interactor must match the one checked inside eventFilter
         interactor = mw.view_3d_manager.plotter.interactor
-        
+
         with patch.object(dlg, "clear_selection") as mock_clear:
             dlg.eventFilter(interactor, press_ev)
             dlg.eventFilter(interactor, release_ev)

--- a/tests/unit/test_planarize_dialog.py
+++ b/tests/unit/test_planarize_dialog.py
@@ -174,3 +174,33 @@ class TestApplyPlanarizeGeometry:
         with patch("moleditpy.ui.planarize_dialog.QMessageBox"):
             dlg.apply_planarize()
         mw.view_3d_manager.draw_molecule_3d.assert_called()
+
+
+# ---------------------------------------------------------------------------
+# Regression: picking an atom must refresh the 3D selection labels
+# ---------------------------------------------------------------------------
+
+
+def test_on_atom_picked_refreshes_labels(qapp):
+    """Clicking an atom in the 3D view shows/updates the numbered labels."""
+    from unittest.mock import patch
+    from moleditpy.ui.planarize_dialog import PlanarizeDialog
+
+    mol = make_ethane()
+    mw = make_mock_mw(mol)
+    with (
+        patch.object(PlanarizeDialog, "show_atom_labels") as mock_labels,
+        patch.object(PlanarizeDialog, "clear_atom_labels"),
+        patch.object(PlanarizeDialog, "enable_picking"),
+        patch.object(PlanarizeDialog, "disable_picking"),
+    ):
+        dlg = PlanarizeDialog(mol, mw)
+        mock_labels.reset_mock()
+
+        dlg.on_atom_picked(0)
+        assert 0 in dlg.selected_atoms
+        mock_labels.assert_called_once()
+
+        dlg.on_atom_picked(0)  # toggle off also refreshes labels
+        assert 0 not in dlg.selected_atoms
+        assert mock_labels.call_count == 2

--- a/tests/unit/test_plugin_manager.py
+++ b/tests/unit/test_plugin_manager.py
@@ -745,3 +745,65 @@ PLUGIN_VERSION = (1, ("x",))
 
         with patch("builtins.open", side_effect=OSError("Err")):
             pm.get_plugin_info_safe(str(f))
+
+
+# =============================================================================
+# ZIP install: single-file archives must get a wrapper folder
+# =============================================================================
+
+
+def test_install_zip_single_file_gets_wrapper_folder(tmp_path):
+    """A ZIP whose only entry is one top-level .py file is a flat ZIP:
+    it must be extracted into a folder named after the archive."""
+    plugin_dir = tmp_path / "plugins"
+    plugin_dir.mkdir()
+    pm = PluginManager(main_window=MagicMock())
+    pm.plugin_dir = str(plugin_dir)
+    pm.discover_plugins = MagicMock()
+
+    zip_file = tmp_path / "solo.zip"
+    with zipfile.ZipFile(zip_file, "w") as zf:
+        zf.writestr("myplugin.py", "PLUGIN_NAME='Solo'")
+
+    success, msg = pm.install_plugin(str(zip_file))
+    assert success, msg
+    assert (plugin_dir / "solo" / "myplugin.py").exists()
+    assert not (plugin_dir / "myplugin.py").exists()
+
+
+def test_install_zip_single_folder_stays_nested(tmp_path):
+    """A ZIP with one top-level folder still extracts directly (Case A)."""
+    plugin_dir = tmp_path / "plugins"
+    plugin_dir.mkdir()
+    pm = PluginManager(main_window=MagicMock())
+    pm.plugin_dir = str(plugin_dir)
+    pm.discover_plugins = MagicMock()
+
+    zip_file = tmp_path / "pkg.zip"
+    with zipfile.ZipFile(zip_file, "w") as zf:
+        zf.writestr("MyPlugin/__init__.py", "PLUGIN_NAME='Pkg'")
+
+    success, msg = pm.install_plugin(str(zip_file))
+    assert success, msg
+    assert (plugin_dir / "MyPlugin" / "__init__.py").exists()
+
+
+# =============================================================================
+# discover_plugins: hidden (dot) directories are skipped
+# =============================================================================
+
+
+def test_discover_plugins_skips_dot_directories(tmp_path):
+    """Plugins inside hidden directories like .git must not be loaded."""
+    plugin_dir = tmp_path / "plugins"
+    hidden = plugin_dir / ".git"
+    hidden.mkdir(parents=True)
+    (hidden / "sneaky.py").write_text(
+        "PLUGIN_NAME='Sneaky'\ndef initialize(context):\n    pass\n",
+        encoding="utf-8",
+    )
+
+    pm = PluginManager(main_window=MagicMock())
+    pm.plugin_dir = str(plugin_dir)
+    plugins = pm.discover_plugins()
+    assert all(p["name"] != "Sneaky" for p in plugins)

--- a/tests/unit/test_system_utils.py
+++ b/tests/unit/test_system_utils.py
@@ -101,15 +101,17 @@ class TestMacOSTheme:
 
     def test_macos_dark_mode(self):
         """AppleInterfaceStyle == Dark -> dark theme."""
-        with patch("platform.system", return_value="Darwin"), patch(
-            "subprocess.run", return_value=self._proc(0, "Dark\n")
+        with (
+            patch("platform.system", return_value="Darwin"),
+            patch("subprocess.run", return_value=self._proc(0, "Dark\n")),
         ):
             assert detect_system_theme() == "dark"
 
     def test_macos_light_mode(self):
         """Missing AppleInterfaceStyle key (non-zero exit) -> light theme."""
-        with patch("platform.system", return_value="Darwin"), patch(
-            "subprocess.run", return_value=self._proc(1, "")
+        with (
+            patch("platform.system", return_value="Darwin"),
+            patch("subprocess.run", return_value=self._proc(1, "")),
         ):
             assert detect_system_theme() == "light"
 

--- a/tests/unit/test_system_utils.py
+++ b/tests/unit/test_system_utils.py
@@ -2,8 +2,9 @@
 Unit tests for utils/system_utils.py.
 
 Covers:
-  - detect_system_theme: Windows dark/light via winreg, macOS always light,
-    Linux via gsettings color-scheme and gtk-theme, unknown platform → None
+  - detect_system_theme: Windows dark/light via winreg, macOS via
+    AppleInterfaceStyle, Linux via gsettings color-scheme and gtk-theme,
+    unknown platform → None
   - Exception suppression (contextlib.suppress)
   - detect_system_dark_mode: wraps detect_system_theme correctly
 """
@@ -91,9 +92,25 @@ class TestWindowsTheme:
 
 
 class TestMacOSTheme:
-    def test_macos_always_light(self):
-        """macOS always returns light theme."""
-        with patch("platform.system", return_value="Darwin"):
+    @staticmethod
+    def _proc(returncode, stdout):
+        p = MagicMock()
+        p.returncode = returncode
+        p.stdout = stdout
+        return p
+
+    def test_macos_dark_mode(self):
+        """AppleInterfaceStyle == Dark -> dark theme."""
+        with patch("platform.system", return_value="Darwin"), patch(
+            "subprocess.run", return_value=self._proc(0, "Dark\n")
+        ):
+            assert detect_system_theme() == "dark"
+
+    def test_macos_light_mode(self):
+        """Missing AppleInterfaceStyle key (non-zero exit) -> light theme."""
+        with patch("platform.system", return_value="Darwin"), patch(
+            "subprocess.run", return_value=self._proc(1, "")
+        ):
             assert detect_system_theme() == "light"
 
 


### PR DESCRIPTION
## Summary

<!-- What does this PR do? List the key changes in 2–4 bullet points. -->

- Applied the `pyqt6 < 6.10` dependency restriction specifically to Python 3.9 across all operating systems.
- Addressed various code review feedback by fixing core data-model bugs, refining the plugin system, and fixing issues in `IOManager` and compute logic.
- Implemented macOS dark-mode detection and fixed a regression in `zoomable_view` gesture handling.
- Conducted extensive MyPy cleanups, removed unused imports, and added regression/unit tests for IO logic, the plugin manager, and charge validation.

## Type of change

<!-- Check all that apply. -->

- [x] Bug fix
- [x] New feature
- [x] Refactor / code cleanup
- [ ] Documentation
- [x] Tests
- [x] CI / build

## Related issues

<!-- Link any related issues, e.g. Closes #123 -->

## Test plan

<!-- How did you verify the change works? -->

- [x] Ran `python tests/run_all_tests.py` — all pass
- [x] Manually tested in the GUI with the check list
- [x] Added new unit tests

## Checklist

- [x] `python -m flake8 moleditpy/src/ --select=F` returns 0 issues
- [x] No bare `except:` clauses added (use `except Exception as e:` and log the error)
- [x] No new unused imports or variables
- [x] Plugin API changes are backwards-compatible (or documented in Summary)