### PR TITLE
Fix: Dynamic UI integration for plugin optimization methods

### DIFF
--- a/moleditpy/src/moleditpy/plugins/plugin_manager.py
+++ b/moleditpy/src/moleditpy/plugins/plugin_manager.py
@@ -485,12 +485,18 @@ class PluginManager:
         self, plugin_name: str, method_name: str, callback: Callable
     ) -> None:
         """Register a named 3D optimization method provided by a plugin."""
-        # Key by upper-case method name for consistency
-        self.optimization_methods[method_name.upper()] = {
+        method_key = method_name.upper()
+        self.optimization_methods[method_key] = {
             "plugin": plugin_name,
             "callback": callback,
             "label": method_name,
         }
+        if hasattr(self.main_window, "init_manager") and hasattr(
+            self.main_window.init_manager, "add_optimization_method"
+        ):
+            self.main_window.init_manager.add_optimization_method(
+                method_name, method_key
+            )
 
     def register_file_opener(
         self, plugin_name: str, extension: str, callback: Callable, priority: int = 0

--- a/moleditpy/src/moleditpy/ui/compute_logic.py
+++ b/moleditpy/src/moleditpy/ui/compute_logic.py
@@ -178,20 +178,10 @@ class ComputeManager:
             return
 
         menu = QMenu(self.host)
-        opt_list = [
-            ("MMFF94s (RDKit)", "MMFF_RDKIT"),
-            ("MMFF94 (RDKit)", "MMFF94_RDKIT"),
-            ("UFF (RDKit)", "UFF_RDKIT"),
-            ("MMFF94s (Open Babel)", "MMFF94s_OBABEL"),
-            ("MMFF94 (Open Babel)", "MMFF94_OBABEL"),
-            ("UFF (Open Babel)", "UFF_OBABEL"),
-            ("GAFF (Open Babel)", "GAFF_OBABEL"),
-            ("Ghemical (Open Babel)", "GHEMICAL_OBABEL"),
-        ]
-        for label, key in opt_list:
+        for key, source_action in self.host.init_manager.opt3d_actions.items():
+            label = source_action.text().replace("&", "")
             a = QAction(label, self.host)
-            if key in self.host.init_manager.opt3d_actions:
-                a.setEnabled(self.host.init_manager.opt3d_actions[key].isEnabled())
+            a.setEnabled(source_action.isEnabled())
             a.triggered.connect(
                 lambda checked=False, k=key: self._trigger_optimize_with_temp_method(k)
             )

--- a/moleditpy/src/moleditpy/ui/main_window_init.py
+++ b/moleditpy/src/moleditpy/ui/main_window_init.py
@@ -1648,7 +1648,7 @@ class MainInitManager:
             self.conv_actions[saved_conv].setChecked(True)
         self.settings["3d_conversion_mode"] = saved_conv
 
-        optimization_menu = settings_menu.addMenu("3D Optimization Settings")
+        self.optimization_menu = settings_menu.addMenu("3D Optimization Settings")
         opt_methods = [
             ("MMFF94s (RDKit)", "MMFF_RDKIT"),
             ("MMFF94 (RDKit)", "MMFF94_RDKIT"),
@@ -1660,8 +1660,8 @@ class MainInitManager:
             ("Ghemical (Open Babel)", "GHEMICAL_OBABEL"),
         ]
         self.opt3d_method_labels = {key.upper(): label for (label, key) in opt_methods}
-        opt_group = QActionGroup(self.host)
-        opt_group.setExclusive(True)
+        self.opt_group = QActionGroup(self.host)
+        self.opt_group.setExclusive(True)
         self.opt3d_actions = {}
         for label, key in opt_methods:
             action = QAction(label, self.host)
@@ -1672,11 +1672,11 @@ class MainInitManager:
                 lambda checked,
                 m=key: self.host.compute_manager.set_optimization_method(m)
             )
-            optimization_menu.addAction(action)
-            opt_group.addAction(action)
+            self.optimization_menu.addAction(action)
+            self.opt_group.addAction(action)
             self.opt3d_actions[key] = action
 
-        optimization_menu.addSeparator()
+        self.opt3d_separator = self.optimization_menu.addSeparator()
         self.host.intermolecular_rdkit_action = QAction(
             "Consider Intermolecular Interaction for RDKit", self.host
         )
@@ -1687,7 +1687,7 @@ class MainInitManager:
         self.host.intermolecular_rdkit_action.triggered.connect(
             self.host.compute_manager.toggle_intermolecular_interaction_rdkit
         )
-        optimization_menu.addAction(self.host.intermolecular_rdkit_action)
+        self.optimization_menu.addAction(self.host.intermolecular_rdkit_action)
 
         saved_opt = (self.settings.get("optimization_method") or "MMFF_RDKIT").upper()
         if (
@@ -1704,6 +1704,24 @@ class MainInitManager:
         reset_settings_action = QAction("Reset All Settings", self.host)
         reset_settings_action.triggered.connect(self.reset_all_settings_menu)
         settings_menu.addAction(reset_settings_action)
+
+    def add_optimization_method(self, label: str, key: str) -> None:
+        """Dynamically add an optimization method to the menu."""
+        key_upper = key.upper()
+        if key_upper in self.opt3d_actions:
+            return
+
+        self.opt3d_method_labels[key_upper] = label
+        action = QAction(label, self.host)
+        action.setCheckable(True)
+        action.triggered.connect(
+            lambda checked,
+            m=key_upper: self.host.compute_manager.set_optimization_method(m)
+        )
+
+        self.optimization_menu.insertAction(self.opt3d_separator, action)
+        self.opt_group.addAction(action)
+        self.opt3d_actions[key_upper] = action
 
     def _init_help_menu(self, menu_bar: Any) -> None:
         """Initialize the Help menu."""

--- a/moleditpy/src/moleditpy/ui/plugin_menu_manager.py
+++ b/moleditpy/src/moleditpy/ui/plugin_menu_manager.py
@@ -81,6 +81,7 @@ class PluginMenuManager:
         self.integrate_plugin_export_actions()
         self.integrate_plugin_file_openers()
         self.integrate_plugin_analysis_tools()
+        self.integrate_plugin_optimization_methods()
 
     def rebuild_plugin_menus(self) -> None:
         """Fully rebuild all plugin-managed UI after an install/uninstall.
@@ -120,6 +121,7 @@ class PluginMenuManager:
             (self.integrate_plugin_file_openers, "file openers"),
             (self.integrate_plugin_analysis_tools, "analysis tools"),
             (self.update_style_menu_with_plugins, "style menu"),
+            (self.integrate_plugin_optimization_methods, "optimization methods"),
         ]:
             try:
                 method()
@@ -365,6 +367,16 @@ class PluginMenuManager:
                 )
                 a.setData(PLUGIN_ACTION_TAG)
                 menu.addAction(a)
+
+    def integrate_plugin_optimization_methods(self) -> None:
+        """Inject plugin optimization methods into the 3D Optimization Settings menu."""
+        if not hasattr(self._im.host.plugin_manager, "optimization_methods"):
+            return
+
+        for key, entry in self._im.host.plugin_manager.optimization_methods.items():
+            self._im.add_optimization_method(entry["label"], key)
+            if key in self._im.opt3d_actions:
+                self._im.opt3d_actions[key].setData("plugin_managed")
 
     def integrate_plugin_file_openers(self) -> None:
         """Inject plugin file-opener entries into the File > Import menu."""

--- a/tests/assertion_catalog.md
+++ b/tests/assertion_catalog.md
@@ -1062,6 +1062,26 @@ _Verify that UFF fallback uses _temp_optimization_method and doesn't change pers
 - mock_optimize.assert_called_once_with('UFF_RDKIT')
 - assert compute.optimization_method == 'MMFF_RDKIT'
 
+### test_plugin_optimization_method_invoked
+_A plugin-registered method is dispatched with the current mol._
+
+- assert calls == [mock_parser_host.view_3d_manager.current_mol]
+- mock_parser_host.view_3d_manager.draw_molecule_3d.assert_called_once()
+- mock_parser_host.edit_actions_manager.push_undo_state.assert_called_once()
+- assert compute.last_successful_optimization_method == 'My Optimizer'
+
+### test_plugin_optimization_failure_is_isolated
+_A raising plugin callback is caught, logged, and reported via status._
+
+- mock_parser_host.view_3d_manager.draw_molecule_3d.assert_not_called()
+- assert any(('failed' in m for m in messages))
+
+### test_plugin_optimization_false_return_reports_failure
+_A callback returning False reports failure without redrawing._
+
+- mock_parser_host.view_3d_manager.draw_molecule_3d.assert_not_called()
+- assert compute.last_successful_optimization_method is None
+
 ## tests/unit/test_constants.py
 
 ### test_constants_version_from_metadata
@@ -2375,6 +2395,16 @@ _Verify 2D overlap resolution logic handles collisions correctly._
 - assert len(moves) > 0
 - assert len(moves[0][0]) == 1
 
+### test_identify_valence_problems_flags_invalid
+_Hypervalent/radical-overloaded atoms are flagged for any element._
+
+- assert center in identify_valence_problems(d.atoms, d.bonds)
+
+### test_identify_valence_problems_accepts_valid
+_Chemically valid atoms (incl. charges/radicals) are not flagged._
+
+- assert center not in identify_valence_problems(d.atoms, d.bonds)
+
 ## tests/unit/test_geometry_base_dialog.py
 
 ### TestSyncInputToSlider.test_valid_float_sets_slider
@@ -2869,7 +2899,7 @@ _No description provided._
 _No description provided._
 
 - dlg.accept.assert_not_called()
-- MockLabel.return_value.setVisible.assert_called_with(True)
+- assert any(('Invalid charge' in m for m in msgs))
 - dlg.accept.assert_called_once()
 
 ## tests/unit/test_items_visual.py
@@ -4231,6 +4261,14 @@ _Planarize triggers a 3D redraw after modifying geometry._
 
 - mw.view_3d_manager.draw_molecule_3d.assert_called()
 
+### test_on_atom_picked_refreshes_labels
+_Clicking an atom in the 3D view shows/updates the numbered labels._
+
+- assert 0 in dlg.selected_atoms
+- mock_labels.assert_called_once()
+- assert 0 not in dlg.selected_atoms
+- assert mock_labels.call_count == 2
+
 ## tests/unit/test_plugin_context.py
 
 ### TestMarkProjectModified.test_sets_has_unsaved_changes
@@ -4589,6 +4627,8 @@ _register_export_action stores the action with its label in export_actions._
 _register_optimization_method stores the callback under its method name._
 
 - assert 'MMFF94' in pm.optimization_methods
+- assert len(pm.main_window.init_manager.added_methods) == 1
+- assert pm.main_window.init_manager.added_methods[0] == ('MMFF94', 'MMFF94')
 
 ### test_register_file_opener
 _register_file_opener stores a callback under the given extension key._
@@ -7342,7 +7382,7 @@ _Test error message when plugin path is invalid._
 ### TestRebuildCompleteness.test_all_six_steps_run_when_all_registries_empty
 _Even with empty registries, all six rebuild methods execute._
 
-- assert called == ['menu_actions', 'toolbar_actions', 'export_actions', 'file_openers', 'analysis_tools', 'style_menu']
+- assert called == ['menu_actions', 'toolbar_actions', 'export_actions', 'file_openers', 'analysis_tools', 'style_menu', 'optimization_methods']
 
 ### TestRebuildCompleteness.test_all_six_steps_run_when_all_registries_populated
 _With all registries populated, all six steps still run._

--- a/tests/coverage_report.md
+++ b/tests/coverage_report.md
@@ -1,6 +1,6 @@
 # MoleditPy Coverage Report
 
-- **Overall Project Coverage**: **82.64%**
+- **Overall Project Coverage**: **82.59%**
 
 ### Coverage Breakdown
 
@@ -8,47 +8,47 @@
 | :--- | :--- | :--- | :--- |
 | moleditpy\src\moleditpy\__init__.py                     |      6 |      2 |   66.7% |
 | moleditpy\src\moleditpy\main.py                         |    114 |     33 |   71.1% |
-| moleditpy\src\moleditpy\core\mol_geometry.py            |    262 |     20 |   92.4% |
+| moleditpy\src\moleditpy\core\mol_geometry.py            |    292 |     42 |   85.6% |
 | moleditpy\src\moleditpy\core\molecular_data.py          |    258 |     28 |   89.1% |
 | moleditpy\src\moleditpy\plugins\plugin_interface.py     |    233 |      6 |   97.4% |
-| moleditpy\src\moleditpy\plugins\plugin_manager.py       |    375 |      8 |   97.9% |
+| moleditpy\src\moleditpy\plugins\plugin_manager.py       |    378 |      8 |   97.9% |
 | moleditpy\src\moleditpy\plugins\plugin_manager_window.py |    186 |      2 |   98.9% |
 | moleditpy\src\moleditpy\ui\__init__.py                  |      7 |      3 |   57.1% |
 | moleditpy\src\moleditpy\ui\about_dialog.py              |     64 |     13 |   79.7% |
 | moleditpy\src\moleditpy\ui\align_plane_dialog.py        |    152 |     16 |   89.5% |
 | moleditpy\src\moleditpy\ui\alignment_dialog.py          |    148 |     11 |   92.6% |
 | moleditpy\src\moleditpy\ui\analysis_window.py           |    117 |     25 |   78.6% |
-| moleditpy\src\moleditpy\ui\angle_dialog.py              |    263 |     28 |   89.4% |
+| moleditpy\src\moleditpy\ui\angle_dialog.py              |    264 |     28 |   89.4% |
 | moleditpy\src\moleditpy\ui\app_state.py                 |    334 |     62 |   81.4% |
-| moleditpy\src\moleditpy\ui\atom_item.py                 |    324 |     39 |   88.0% |
+| moleditpy\src\moleditpy\ui\atom_item.py                 |    325 |     39 |   88.0% |
 | moleditpy\src\moleditpy\ui\atom_picking.py              |    167 |     44 |   73.7% |
-| moleditpy\src\moleditpy\ui\base_picking_dialog.py       |     80 |      4 |   95.0% |
+| moleditpy\src\moleditpy\ui\base_picking_dialog.py       |     81 |      4 |   95.1% |
 | moleditpy\src\moleditpy\ui\bond_item.py                 |    366 |     56 |   84.7% |
-| moleditpy\src\moleditpy\ui\bond_length_dialog.py        |    237 |     17 |   92.8% |
-| moleditpy\src\moleditpy\ui\calculation_worker.py        |    582 |    102 |   82.5% |
-| moleditpy\src\moleditpy\ui\color_settings_dialog.py     |    165 |     13 |   92.1% |
-| moleditpy\src\moleditpy\ui\compute_logic.py             |    391 |     89 |   77.2% |
+| moleditpy\src\moleditpy\ui\bond_length_dialog.py        |    238 |     17 |   92.9% |
+| moleditpy\src\moleditpy\ui\calculation_worker.py        |    583 |    102 |   82.5% |
+| moleditpy\src\moleditpy\ui\color_settings_dialog.py     |    166 |     13 |   92.2% |
+| moleditpy\src\moleditpy\ui\compute_logic.py             |    417 |     88 |   78.9% |
 | moleditpy\src\moleditpy\ui\constrained_optimization_dialog.py |    472 |    120 |   74.6% |
 | moleditpy\src\moleditpy\ui\custom_interactor_style.py   |    470 |    247 |   47.4% |
 | moleditpy\src\moleditpy\ui\custom_qt_interactor.py      |     44 |     35 |   20.5% |
 | moleditpy\src\moleditpy\ui\dialog_3d_picking_mixin.py   |    137 |     19 |   86.1% |
 | moleditpy\src\moleditpy\ui\dialog_logic.py              |    229 |     25 |   89.1% |
-| moleditpy\src\moleditpy\ui\dihedral_dialog.py           |    267 |     32 |   88.0% |
-| moleditpy\src\moleditpy\ui\edit_3d_logic.py             |    220 |     32 |   85.5% |
+| moleditpy\src\moleditpy\ui\dihedral_dialog.py           |    268 |     32 |   88.1% |
+| moleditpy\src\moleditpy\ui\edit_3d_logic.py             |    221 |     32 |   85.5% |
 | moleditpy\src\moleditpy\ui\edit_actions_logic.py        |    815 |    199 |   75.6% |
 | moleditpy\src\moleditpy\ui\export_logic.py              |    520 |    153 |   70.6% |
-| moleditpy\src\moleditpy\ui\geometry_base_dialog.py      |     51 |      1 |   98.0% |
-| moleditpy\src\moleditpy\ui\io_logic.py                  |    681 |    113 |   83.4% |
+| moleditpy\src\moleditpy\ui\geometry_base_dialog.py      |     52 |      1 |   98.1% |
+| moleditpy\src\moleditpy\ui\io_logic.py                  |    679 |    113 |   83.4% |
 | moleditpy\src\moleditpy\ui\main_window.py               |    195 |     14 |   92.8% |
-| moleditpy\src\moleditpy\ui\main_window_init.py          |   1045 |    107 |   89.8% |
+| moleditpy\src\moleditpy\ui\main_window_init.py          |   1056 |    108 |   89.8% |
 | moleditpy\src\moleditpy\ui\mirror_dialog.py             |     72 |      7 |   90.3% |
 | moleditpy\src\moleditpy\ui\molecular_scene_handler.py   |    997 |    161 |   83.9% |
 | moleditpy\src\moleditpy\ui\molecule_scene.py            |    614 |    118 |   80.8% |
 | moleditpy\src\moleditpy\ui\move_group_dialog.py         |    386 |    130 |   66.3% |
 | moleditpy\src\moleditpy\ui\move_selected_atoms_dialog.py |    461 |     75 |   83.7% |
 | moleditpy\src\moleditpy\ui\periodic_table_dialog.py     |     37 |      2 |   94.6% |
-| moleditpy\src\moleditpy\ui\planarize_dialog.py          |    111 |     10 |   91.0% |
-| moleditpy\src\moleditpy\ui\plugin_menu_manager.py       |    252 |     49 |   80.6% |
+| moleditpy\src\moleditpy\ui\planarize_dialog.py          |    112 |      9 |   92.0% |
+| moleditpy\src\moleditpy\ui\plugin_menu_manager.py       |    260 |     53 |   79.6% |
 | moleditpy\src\moleditpy\ui\settings_dialog.py           |    101 |      3 |   97.0% |
 | moleditpy\src\moleditpy\ui\string_importers.py          |    121 |     24 |   80.2% |
 | moleditpy\src\moleditpy\ui\template_preview_item.py     |    102 |      3 |   97.1% |
@@ -62,11 +62,12 @@
 | moleditpy\src\moleditpy\ui\settings_tabs\settings_3d_tabs.py |    142 |      0 |  100.0% |
 | moleditpy\src\moleditpy\ui\settings_tabs\settings_other_tab.py |     89 |      0 |  100.0% |
 | moleditpy\src\moleditpy\ui\settings_tabs\settings_tab_base.py |     57 |      0 |  100.0% |
-| moleditpy\src\moleditpy\utils\constants.py              |     57 |      0 |  100.0% |
+| moleditpy\src\moleditpy\utils\constants.py              |     58 |      0 |  100.0% |
 | moleditpy\src\moleditpy\utils\default_settings.py       |      1 |      0 |  100.0% |
 | moleditpy\src\moleditpy\utils\sip_isdeleted_safe.py     |     19 |      0 |  100.0% |
+| moleditpy\src\moleditpy\utils\suppress_log.py           |     10 |      0 |  100.0% |
 | moleditpy\src\moleditpy\utils\system_utils.py           |     39 |      0 |  100.0% |
-| **TOTAL** | **15918** | **2763** | **82.64%** |
+| **TOTAL** | **16015** | **2788** | **82.59%** |
 
 ## Test Suite Status
 - **Unit tests**: PASSED

--- a/tests/integration/test_plugin_menu_rebuild.py
+++ b/tests/integration/test_plugin_menu_rebuild.py
@@ -45,6 +45,7 @@ def _make_plugin_manager(
     pm.file_openers = file_openers or {}
     pm.analysis_tools = analysis_tools or []
     pm.custom_3d_styles = custom_3d_styles or []
+    pm.optimization_methods = {}
     return pm
 
 
@@ -89,6 +90,7 @@ class TestRebuildCompleteness:
         pmm.integrate_plugin_file_openers = track("file_openers")
         pmm.integrate_plugin_analysis_tools = track("analysis_tools")
         pmm.update_style_menu_with_plugins = track("style_menu")
+        pmm.integrate_plugin_optimization_methods = track("optimization_methods")
 
         pmm.rebuild_plugin_menus()
 
@@ -99,6 +101,7 @@ class TestRebuildCompleteness:
             "file_openers",
             "analysis_tools",
             "style_menu",
+            "optimization_methods",
         ], f"Expected all six steps in order, got: {called}"
 
     def test_all_six_steps_run_when_all_registries_populated(self):
@@ -278,6 +281,7 @@ class TestUpdatePluginMenuIntegration:
             "integrate_plugin_export_actions",
             "integrate_plugin_file_openers",
             "integrate_plugin_analysis_tools",
+            "integrate_plugin_optimization_methods",
         ]
         mocks = {m: MagicMock() for m in integration_methods}
         for m, mock in mocks.items():

--- a/tests/pylint-score.txt
+++ b/tests/pylint-score.txt
@@ -1,1 +1,1 @@
-Your code has been rated at 9.36/10
+Your code has been rated at 9.33/10

--- a/tests/unit/test_plugin_manager.py
+++ b/tests/unit/test_plugin_manager.py
@@ -148,8 +148,26 @@ def test_register_export_action():
 def test_register_optimization_method():
     """register_optimization_method stores the callback under its method name."""
     pm = PluginManager()
+
+    # Mock main_window and init_manager
+    class MockInitManager:
+        def __init__(self):
+            self.added_methods = []
+
+        def add_optimization_method(self, label, key):
+            self.added_methods.append((label, key))
+
+    class MockMainWindow:
+        def __init__(self):
+            self.init_manager = MockInitManager()
+
+    pm.main_window = MockMainWindow()
+
     pm.register_optimization_method("TestPlugin", "MMFF94", lambda: None)
+
     assert "MMFF94" in pm.optimization_methods
+    assert len(pm.main_window.init_manager.added_methods) == 1
+    assert pm.main_window.init_manager.added_methods[0] == ("MMFF94", "MMFF94")
 
 
 def test_register_file_opener():


### PR DESCRIPTION
## Summary

- Fixed dynamic registration for plugin-provided 3D optimization methods so they populate both the top-level "3D Optimization Settings" menu and the right-click context menu.
- Integrated optimization methods into the `PluginMenuManager` rebuild cycle for consistent UI synchronization on reload/plugin changes.
- Added comprehensive unit and integration tests covering registration propagation and UI rebuilding.

## Type of change

- [x] Bug fix
- [ ] New feature
- [x] Refactor / code cleanup
- [ ] Documentation
- [x] Tests
- [ ] CI / build

## Related issues

- Fixes the bug where plugin-registered optimization methods were not displaying in the top menu or the right-click optimization settings context menu.

## Test plan

- [x] Ran `python tests/run_all_tests.py` — all pass
- [-] Manually tested in the GUI with the check list
- [x] Added new unit tests

## Checklist

- [x] `python -m flake8 moleditpy/src/ --select=F` returns 0 issues
- [x] No bare `except:` clauses added (use `except Exception as e:` and log the error)
- [x] No new unused imports or variables
- [x] Plugin API changes are backwards-compatible (or documented in Summary)