### PR TITLE
Dev 4.2.2

### DIFF
--- a/moleditpy/src/moleditpy/ui/compute_logic.py
+++ b/moleditpy/src/moleditpy/ui/compute_logic.py
@@ -45,6 +45,9 @@ class ComputeManager:
         self.halt_ids: Set[int] = set()
         self.next_conversion_id: int = 1
         self.active_worker_ids: Set[int] = set()
+        # worker_id -> (method_key, plugin_entry) for a plugin optimizer to run
+        # as a post-step once conversion's built-in pre-optimization completes.
+        self._pending_plugin_opt: Dict[int, Tuple[str, Dict[str, Any]]] = {}
 
     def reset_active_threads(self) -> None:
         """Reset active calculation threads list."""
@@ -239,6 +242,25 @@ class ComputeManager:
         self.next_conversion_id = run_id + 1
         self.active_worker_ids.add(run_id)
 
+        # The worker only runs built-in force fields. If the selected method is a
+        # plugin optimizer, pre-optimize with MMFF (RDKit) in the worker (which
+        # auto-falls-back to UFF if MMFF setup fails), then run the plugin
+        # callback as a post-step in on_calculation_finished.
+        effective_method = (
+            optimization_method
+            or self.host.init_manager.optimization_method
+            or "MMFF_RDKIT"
+        ).upper()
+        _reg = getattr(
+            getattr(self.host, "plugin_manager", None), "optimization_methods", None
+        )
+        plugin_entry = _reg.get(effective_method) if isinstance(_reg, dict) else None
+        if plugin_entry:
+            self._pending_plugin_opt[run_id] = (effective_method, plugin_entry)
+            worker_method = "MMFF_RDKIT"
+        else:
+            worker_method = effective_method
+
         # UI Updates
         self.host.init_manager.convert_button.setText("Halt conversion")  # type: ignore[union-attr]
         self._safe_disconnect(self.host.init_manager.convert_button.clicked)  # type: ignore[union-attr]
@@ -267,8 +289,7 @@ class ComputeManager:
         options = {
             "conversion_mode": conversion_mode
             or self.host.init_manager.settings.get("3d_conversion_mode", "fallback"),
-            "optimization_method": optimization_method
-            or self.host.init_manager.optimization_method,
+            "optimization_method": worker_method,
             "optimize_intermolecular_interaction_rdkit": self.host.init_manager.settings.get(
                 "optimize_intermolecular_interaction_rdkit", True
             ),
@@ -285,6 +306,7 @@ class ComputeManager:
         if wids_to_halt:
             self.halt_ids.update(wids_to_halt)
         self.active_worker_ids.clear()
+        self._pending_plugin_opt.clear()
 
         self._restore_button_ui()
         self.host.init_manager.cleanup_button.setEnabled(True)  # type: ignore[union-attr]
@@ -529,6 +551,16 @@ class ComputeManager:
         self.host.view_3d_manager.update_atom_id_menu_text()
         self.host.view_3d_manager.update_atom_id_menu_state()
 
+        # If the selected method was a plugin optimizer, the worker only did the
+        # built-in pre-optimization; run the plugin callback now on the result.
+        pending = (
+            self._pending_plugin_opt.pop(worker_id, None)
+            if worker_id is not None
+            else None
+        )
+        if pending and mol:
+            self._run_plugin_optimization(*pending)
+
     def on_calculation_error(self, message: Union[str, Tuple[int, str]]) -> None:
         """Handle an error or halt signal from the background optimization worker."""
         # Accept either a string or (worker_id, message) tuple from the worker signal
@@ -547,8 +579,10 @@ class ComputeManager:
                     self.host.statusBar().showMessage(  # type: ignore[union-attr]
                         f"Ignored stale worker error: {msg} (ID = {worker_id})"
                     )
+                self._pending_plugin_opt.pop(worker_id, None)
                 return  # stale worker, ignore
             self.active_worker_ids.discard(worker_id)
+            self._pending_plugin_opt.pop(worker_id, None)
         else:
             msg = str(message)
 

--- a/moleditpy/src/moleditpy/ui/main_window_init.py
+++ b/moleditpy/src/moleditpy/ui/main_window_init.py
@@ -1723,6 +1723,13 @@ class MainInitManager:
         self.opt_group.addAction(action)
         self.opt3d_actions[key_upper] = action
 
+        # Plugins register after menu-init, so restore the saved default here
+        # if it names this method (menu-init fell back to MMFF_RDKIT).
+        saved_opt = (self.settings.get("optimization_method") or "").upper()
+        if key_upper == saved_opt:
+            action.setChecked(True)
+            self.optimization_method = key_upper
+
     def _init_help_menu(self, menu_bar: Any) -> None:
         """Initialize the Help menu."""
         help_menu = menu_bar.addMenu("&Help")

--- a/moleditpy/src/moleditpy/ui/plugin_menu_manager.py
+++ b/moleditpy/src/moleditpy/ui/plugin_menu_manager.py
@@ -369,14 +369,30 @@ class PluginMenuManager:
                 menu.addAction(a)
 
     def integrate_plugin_optimization_methods(self) -> None:
-        """Inject plugin optimization methods into the 3D Optimization Settings menu."""
-        if not hasattr(self._im.host.plugin_manager, "optimization_methods"):
+        """Inject plugin optimization methods into the 3D Optimization Settings menu.
+
+        Idempotent: previously-added plugin methods are purged first, so a menu
+        rebuild (install/uninstall/reload) re-adds only the currently registered
+        ones. Without this, _clean_menu removes the menu action while
+        opt3d_actions still holds it, and add_optimization_method's dedupe guard
+        would then skip re-adding a still-installed method.
+        """
+        im = self._im
+        methods = getattr(im.host.plugin_manager, "optimization_methods", None)
+        if not isinstance(methods, dict):
             return
 
-        for key, entry in self._im.host.plugin_manager.optimization_methods.items():
-            self._im.add_optimization_method(entry["label"], key)
-            if key in self._im.opt3d_actions:
-                self._im.opt3d_actions[key].setData("plugin_managed")
+        for key, action in list(im.opt3d_actions.items()):
+            if action.data() == "plugin_managed":
+                im.opt_group.removeAction(action)
+                im.optimization_menu.removeAction(action)
+                del im.opt3d_actions[key]
+                im.opt3d_method_labels.pop(key, None)
+
+        for key, entry in methods.items():
+            im.add_optimization_method(entry["label"], key)
+            if key in im.opt3d_actions:
+                im.opt3d_actions[key].setData("plugin_managed")
 
     def integrate_plugin_file_openers(self) -> None:
         """Inject plugin file-opener entries into the File > Import menu."""

--- a/tests/assertion_catalog.md
+++ b/tests/assertion_catalog.md
@@ -7471,6 +7471,22 @@ _Registered analysis tools appear as actions in the Analysis menu after rebuild.
 - assert 'NMR Predict' in added.text()
 - assert 'NMRPro' in added.text()
 
+## tests/integration/test_plugin_opt_method_rebuild.py
+
+### test_plugin_method_readded_after_rebuild
+_No description provided._
+
+- assert 'Quick UFF' in _menu_labels(im)
+- assert 'Quick UFF' not in _menu_labels(im)
+- assert 'Quick UFF' in _menu_labels(im)
+- assert 'QUICK UFF' in im.opt3d_actions
+
+### test_uninstalled_plugin_method_purged_on_rebuild
+_No description provided._
+
+- assert 'QUICK UFF' not in im.opt3d_actions
+- assert 'Quick UFF' not in _menu_labels(im)
+
 ## tests/integration/test_trigger_conversion_plugin_wrap.py
 
 ### TestTriggerConversionTempMode.test_temp_mode_stored_and_consumed

--- a/tests/assertion_catalog.md
+++ b/tests/assertion_catalog.md
@@ -4044,6 +4044,22 @@ _Test that a single click clears the selection when Box Selection is ON._
 
 - mock_clear.assert_called_once()
 
+## tests/unit/test_optimization_method_restore.py
+
+### test_saved_plugin_method_restored_on_registration
+_No description provided._
+
+- assert im.opt3d_actions['QUICK UFF'].isChecked()
+- assert not im.opt3d_actions['MMFF_RDKIT'].isChecked()
+- assert im.optimization_method == 'QUICK UFF'
+
+### test_non_default_plugin_method_left_unchecked
+_No description provided._
+
+- assert not im.opt3d_actions['QUICK UFF'].isChecked()
+- assert im.opt3d_actions['MMFF_RDKIT'].isChecked()
+- assert im.optimization_method == 'MMFF_RDKIT'
+
 ## tests/unit/test_parser_robustness.py
 
 ### test_set_mol_prop_safe_robustness
@@ -7487,6 +7503,24 @@ _The conversion mode set via _trigger_conversion_with_temp_mode_
 
 - assert hasattr(compute, '_captured_options')
 - assert compute._captured_options['conversion_mode'] == 'fallback'
+
+### TestPluginConversionPreOptimize.test_plugin_default_preoptimizes_with_mmff_and_queues_post_step
+_No description provided._
+
+- assert options['optimization_method'] == 'MMFF_RDKIT'
+- assert compute._pending_plugin_opt[run_id] == ('QUICK UFF', entry)
+
+### TestPluginConversionPreOptimize.test_builtin_default_queues_no_post_step
+_No description provided._
+
+- assert options['optimization_method'] == 'UFF_RDKIT'
+- assert compute._pending_plugin_opt == {}
+
+### TestPluginConversionPreOptimize.test_finished_runs_pending_plugin_callback
+_No description provided._
+
+- cb.assert_called_once_with(mol)
+- assert run_id not in compute._pending_plugin_opt
 
 ## tests/gui/test_additional_dialogs_launch.py
 

--- a/tests/coverage_report.md
+++ b/tests/coverage_report.md
@@ -1,6 +1,6 @@
 # MoleditPy Coverage Report
 
-- **Overall Project Coverage**: **82.67%**
+- **Overall Project Coverage**: **82.71%**
 
 ### Coverage Breakdown
 
@@ -25,7 +25,7 @@
 | moleditpy\src\moleditpy\ui\base_picking_dialog.py       |     81 |      4 |   95.1% |
 | moleditpy\src\moleditpy\ui\bond_item.py                 |    366 |     56 |   84.7% |
 | moleditpy\src\moleditpy\ui\bond_length_dialog.py        |    238 |     17 |   92.9% |
-| moleditpy\src\moleditpy\ui\calculation_worker.py        |    583 |    102 |   82.5% |
+| moleditpy\src\moleditpy\ui\calculation_worker.py        |    583 |    101 |   82.7% |
 | moleditpy\src\moleditpy\ui\color_settings_dialog.py     |    166 |     13 |   92.2% |
 | moleditpy\src\moleditpy\ui\compute_logic.py             |    431 |     88 |   79.6% |
 | moleditpy\src\moleditpy\ui\constrained_optimization_dialog.py |    472 |    120 |   74.6% |
@@ -48,7 +48,7 @@
 | moleditpy\src\moleditpy\ui\move_selected_atoms_dialog.py |    461 |     75 |   83.7% |
 | moleditpy\src\moleditpy\ui\periodic_table_dialog.py     |     37 |      2 |   94.6% |
 | moleditpy\src\moleditpy\ui\planarize_dialog.py          |    112 |      9 |   92.0% |
-| moleditpy\src\moleditpy\ui\plugin_menu_manager.py       |    260 |     53 |   79.6% |
+| moleditpy\src\moleditpy\ui\plugin_menu_manager.py       |    268 |     49 |   81.7% |
 | moleditpy\src\moleditpy\ui\settings_dialog.py           |    101 |      3 |   97.0% |
 | moleditpy\src\moleditpy\ui\string_importers.py          |    121 |     24 |   80.2% |
 | moleditpy\src\moleditpy\ui\template_preview_item.py     |    102 |      3 |   97.1% |
@@ -67,7 +67,7 @@
 | moleditpy\src\moleditpy\utils\sip_isdeleted_safe.py     |     19 |      0 |  100.0% |
 | moleditpy\src\moleditpy\utils\suppress_log.py           |     10 |      0 |  100.0% |
 | moleditpy\src\moleditpy\utils\system_utils.py           |     39 |      0 |  100.0% |
-| **TOTAL** | **16033** | **2778** | **82.67%** |
+| **TOTAL** | **16041** | **2773** | **82.71%** |
 
 ## Test Suite Status
 - **Unit tests**: PASSED

--- a/tests/coverage_report.md
+++ b/tests/coverage_report.md
@@ -1,6 +1,6 @@
 # MoleditPy Coverage Report
 
-- **Overall Project Coverage**: **82.59%**
+- **Overall Project Coverage**: **82.67%**
 
 ### Coverage Breakdown
 
@@ -27,7 +27,7 @@
 | moleditpy\src\moleditpy\ui\bond_length_dialog.py        |    238 |     17 |   92.9% |
 | moleditpy\src\moleditpy\ui\calculation_worker.py        |    583 |    102 |   82.5% |
 | moleditpy\src\moleditpy\ui\color_settings_dialog.py     |    166 |     13 |   92.2% |
-| moleditpy\src\moleditpy\ui\compute_logic.py             |    417 |     88 |   78.9% |
+| moleditpy\src\moleditpy\ui\compute_logic.py             |    431 |     88 |   79.6% |
 | moleditpy\src\moleditpy\ui\constrained_optimization_dialog.py |    472 |    120 |   74.6% |
 | moleditpy\src\moleditpy\ui\custom_interactor_style.py   |    470 |    247 |   47.4% |
 | moleditpy\src\moleditpy\ui\custom_qt_interactor.py      |     44 |     35 |   20.5% |
@@ -40,7 +40,7 @@
 | moleditpy\src\moleditpy\ui\geometry_base_dialog.py      |     52 |      1 |   98.1% |
 | moleditpy\src\moleditpy\ui\io_logic.py                  |    679 |    113 |   83.4% |
 | moleditpy\src\moleditpy\ui\main_window.py               |    195 |     14 |   92.8% |
-| moleditpy\src\moleditpy\ui\main_window_init.py          |   1056 |    108 |   89.8% |
+| moleditpy\src\moleditpy\ui\main_window_init.py          |   1060 |     99 |   90.7% |
 | moleditpy\src\moleditpy\ui\mirror_dialog.py             |     72 |      7 |   90.3% |
 | moleditpy\src\moleditpy\ui\molecular_scene_handler.py   |    997 |    161 |   83.9% |
 | moleditpy\src\moleditpy\ui\molecule_scene.py            |    614 |    118 |   80.8% |
@@ -56,7 +56,7 @@
 | moleditpy\src\moleditpy\ui\translation_dialog.py        |    276 |     21 |   92.4% |
 | moleditpy\src\moleditpy\ui\ui_manager.py                |    368 |     98 |   73.4% |
 | moleditpy\src\moleditpy\ui\user_template_dialog.py      |    360 |     79 |   78.1% |
-| moleditpy\src\moleditpy\ui\view_3d_logic.py             |   1007 |    259 |   74.3% |
+| moleditpy\src\moleditpy\ui\view_3d_logic.py             |   1007 |    258 |   74.4% |
 | moleditpy\src\moleditpy\ui\zoomable_view.py             |     82 |      2 |   97.6% |
 | moleditpy\src\moleditpy\ui\settings_tabs\settings_2d_tab.py |    144 |      0 |  100.0% |
 | moleditpy\src\moleditpy\ui\settings_tabs\settings_3d_tabs.py |    142 |      0 |  100.0% |
@@ -67,7 +67,7 @@
 | moleditpy\src\moleditpy\utils\sip_isdeleted_safe.py     |     19 |      0 |  100.0% |
 | moleditpy\src\moleditpy\utils\suppress_log.py           |     10 |      0 |  100.0% |
 | moleditpy\src\moleditpy\utils\system_utils.py           |     39 |      0 |  100.0% |
-| **TOTAL** | **16015** | **2788** | **82.59%** |
+| **TOTAL** | **16033** | **2778** | **82.67%** |
 
 ## Test Suite Status
 - **Unit tests**: PASSED

--- a/tests/integration/test_plugin_menu_rebuild.py
+++ b/tests/integration/test_plugin_menu_rebuild.py
@@ -13,15 +13,24 @@ from moleditpy.ui.plugin_menu_manager import PluginMenuManager
 
 
 # QAction(text, MagicMock) fails because PyQt6 strictly validates parent type.
-# Patch it to drop the mock parent so tests run headlessly (including CI).
+# Patch it to parent actions to a real QObject instead of the mock. Parenting
+# (rather than dropping the parent) gives the QActions a deterministic owner, so
+# Qt destroys them in order with the holder while QApplication is still alive —
+# leaving them unparented causes an access-violation crash at GC on Windows when
+# this file runs in isolation.
 @pytest.fixture(autouse=True)
-def _patch_qaction(monkeypatch):
+def _patch_qaction(monkeypatch, app):
+    from PyQt6.QtCore import QObject
     from PyQt6.QtGui import QAction as _RealQAction
 
+    holder = QObject()
+
     def _safe_qaction(text: str, parent=None) -> _RealQAction:
-        return _RealQAction(text)
+        return _RealQAction(text, holder)
 
     monkeypatch.setattr("moleditpy.ui.plugin_menu_manager.QAction", _safe_qaction)
+    yield
+    holder.deleteLater()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integration/test_plugin_opt_method_rebuild.py
+++ b/tests/integration/test_plugin_opt_method_rebuild.py
@@ -1,0 +1,75 @@
+"""Regression test: plugin optimization methods survive a menu rebuild.
+
+On rebuild_plugin_menus, _clean_menu removes the plugin-managed optimization
+action from the menu but leaves it in opt3d_actions. Before the fix,
+add_optimization_method's dedupe guard then skipped re-adding a still-installed
+method, so plugin optimizers vanished from the 3D Optimization Settings menu
+after any plugin install/uninstall/reload.
+"""
+
+from types import SimpleNamespace
+
+from PyQt6.QtCore import QObject
+from PyQt6.QtGui import QAction, QActionGroup
+from PyQt6.QtWidgets import QMenu
+
+from moleditpy.ui.main_window_init import MainInitManager
+from moleditpy.ui.plugin_menu_manager import PluginMenuManager
+
+
+def _make_im(methods):
+    im = MainInitManager.__new__(MainInitManager)
+    im.host = QObject()
+    im.host.plugin_manager = SimpleNamespace(optimization_methods=methods)
+    im.settings = {"optimization_method": "MMFF_RDKIT"}
+    im.optimization_menu = QMenu()
+    im.opt3d_separator = im.optimization_menu.addSeparator()
+    im.opt_group = QActionGroup(im.optimization_menu)
+    im.opt_group.setExclusive(True)
+    im.opt3d_method_labels = {}
+
+    mmff = QAction("MMFF94s (RDKit)")
+    mmff.setCheckable(True)
+    im.opt_group.addAction(mmff)
+    im.opt3d_actions = {"MMFF_RDKIT": mmff}
+    return im
+
+
+def _menu_labels(im):
+    return {a.text() for a in im.optimization_menu.actions() if not a.isSeparator()}
+
+
+def test_plugin_method_readded_after_rebuild(app):
+    methods = {
+        "QUICK UFF": {"plugin": "P", "callback": lambda m: True, "label": "Quick UFF"}
+    }
+    im = _make_im(methods)
+    pmm = PluginMenuManager(im)
+
+    pmm.integrate_plugin_optimization_methods()
+    assert "Quick UFF" in _menu_labels(im)
+
+    # Simulate _clean_menu during rebuild: the tagged action is pulled from the
+    # menu but not from opt3d_actions.
+    im.optimization_menu.removeAction(im.opt3d_actions["QUICK UFF"])
+    assert "Quick UFF" not in _menu_labels(im)
+
+    pmm.integrate_plugin_optimization_methods()
+    assert "Quick UFF" in _menu_labels(im)
+    assert "QUICK UFF" in im.opt3d_actions
+
+
+def test_uninstalled_plugin_method_purged_on_rebuild(app):
+    methods = {
+        "QUICK UFF": {"plugin": "P", "callback": lambda m: True, "label": "Quick UFF"}
+    }
+    im = _make_im(methods)
+    pmm = PluginMenuManager(im)
+    pmm.integrate_plugin_optimization_methods()
+
+    # Plugin uninstalled: registry empties before the rebuild.
+    methods.clear()
+    pmm.integrate_plugin_optimization_methods()
+
+    assert "QUICK UFF" not in im.opt3d_actions
+    assert "Quick UFF" not in _menu_labels(im)

--- a/tests/integration/test_trigger_conversion_plugin_wrap.py
+++ b/tests/integration/test_trigger_conversion_plugin_wrap.py
@@ -351,3 +351,101 @@ class TestPluginWrappedTriggerConversion:
             "trigger_conversion never reached _start_calculation_worker"
         )
         assert compute._captured_options["conversion_mode"] == "fallback"
+
+
+# ---------------------------------------------------------------------------
+# Test: plugin optimization method as the conversion default
+# ---------------------------------------------------------------------------
+
+
+class TestPluginConversionPreOptimize:
+    """When the default optimizer is a plugin method, conversion pre-optimizes
+    with a built-in force field and runs the plugin callback as a post-step."""
+
+    @staticmethod
+    def _make_compute(host):
+        compute = object.__new__(ComputeManager)
+        compute._host = host
+        ComputeManager.__init__(compute, host)
+        return compute
+
+    def test_plugin_default_preoptimizes_with_mmff_and_queues_post_step(
+        self, host, app
+    ):
+        compute = self._make_compute(host)
+        entry = {
+            "plugin": "P",
+            "callback": MagicMock(return_value=True),
+            "label": "Quick UFF",
+        }
+        host.plugin_manager.optimization_methods = {"QUICK UFF": entry}
+        host.init_manager.optimization_method = "QUICK UFF"
+
+        mol = Chem.MolFromSmiles("C")
+        host.state_manager.data.atoms = {1: {"symbol": "C"}}
+
+        with (
+            patch.object(host.state_manager.data, "to_rdkit_mol", return_value=mol),
+            patch("rdkit.Chem.DetectChemistryProblems", return_value=[]),
+            patch("rdkit.Chem.SanitizeMol"),
+            patch.object(
+                host.state_manager.data,
+                "to_mol_block",
+                return_value=Chem.MolToMolBlock(mol),
+            ),
+            patch.object(compute, "_start_calculation_worker") as mock_start,
+        ):
+            compute.trigger_conversion()
+
+        options = mock_start.call_args[0][1]
+        # Worker gets a built-in FF, not the plugin key.
+        assert options["optimization_method"] == "MMFF_RDKIT"
+        # The plugin post-step is queued against the worker id.
+        run_id = options["worker_id"]
+        assert compute._pending_plugin_opt[run_id] == ("QUICK UFF", entry)
+
+    def test_builtin_default_queues_no_post_step(self, host, app):
+        compute = self._make_compute(host)
+        host.plugin_manager.optimization_methods = {}
+        host.init_manager.optimization_method = "UFF_RDKIT"
+
+        mol = Chem.MolFromSmiles("C")
+        host.state_manager.data.atoms = {1: {"symbol": "C"}}
+
+        with (
+            patch.object(host.state_manager.data, "to_rdkit_mol", return_value=mol),
+            patch("rdkit.Chem.DetectChemistryProblems", return_value=[]),
+            patch("rdkit.Chem.SanitizeMol"),
+            patch.object(
+                host.state_manager.data,
+                "to_mol_block",
+                return_value=Chem.MolToMolBlock(mol),
+            ),
+            patch.object(compute, "_start_calculation_worker") as mock_start,
+        ):
+            compute.trigger_conversion()
+
+        options = mock_start.call_args[0][1]
+        assert options["optimization_method"] == "UFF_RDKIT"
+        assert compute._pending_plugin_opt == {}
+
+    def test_finished_runs_pending_plugin_callback(self, host, app):
+        compute = self._make_compute(host)
+        cb = MagicMock(return_value=True)
+        entry = {"plugin": "P", "callback": cb, "label": "Quick UFF"}
+        run_id = 7
+        compute._pending_plugin_opt[run_id] = ("QUICK UFF", entry)
+        compute.active_worker_ids.add(run_id)
+
+        mol = Chem.MolFromSmiles("C")
+        host.view_3d_manager.current_mol = mol
+
+        with (
+            patch.object(compute, "create_atom_id_mapping"),
+            patch.object(compute, "_refresh_ui_state"),
+            patch.object(compute, "_remove_calculating_text"),
+        ):
+            compute.on_calculation_finished((run_id, mol))
+
+        cb.assert_called_once_with(mol)
+        assert run_id not in compute._pending_plugin_opt

--- a/tests/unit/test_main_window_init_coverage.py
+++ b/tests/unit/test_main_window_init_coverage.py
@@ -8,21 +8,26 @@ def test_imports_mainwindow():
     assert hasattr(MainInitManager, "init_ui")
 
 
-def test_mainwindow_init_with_mocks():
+def test_mainwindow_init_with_mocks(app):
     """Verify MainWindow instantiates MainInitManager during initialization."""
     # Patch the MainInitManager class in the main_window module
     with patch("moleditpy.ui.main_window.MainInitManager") as MockInitManager:
         from moleditpy.ui.main_window import MainWindow
 
-        # Instantiate MainWindow
+        # Instantiate MainWindow. Close + delete it before teardown: an un-closed
+        # real QMainWindow GC'd after QApplication teardown crashes on Windows
+        # when this file runs in isolation.
         mw = MainWindow()
+        try:
+            # Verify MainInitManager was instantiated
+            MockInitManager.assert_called_once()
 
-        # Verify MainInitManager was instantiated
-        MockInitManager.assert_called_once()
+            # Verify the instance is assigned to mw.init_manager
+            assert mw.init_manager == MockInitManager.return_value
 
-        # Verify the instance is assigned to mw.init_manager
-        assert mw.init_manager == MockInitManager.return_value
-
-        # Verify it was called with mw as the first argument (host)
-        args, kwargs = MockInitManager.call_args
-        assert args[0] == mw
+            # Verify it was called with mw as the first argument (host)
+            args, kwargs = MockInitManager.call_args
+            assert args[0] == mw
+        finally:
+            mw.close()
+            mw.deleteLater()

--- a/tests/unit/test_optimization_method_restore.py
+++ b/tests/unit/test_optimization_method_restore.py
@@ -1,0 +1,57 @@
+"""Regression tests for restoring a persisted plugin optimization method.
+
+Plugins register their optimization methods *after* the settings menu is built,
+so a saved default naming a plugin method could not be restored at menu-init and
+silently fell back to MMFF_RDKIT. add_optimization_method must reconcile the
+newly added method with the saved default.
+"""
+
+from PyQt6.QtCore import QObject
+from PyQt6.QtGui import QAction, QActionGroup
+from PyQt6.QtWidgets import QMenu
+
+from moleditpy.ui.main_window_init import MainInitManager
+
+
+def _make_init_manager(saved_opt):
+    """Build a MainInitManager with only the state add_optimization_method needs,
+    simulating the post-menu-init state where MMFF_RDKIT is the checked fallback.
+    """
+    im = MainInitManager.__new__(MainInitManager)
+    # Real QObject so QAction accepts it as parent (PyQt6 validates parent type);
+    # the triggered lambda is only stored, never invoked here.
+    im.host = QObject()
+    im.settings = {"optimization_method": saved_opt}
+    im.optimization_menu = QMenu()
+    im.opt3d_separator = im.optimization_menu.addSeparator()
+    im.opt_group = QActionGroup(im.optimization_menu)
+    im.opt_group.setExclusive(True)
+    im.opt3d_method_labels = {}
+
+    mmff = QAction("MMFF94s (RDKit)")
+    mmff.setCheckable(True)
+    mmff.setChecked(True)
+    im.opt_group.addAction(mmff)
+    im.opt3d_actions = {"MMFF_RDKIT": mmff}
+    im.optimization_method = "MMFF_RDKIT"
+    return im
+
+
+def test_saved_plugin_method_restored_on_registration(app):
+    im = _make_init_manager(saved_opt="QUICK UFF")
+
+    im.add_optimization_method("Quick UFF", "QUICK UFF")
+
+    assert im.opt3d_actions["QUICK UFF"].isChecked()
+    assert not im.opt3d_actions["MMFF_RDKIT"].isChecked()
+    assert im.optimization_method == "QUICK UFF"
+
+
+def test_non_default_plugin_method_left_unchecked(app):
+    im = _make_init_manager(saved_opt="MMFF_RDKIT")
+
+    im.add_optimization_method("Quick UFF", "QUICK UFF")
+
+    assert not im.opt3d_actions["QUICK UFF"].isChecked()
+    assert im.opt3d_actions["MMFF_RDKIT"].isChecked()
+    assert im.optimization_method == "MMFF_RDKIT"

--- a/tests/unit/test_plugin_menu_manager.py
+++ b/tests/unit/test_plugin_menu_manager.py
@@ -16,14 +16,25 @@ from moleditpy.ui.plugin_menu_manager import PluginMenuManager
 
 
 @pytest.fixture(autouse=True)
-def _patch_qaction(monkeypatch):
-    """Allow QAction to be constructed with a MagicMock host in unit tests."""
+def _patch_qaction(monkeypatch, app):
+    """Allow QAction to be constructed with a MagicMock host in unit tests.
+
+    Parent the actions to a real QObject holder (not None): unparented QActions
+    get GC'd after QApplication teardown, causing an access-violation crash on
+    Windows when this file runs in isolation. The holder gives them an owner
+    destroyed in order while the app is alive.
+    """
+    from PyQt6.QtCore import QObject
     from PyQt6.QtGui import QAction as _RealQAction
 
+    holder = QObject()
+
     def _safe_qaction(text: str, parent=None) -> QAction:
-        return _RealQAction(text)
+        return _RealQAction(text, holder)
 
     monkeypatch.setattr("moleditpy.ui.plugin_menu_manager.QAction", _safe_qaction)
+    yield
+    holder.deleteLater()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **Saved Default Restoration:** Restores the persisted plugin-defined default optimization method at startup by reconciling the saved setting with plugin methods as they register.
- **Menu Rebuild Idempotency:** Fixes a bug where plugin optimization methods disappeared from the menu after a plugin reload, install, or uninstall by properly purging old plugin actions before re-populating.
- **Plugin Optimizer in 2D->3D Conversion:** Supports plugin-registered optimizers during 2D->3D conversion by running a built-in MMFF (RDKit) pre-optimization in the background worker, then executing the plugin's optimization callback on the main thread as a post-step.
- **Plugin Wrapping Compatibility:** Maintains backwards compatibility with third-party plugins that monkey-patch `trigger_conversion` without forwarding kwargs, passing the mode via `_pending_conversion_mode` state instead.

## Type of change

- [x] Bug fix
- [ ] New feature
- [x] Refactor / code cleanup
- [ ] Documentation
- [x] Tests
- [ ] CI / build

## Related issues


## Test plan

- [x] Ran `python tests/run_all_tests.py` — all pass
- [-] Manually tested in the GUI with the check list
- [x] Added new unit tests

## Checklist

- [x] `python -m flake8 moleditpy/src/ --select=F` returns 0 issues
- [x] No bare `except:` clauses added (use `except Exception as e:` and log the error)
- [x] No new unused imports or variables
- [x] Plugin API changes are backwards-compatible (or documented in Summary)