### PR TITLE
Dev 4.3.0

### DIFF
--- a/moleditpy/src/moleditpy/main.py
+++ b/moleditpy/src/moleditpy/main.py
@@ -98,9 +98,7 @@ class _ErrorDialogHandler(logging.Handler):
             # Source location (as the terminal log shows), then any traceback.
             detail = f"{record.pathname}:{record.lineno}"
             if record.exc_info:
-                detail += "\n\n" + "".join(
-                    traceback.format_exception(*record.exc_info)
-                )
+                detail += "\n\n" + "".join(traceback.format_exception(*record.exc_info))
 
             signature = hashlib.sha1(
                 (message + detail).encode("utf-8", "replace")

--- a/moleditpy/src/moleditpy/main.py
+++ b/moleditpy/src/moleditpy/main.py
@@ -11,20 +11,22 @@ DOI: 10.5281/zenodo.17268532
 """
 
 import ctypes
+import hashlib
 import json
 import logging
 import logging.handlers
 import os
 import sys
 import argparse
+import traceback
 from typing import Any, Optional
 
 from .utils.constants import VERSION
 
 # VERSION is resolved above (before Qt) so --version works without launching the app.
 
-from PyQt6.QtCore import QtMsgType, qInstallMessageHandler
-from PyQt6.QtWidgets import QApplication
+from PyQt6.QtCore import QtMsgType, QThread, qInstallMessageHandler
+from PyQt6.QtWidgets import QApplication, QMessageBox
 
 from .ui.main_window import MainWindow
 
@@ -47,6 +49,57 @@ def _qt_message_handler(mode: QtMsgType, _context: Any, message: Optional[str]) 
             logging.debug("Qt: %s", message)
             return
     logging.log(_QT_LOG_LEVEL.get(mode, logging.WARNING), "Qt: %s", message)
+
+
+# Traceback signatures already shown this session, so a repeating exception
+# (e.g. one thrown from a QTimer slot or a paint event) surfaces a dialog once
+# instead of storming the user with an unclosable stack of modals.
+_shown_exception_signatures: set[str] = set()
+
+
+def _show_exception_dialog(
+    exc_type: Any, exc_value: Any, exc_traceback: Any
+) -> None:
+    """Surface an uncaught exception in a modal dialog, at most once per bug.
+
+    Only runs when a GUI event loop is up and we are on the GUI thread — an
+    exception raised before/without the QApplication, or from a worker thread
+    (where a QMessageBox is unsafe), falls back to the already-emitted log
+    record. Anything that goes wrong here is swallowed to DEBUG so the
+    excepthook can never recurse or mask the original error.
+    """
+    try:
+        app = QApplication.instance()
+        if app is None or QThread.currentThread() is not app.thread():
+            return
+
+        tb_text = "".join(
+            traceback.format_exception(exc_type, exc_value, exc_traceback)
+        )
+        signature = hashlib.sha1(tb_text.encode("utf-8", "replace")).hexdigest()
+        if signature in _shown_exception_signatures:
+            return
+        _shown_exception_signatures.add(signature)
+
+        log_path = os.path.join(
+            os.path.expanduser("~"), ".moleditpy", "moleditpy.log"
+        )
+        box = QMessageBox()
+        box.setIcon(QMessageBox.Icon.Critical)
+        box.setWindowTitle("MoleditPy — Unexpected Error")
+        box.setText(
+            "An unexpected error occurred. The application may be unstable; "
+            "saving your work and restarting is recommended."
+        )
+        box.setInformativeText(
+            f"{exc_type.__name__}: {exc_value}\n\n"
+            f"Details are in the log:\n{log_path}"
+        )
+        box.setDetailedText(tb_text)
+        box.setStandardButtons(QMessageBox.StandardButton.Ok)
+        box.exec()
+    except Exception:
+        logging.debug("Failed to show exception dialog", exc_info=True)
 
 
 def _read_startup_log_settings() -> tuple[bool, bool]:
@@ -94,13 +147,18 @@ def setup_logging() -> None:
             logging.warning("Could not open log file: %s", e)
 
     def handle_exception(exc_type: Any, exc_value: Any, exc_traceback: Any) -> None:
-        """Log unhandled exceptions using the configured logging system."""
+        """Log unhandled exceptions and, if a GUI is up, surface them once.
+
+        This fires only for genuinely uncaught exceptions (real bugs) — never
+        for logged warnings/info, which do not pass through sys.excepthook.
+        """
         if issubclass(exc_type, KeyboardInterrupt):
             sys.__excepthook__(exc_type, exc_value, exc_traceback)
             return
         logging.error(
             "Uncaught exception", exc_info=(exc_type, exc_value, exc_traceback)
         )
+        _show_exception_dialog(exc_type, exc_value, exc_traceback)
 
     sys.excepthook = handle_exception
 

--- a/moleditpy/src/moleditpy/main.py
+++ b/moleditpy/src/moleditpy/main.py
@@ -91,6 +91,8 @@ class _ErrorDialogHandler(logging.Handler):
             app = QApplication.instance()
             if app is None or QThread.currentThread() is not app.thread():
                 return
+            if app.property("moleditpy_shutting_down"):
+                return
 
             message = record.getMessage()
             # Source location (as the terminal log shows), then any traceback.

--- a/moleditpy/src/moleditpy/main.py
+++ b/moleditpy/src/moleditpy/main.py
@@ -93,9 +93,12 @@ class _ErrorDialogHandler(logging.Handler):
                 return
 
             message = record.getMessage()
-            detail = ""
+            # Source location (as the terminal log shows), then any traceback.
+            detail = f"{record.pathname}:{record.lineno}"
             if record.exc_info:
-                detail = "".join(traceback.format_exception(*record.exc_info))
+                detail += "\n\n" + "".join(
+                    traceback.format_exception(*record.exc_info)
+                )
 
             signature = hashlib.sha1(
                 (message + detail).encode("utf-8", "replace")

--- a/moleditpy/src/moleditpy/main.py
+++ b/moleditpy/src/moleditpy/main.py
@@ -25,7 +25,7 @@ from .utils.constants import VERSION
 
 # VERSION is resolved above (before Qt) so --version works without launching the app.
 
-from PyQt6.QtCore import QtMsgType, QThread, qInstallMessageHandler
+from PyQt6.QtCore import QtMsgType, QThread, QTimer, qInstallMessageHandler
 from PyQt6.QtWidgets import QApplication, QMessageBox
 
 from .ui.main_window import MainWindow
@@ -51,55 +51,99 @@ def _qt_message_handler(mode: QtMsgType, _context: Any, message: Optional[str]) 
     logging.log(_QT_LOG_LEVEL.get(mode, logging.WARNING), "Qt: %s", message)
 
 
-# Traceback signatures already shown this session, so a repeating exception
-# (e.g. one thrown from a QTimer slot or a paint event) surfaces a dialog once
-# instead of storming the user with an unclosable stack of modals.
-_shown_exception_signatures: set[str] = set()
+class _ErrorDialogHandler(logging.Handler):
+    """Surface ERROR/CRITICAL log records in a dialog, once per unique message.
 
+    The uncaught-exception hook routes through here too (it logs at ERROR with
+    ``exc_info``), so every genuine failure — logged explicitly or bubbling out
+    of Qt — gets one dialog. Warnings/info never reach it (handler level is
+    ERROR). All state is per-instance; the one instance is created and attached
+    in :func:`setup_logging` (only for a real GUI run, never headless).
 
-def _show_exception_dialog(
-    exc_type: Any, exc_value: Any, exc_traceback: Any
-) -> None:
-    """Surface an uncaught exception in a modal dialog, at most once per bug.
+    Guards: GUI thread + live QApplication only (a worker-thread record, where a
+    QMessageBox is unsafe, stays log-only); per-message-signature dedup so a
+    repeating error surfaces once, not once per tick; and
+    ``extra={"no_dialog": True}`` to opt a record out. ``emit`` never raises.
 
-    Only runs when a GUI event loop is up and we are on the GUI thread — an
-    exception raised before/without the QApplication, or from a worker thread
-    (where a QMessageBox is unsafe), falls back to the already-emitted log
-    record. Anything that goes wrong here is swallowed to DEBUG so the
-    excepthook can never recurse or mask the original error.
+    The dialog is shown non-blocking (``show``, not ``exec``): it never spins a
+    nested event loop, so it cannot freeze the app — or a GUI-enabled test run —
+    while it is on screen.
     """
-    try:
-        app = QApplication.instance()
-        if app is None or QThread.currentThread() is not app.thread():
-            return
 
-        tb_text = "".join(
-            traceback.format_exception(exc_type, exc_value, exc_traceback)
-        )
-        signature = hashlib.sha1(tb_text.encode("utf-8", "replace")).hexdigest()
-        if signature in _shown_exception_signatures:
-            return
-        _shown_exception_signatures.add(signature)
+    def __init__(self, log_path: Optional[str] = None) -> None:
+        super().__init__(level=logging.ERROR)
+        # Message+traceback signatures already shown this session.
+        self._shown_signatures: set[str] = set()
+        # Live dialogs, held so a non-blocking box is not garbage collected
+        # (and thus dismissed) the moment _show returns.
+        self._open_boxes: set = set()
+        # Log-file path, set only when file logging is enabled (see _details).
+        self._log_path = log_path
 
-        log_path = os.path.join(
-            os.path.expanduser("~"), ".moleditpy", "moleditpy.log"
+    def emit(self, record: logging.LogRecord) -> None:
+        try:
+            if getattr(record, "no_dialog", False):
+                return
+            app = QApplication.instance()
+            if app is None or QThread.currentThread() is not app.thread():
+                return
+
+            message = record.getMessage()
+            detail = ""
+            if record.exc_info:
+                detail = "".join(traceback.format_exception(*record.exc_info))
+
+            signature = hashlib.sha1(
+                (message + detail).encode("utf-8", "replace")
+            ).hexdigest()
+            if signature in self._shown_signatures:
+                return
+            self._shown_signatures.add(signature)
+
+            # Defer so a site's own QMessageBox.critical (raised right after the
+            # log call) is already modal when _show checks activeModalWidget.
+            QTimer.singleShot(0, lambda: self._show(message, detail))
+        except Exception:  # pragma: no cover - logging must never raise
+            self.handleError(record)
+
+    def _details(self) -> str:
+        """Where to find the full error text, honest about file logging."""
+        if self._log_path:
+            return (
+                "Full details are in the terminal output and the log file:\n"
+                f"{self._log_path}"
+            )
+        return (
+            "Full details are in the terminal output. Enable "
+            "Settings ▸ Other ▸ 'Save log to file' to also keep them "
+            "on disk."
         )
-        box = QMessageBox()
-        box.setIcon(QMessageBox.Icon.Critical)
-        box.setWindowTitle("MoleditPy — Unexpected Error")
-        box.setText(
-            "An unexpected error occurred. The application may be unstable; "
-            "saving your work and restarting is recommended."
-        )
-        box.setInformativeText(
-            f"{exc_type.__name__}: {exc_value}\n\n"
-            f"Details are in the log:\n{log_path}"
-        )
-        box.setDetailedText(tb_text)
-        box.setStandardButtons(QMessageBox.StandardButton.Ok)
-        box.exec()
-    except Exception:
-        logging.debug("Failed to show exception dialog", exc_info=True)
+
+    def _show(self, message: str, detail: str) -> None:
+        """Show one non-blocking error dialog, unless another modal is up.
+
+        Sites (and plugins) log the error and then immediately raise their own
+        ``QMessageBox.critical``; by the time this deferred call fires, that
+        modal is up, so we detect it and stay quiet — surfacing the generic
+        dialog only for errors nobody else reports.
+        """
+        if QApplication.activeModalWidget() is not None:
+            return
+        try:
+            box = QMessageBox()
+            box.setIcon(QMessageBox.Icon.Critical)
+            box.setWindowTitle("MoleditPy — Error")
+            box.setText(message or "An unexpected error occurred.")
+            box.setInformativeText(self._details())
+            if detail:
+                box.setDetailedText(detail)
+            box.setStandardButtons(QMessageBox.StandardButton.Ok)
+            box.setModal(True)
+            self._open_boxes.add(box)
+            box.finished.connect(lambda _result, b=box: self._open_boxes.discard(b))
+            box.show()
+        except Exception:
+            logging.debug("Failed to show error dialog", exc_info=True)
 
 
 def _read_startup_log_settings() -> tuple[bool, bool]:
@@ -131,6 +175,7 @@ def setup_logging() -> None:
         force=True,
     )
 
+    active_log_path: Optional[str] = None
     if log_to_file:
         log_dir = os.path.join(os.path.expanduser("~"), ".moleditpy")
         try:
@@ -143,14 +188,22 @@ def setup_logging() -> None:
             fh.setFormatter(logging.Formatter(fmt))
             logging.getLogger().addHandler(fh)
             logging.info("File logging enabled: %s", log_path)
+            active_log_path = log_path
         except OSError as e:
             logging.warning("Could not open log file: %s", e)
 
-    def handle_exception(exc_type: Any, exc_value: Any, exc_traceback: Any) -> None:
-        """Log unhandled exceptions and, if a GUI is up, surface them once.
+    # Surface every ERROR/CRITICAL record in a dialog (see _ErrorDialogHandler);
+    # uncaught exceptions flow through here too via handle_exception's log call.
+    # It is a GUI feature, so it is skipped in headless mode (MOLEDITPY_HEADLESS),
+    # where a blocking modal would hang the run.
+    if not os.environ.get("MOLEDITPY_HEADLESS"):
+        logging.getLogger().addHandler(_ErrorDialogHandler(log_path=active_log_path))
 
-        This fires only for genuinely uncaught exceptions (real bugs) — never
-        for logged warnings/info, which do not pass through sys.excepthook.
+    def handle_exception(exc_type: Any, exc_value: Any, exc_traceback: Any) -> None:
+        """Log unhandled exceptions; the ERROR dialog handler surfaces them.
+
+        The dialog fires only for genuine failures — this log call and explicit
+        logging.error/critical calls — never for warnings/info.
         """
         if issubclass(exc_type, KeyboardInterrupt):
             sys.__excepthook__(exc_type, exc_value, exc_traceback)
@@ -158,7 +211,6 @@ def setup_logging() -> None:
         logging.error(
             "Uncaught exception", exc_info=(exc_type, exc_value, exc_traceback)
         )
-        _show_exception_dialog(exc_type, exc_value, exc_traceback)
 
     sys.excepthook = handle_exception
 

--- a/moleditpy/src/moleditpy/main.py
+++ b/moleditpy/src/moleditpy/main.py
@@ -72,12 +72,9 @@ class _ErrorDialogHandler(logging.Handler):
 
     def __init__(self, log_path: Optional[str] = None) -> None:
         super().__init__(level=logging.ERROR)
-        # Message+traceback signatures already shown this session.
         self._shown_signatures: set[str] = set()
-        # Live dialogs, held so a non-blocking box is not garbage collected
-        # (and thus dismissed) the moment _show returns.
+        # Held so a non-blocking box is not garbage-collected before it closes.
         self._open_boxes: set = set()
-        # Log-file path, set only when file logging is enabled (see _details).
         self._log_path = log_path
 
     def emit(self, record: logging.LogRecord) -> None:

--- a/moleditpy/src/moleditpy/main.py
+++ b/moleditpy/src/moleditpy/main.py
@@ -18,8 +18,9 @@ import logging.handlers
 import os
 import sys
 import argparse
+import time
 import traceback
-from typing import Any, Optional
+from typing import Any, Dict, Optional
 
 from .utils.constants import VERSION
 
@@ -61,18 +62,24 @@ class _ErrorDialogHandler(logging.Handler):
     in :func:`setup_logging` (only for a real GUI run, never headless).
 
     Guards: GUI thread + live QApplication only (a worker-thread record, where a
-    QMessageBox is unsafe, stays log-only); per-message-signature dedup so a
-    repeating error surfaces once, not once per tick; and
-    ``extra={"no_dialog": True}`` to opt a record out. ``emit`` never raises.
+    QMessageBox is unsafe, stays log-only); a time-windowed dedup so a fast
+    repeating error (e.g. from a QTimer slot) collapses to one dialog while a
+    genuine retry seconds later surfaces again; and ``extra={"no_dialog": True}``
+    to opt a record out. ``emit`` never raises.
 
     The dialog is shown non-blocking (``show``, not ``exec``): it never spins a
     nested event loop, so it cannot freeze the app — or a GUI-enabled test run —
     while it is on screen.
     """
 
+    # Identical errors within this many seconds share one dialog; a repeat
+    # after it surfaces again.
+    _DEDUP_WINDOW_S = 10.0
+
     def __init__(self, log_path: Optional[str] = None) -> None:
         super().__init__(level=logging.ERROR)
-        self._shown_signatures: set[str] = set()
+        # signature -> monotonic timestamp of its last shown dialog.
+        self._last_shown: Dict[str, float] = {}
         # Held so a non-blocking box is not garbage-collected before it closes.
         self._open_boxes: set = set()
         self._log_path = log_path
@@ -93,9 +100,11 @@ class _ErrorDialogHandler(logging.Handler):
             signature = hashlib.sha1(
                 (message + detail).encode("utf-8", "replace")
             ).hexdigest()
-            if signature in self._shown_signatures:
+            now = time.monotonic()
+            last = self._last_shown.get(signature)
+            if last is not None and now - last < self._DEDUP_WINDOW_S:
                 return
-            self._shown_signatures.add(signature)
+            self._last_shown[signature] = now
 
             # Defer so a site's own QMessageBox.critical (raised right after the
             # log call) is already modal when _show checks activeModalWidget.

--- a/moleditpy/src/moleditpy/plugins/plugin_manager.py
+++ b/moleditpy/src/moleditpy/plugins/plugin_manager.py
@@ -381,7 +381,9 @@ class PluginManager:
                         module.initialize(context)
                     except Exception as e:  # plugins have full app access; catch everything to isolate faults
                         status = f"Error (Init): {e}"
-                        logging.warning("Plugin %s initialize error", plugin_name, exc_info=True)
+                        logging.warning(
+                            "Plugin %s initialize error", plugin_name, exc_info=True
+                        )
                 elif has_autorun:
                     try:
                         if self.main_window:
@@ -390,7 +392,9 @@ class PluginManager:
                             status = "Skipped (No MW)"
                     except Exception as e:  # plugins have full app access; catch everything to isolate faults
                         status = f"Error (Autorun): {e}"
-                        logging.warning("Plugin %s autorun error", plugin_name, exc_info=True)
+                        logging.warning(
+                            "Plugin %s autorun error", plugin_name, exc_info=True
+                        )
                 elif not has_run:
                     status = "No Entry Point"
 
@@ -409,7 +413,9 @@ class PluginManager:
                 )
 
         except Exception as e:  # plugins have full app access; isolate any load failure to prevent crashing discovery
-            logging.warning("Failed to load plugin %s: %s", module_name, e, exc_info=True)
+            logging.warning(
+                "Failed to load plugin %s: %s", module_name, e, exc_info=True
+            )
 
     def run_plugin(self, module: Any, main_window: Any) -> None:
         """Executes the plugin's run method (Legacy manual trigger)."""
@@ -641,7 +647,10 @@ class PluginManager:
                 handler["callback"]()
             except Exception as e:  # plugins have full app access; catch everything to prevent data loss on document reset
                 logging.warning(
-                    "Error in document reset handler for %s: %s", handler["plugin"], e, exc_info=True
+                    "Error in document reset handler for %s: %s",
+                    handler["plugin"],
+                    e,
+                    exc_info=True,
                 )
 
     def get_plugin_info_safe(self, file_path: str) -> Dict[str, str]:

--- a/moleditpy/src/moleditpy/plugins/plugin_manager.py
+++ b/moleditpy/src/moleditpy/plugins/plugin_manager.py
@@ -113,7 +113,7 @@ class PluginManager:
             try:
                 os.makedirs(self.plugin_dir)
             except OSError as e:
-                logging.error(f"Error creating plugin directory: {e}")
+                logging.warning(f"Error creating plugin directory: {e}")
 
     def open_plugin_folder(self) -> None:
         """Opens the plugin directory in the OS file explorer."""
@@ -381,7 +381,7 @@ class PluginManager:
                         module.initialize(context)
                     except Exception as e:  # plugins have full app access; catch everything to isolate faults
                         status = f"Error (Init): {e}"
-                        logging.exception("Plugin %s initialize error", plugin_name)
+                        logging.warning("Plugin %s initialize error", plugin_name, exc_info=True)
                 elif has_autorun:
                     try:
                         if self.main_window:
@@ -390,7 +390,7 @@ class PluginManager:
                             status = "Skipped (No MW)"
                     except Exception as e:  # plugins have full app access; catch everything to isolate faults
                         status = f"Error (Autorun): {e}"
-                        logging.exception("Plugin %s autorun error", plugin_name)
+                        logging.warning("Plugin %s autorun error", plugin_name, exc_info=True)
                 elif not has_run:
                     status = "No Entry Point"
 
@@ -409,7 +409,7 @@ class PluginManager:
                 )
 
         except Exception as e:  # plugins have full app access; isolate any load failure to prevent crashing discovery
-            logging.exception("Failed to load plugin %s: %s", module_name, e)
+            logging.warning("Failed to load plugin %s: %s", module_name, e, exc_info=True)
 
     def run_plugin(self, module: Any, main_window: Any) -> None:
         """Executes the plugin's run method (Legacy manual trigger)."""
@@ -620,7 +620,7 @@ class PluginManager:
                             except (RuntimeError, ValueError, TypeError):
                                 continue
         except (RuntimeError, AttributeError) as e:
-            logging.error(f"Error retrieving selected atom indices: {e}")
+            logging.warning(f"Error retrieving selected atom indices: {e}")
 
         return selected_indices
 
@@ -640,8 +640,8 @@ class PluginManager:
             try:
                 handler["callback"]()
             except Exception as e:  # plugins have full app access; catch everything to prevent data loss on document reset
-                logging.exception(
-                    "Error in document reset handler for %s: %s", handler["plugin"], e
+                logging.warning(
+                    "Error in document reset handler for %s: %s", handler["plugin"], e, exc_info=True
                 )
 
     def get_plugin_info_safe(self, file_path: str) -> Dict[str, str]:

--- a/moleditpy/src/moleditpy/plugins/plugin_manager_window.py
+++ b/moleditpy/src/moleditpy/plugins/plugin_manager_window.py
@@ -10,6 +10,7 @@ Repo: https://github.com/HiroYokoyama/python_molecular_editor
 DOI: 10.5281/zenodo.17268532
 """
 
+import logging
 import os
 import shutil
 from typing import Any, Optional
@@ -213,9 +214,7 @@ class PluginManagerWindow(QDialog):
                             f"Removed '{plugin.get('name', 'Unknown')}'.",
                         )
                     except OSError as e:
-                        QMessageBox.critical(
-                            self, "Error", f"Failed to delete plugin: {e}"
-                        )
+                        logging.exception("Failed to delete plugin: %s", e)
             else:
                 QMessageBox.warning(
                     self, "Error", f"Plugin file not found:\n{filepath}"

--- a/moleditpy/src/moleditpy/ui/align_plane_dialog.py
+++ b/moleditpy/src/moleditpy/ui/align_plane_dialog.py
@@ -285,5 +285,4 @@ class AlignPlaneDialog(BasePickingDialog):
             self.show_atom_labels()
 
         except (AttributeError, RuntimeError, ValueError, TypeError) as e:
-            logging.exception("Failed to apply align")
-            QMessageBox.critical(self, "Error", f"Failed to apply align: {str(e)}")
+            logging.exception("Failed to apply align: %s", e)

--- a/moleditpy/src/moleditpy/ui/align_plane_dialog.py
+++ b/moleditpy/src/moleditpy/ui/align_plane_dialog.py
@@ -162,7 +162,7 @@ class AlignPlaneDialog(BasePickingDialog):
             self.update_display()
 
         except (AttributeError, RuntimeError, TypeError, KeyError) as e:
-            logging.exception("Failed to select all atoms")
+            logging.warning("Failed to select all atoms", exc_info=True)
             QMessageBox.warning(self, "Warning", f"Failed to select all atoms: {e}")
 
     def update_display(self) -> None:

--- a/moleditpy/src/moleditpy/ui/alignment_dialog.py
+++ b/moleditpy/src/moleditpy/ui/alignment_dialog.py
@@ -276,8 +276,7 @@ class AlignmentDialog(Dialog3DPickingMixin, QDialog):
             )
 
         except (AttributeError, RuntimeError, ValueError, TypeError) as e:
-            logging.exception("Failed to apply alignment")
-            QMessageBox.critical(self, "Error", f"Failed to apply alignment: {str(e)}")
+            logging.exception("Failed to apply alignment: %s", e)
 
     def closeEvent(self, event: Optional[QCloseEvent]) -> None:
         """Clean up when the dialog is closed."""

--- a/moleditpy/src/moleditpy/ui/app_state.py
+++ b/moleditpy/src/moleditpy/ui/app_state.py
@@ -232,7 +232,7 @@ class StateManager:
                     self.host.clear_3d_view()
                     self.host.ui_manager.enable_3d_features(False)
             except (RuntimeError, ValueError, TypeError) as e:
-                logging.error(f"Could not load 3D model from state data: {e}")
+                logging.warning(f"Could not load 3D model from state data: {e}")
                 self.host.update_status_message(f"Error loading 3D model: {e}", 5000)
                 self.host.set_current_molecule(None)
                 self.host.ui_manager.enable_3d_features(False)
@@ -528,7 +528,7 @@ class StateManager:
                         p_state = callback()
                         plugin_data[name] = p_state
                     except Exception:  # plugins have full app access; catch everything to prevent save corruption
-                        logging.exception("Error saving state for plugin %s", name)
+                        logging.warning("Error saving state for plugin %s", name, exc_info=True)
 
         if plugin_data:
             json_data["plugins"] = plugin_data
@@ -564,7 +564,7 @@ class StateManager:
                         try:
                             load_hand(p_state)
                         except Exception:  # plugins have full app access; catch everything to prevent load corruption
-                            logging.exception("Error loading state for plugin %s", name)
+                            logging.warning("Error loading state for plugin %s", name, exc_info=True)
                     else:
                         # No handler found (plugin disabled or missing)
                         # Preserve data so it's not lost on next save
@@ -671,5 +671,5 @@ class StateManager:
                                 "Suppressed non-critical error", exc_info=True
                             )
             except (RuntimeError, ValueError, TypeError, binascii.Error) as e:
-                logging.error(f"Could not restore 3D molecular data: {e}")
+                logging.warning(f"Could not restore 3D molecular data: {e}")
                 self.host.set_current_molecule(None)

--- a/moleditpy/src/moleditpy/ui/app_state.py
+++ b/moleditpy/src/moleditpy/ui/app_state.py
@@ -532,7 +532,9 @@ class StateManager:
                         p_state = callback()
                         plugin_data[name] = p_state
                     except Exception:  # plugins have full app access; catch everything to prevent save corruption
-                        logging.warning("Error saving state for plugin %s", name, exc_info=True)
+                        logging.warning(
+                            "Error saving state for plugin %s", name, exc_info=True
+                        )
 
         if plugin_data:
             json_data["plugins"] = plugin_data
@@ -568,7 +570,9 @@ class StateManager:
                         try:
                             load_hand(p_state)
                         except Exception:  # plugins have full app access; catch everything to prevent load corruption
-                            logging.warning("Error loading state for plugin %s", name, exc_info=True)
+                            logging.warning(
+                                "Error loading state for plugin %s", name, exc_info=True
+                            )
                     else:
                         # No handler found (plugin disabled or missing)
                         # Preserve data so it's not lost on next save

--- a/moleditpy/src/moleditpy/ui/app_state.py
+++ b/moleditpy/src/moleditpy/ui/app_state.py
@@ -223,7 +223,11 @@ class StateManager:
                     self.host.view_3d_manager.draw_molecule_3d(
                         self.host.view_3d_manager.current_mol
                     )
-                    if self.host.view_3d_manager.plotter:
+                    # draw_molecule_3d already preserves the camera; only refit
+                    # on a fresh load, not on undo/redo (which restores state).
+                    if self.host.view_3d_manager.plotter and not getattr(
+                        self.host, "is_restoring_state", False
+                    ):
                         self.host.view_3d_manager.plotter.reset_camera()
 
                     self.host.ui_manager.enable_3d_features(True)

--- a/moleditpy/src/moleditpy/ui/bond_item.py
+++ b/moleditpy/src/moleditpy/ui/bond_item.py
@@ -96,7 +96,7 @@ class BondItem(QGraphicsItem):
                     view.viewport().update()  # type: ignore[union-attr]
 
         except (AttributeError, RuntimeError, TypeError):
-            logging.exception("Error in BondItem.set_stereo")
+            logging.warning("Error in BondItem.set_stereo", exc_info=True)
             # Continue without crashing
             self.stereo = new_stereo
 
@@ -604,7 +604,7 @@ class BondItem(QGraphicsItem):
                 self.setPos(self.atom1.pos())
             self.update()
         except (AttributeError, RuntimeError):
-            logging.exception("Error updating bond position")
+            logging.warning("Error updating bond position", exc_info=True)
             # Continue without crashing
 
     def hoverEnterEvent(self, event: QGraphicsSceneHoverEvent) -> None:  # type: ignore[override]

--- a/moleditpy/src/moleditpy/ui/compute_logic.py
+++ b/moleditpy/src/moleditpy/ui/compute_logic.py
@@ -587,7 +587,8 @@ class ComputeManager:
             msg = str(message)
 
         self._remove_calculating_text()
-        self._restore_button_ui()
+        # Full restore like the success path, else Export stays disabled on error.
+        self._refresh_ui_state()
 
         if msg == "Halt" or msg == "Halted":
             self.host.statusBar().showMessage("Halted")  # type: ignore[union-attr]

--- a/moleditpy/src/moleditpy/ui/compute_logic.py
+++ b/moleditpy/src/moleditpy/ui/compute_logic.py
@@ -390,7 +390,7 @@ class ComputeManager:
         try:
             success = bool(entry["callback"](mol))
         except Exception:  # plugins have full app access; isolate failures
-            logging.exception("Plugin optimization method '%s' failed", label)
+            logging.warning("Plugin optimization method '%s' failed", label, exc_info=True)
             self._refresh_ui_state()
             self.host.update_status_message(
                 f"Plugin optimization '{label}' failed (see log)."
@@ -431,7 +431,7 @@ class ComputeManager:
         try:
             Chem.SanitizeMol(mol)
         except (ValueError, RuntimeError) as e:
-            logging.error(f"Sanitization failed: {e}")
+            logging.warning(f"Sanitization failed: {e}")
             self.host.statusBar().showMessage("Error: Invalid chemical structure.")  # type: ignore[union-attr]
             return None
         return mol

--- a/moleditpy/src/moleditpy/ui/compute_logic.py
+++ b/moleditpy/src/moleditpy/ui/compute_logic.py
@@ -390,7 +390,9 @@ class ComputeManager:
         try:
             success = bool(entry["callback"](mol))
         except Exception:  # plugins have full app access; isolate failures
-            logging.warning("Plugin optimization method '%s' failed", label, exc_info=True)
+            logging.warning(
+                "Plugin optimization method '%s' failed", label, exc_info=True
+            )
             self._refresh_ui_state()
             self.host.update_status_message(
                 f"Plugin optimization '{label}' failed (see log)."

--- a/moleditpy/src/moleditpy/ui/constrained_optimization_dialog.py
+++ b/moleditpy/src/moleditpy/ui/constrained_optimization_dialog.py
@@ -528,9 +528,7 @@ class ConstrainedOptimizationDialog(Dialog3DPickingMixin, QDialog):
                 add_torsion_constraint = ff.UFFAddTorsionConstraint
 
         except (AttributeError, RuntimeError, ValueError, TypeError) as e:
-            QMessageBox.critical(
-                self, "Error", f"Failed to initialize force field {ff_name}: {e}"
-            )
+            logging.exception("Failed to initialize force field %s: %s", ff_name, e)
             return
 
         # Add constraints
@@ -578,8 +576,7 @@ class ConstrainedOptimizationDialog(Dialog3DPickingMixin, QDialog):
                     )
 
         except (AttributeError, RuntimeError, ValueError, TypeError) as e:
-            QMessageBox.critical(self, "Error", f"Failed to add constraints: {e}")
-            logging.error("Failed to add constraints", exc_info=True)
+            logging.exception("Failed to add constraints: %s", e)
             return
 
         # Execute optimization
@@ -598,7 +595,7 @@ class ConstrainedOptimizationDialog(Dialog3DPickingMixin, QDialog):
             self._opt_thread.start()
 
         except Exception as e:
-            QMessageBox.critical(self, "Error", f"Failed to start optimization: {e}")
+            logging.exception("Failed to start optimization: %s", e)
             self.optimize_button.setEnabled(True)
 
     def _on_optimization_error(self, err_msg: str) -> None:
@@ -673,7 +670,7 @@ class ConstrainedOptimizationDialog(Dialog3DPickingMixin, QDialog):
                 logging.warning("Failed to save constraints post-optimization: %s", e)
 
         except (AttributeError, RuntimeError, ValueError, TypeError) as e:
-            QMessageBox.critical(self, "Error", f"Optimization failed: {e}")
+            logging.exception("Optimization failed: %s", e)
 
     def closeEvent(self, event: Any) -> None:
         """Delegate window close to reject."""

--- a/moleditpy/src/moleditpy/ui/constrained_optimization_dialog.py
+++ b/moleditpy/src/moleditpy/ui/constrained_optimization_dialog.py
@@ -156,7 +156,7 @@ class ConstrainedOptimizationDialog(Dialog3DPickingMixin, QDialog):
                 self.ff_combo.setCurrentText("MMFF94s")
 
         except (AttributeError, RuntimeError, ValueError, TypeError):
-            logging.exception("Could not set default force field")
+            logging.warning("Could not set default force field", exc_info=True)
 
     def init_ui(self) -> None:
         """Build the constrained optimization dialog with constraint table and controls."""

--- a/moleditpy/src/moleditpy/ui/custom_interactor_style.py
+++ b/moleditpy/src/moleditpy/ui/custom_interactor_style.py
@@ -725,7 +725,9 @@ class CustomInteractorStyle(vtkInteractorStyleTrackballCamera):
                                 ),
                             )
                     except (AttributeError, RuntimeError, ValueError, TypeError):
-                        logging.warning("Caught exception in " + __file__, exc_info=True)
+                        logging.warning(
+                            "Caught exception in " + __file__, exc_info=True
+                        )
 
                     # Defer the redraw + undo push out of the VTK observer
                     # callback to prevent re-entrant plotter.render() deadlock.

--- a/moleditpy/src/moleditpy/ui/custom_interactor_style.py
+++ b/moleditpy/src/moleditpy/ui/custom_interactor_style.py
@@ -120,7 +120,7 @@ class CustomInteractorStyle(vtkInteractorStyleTrackballCamera):
                     move_group_dialog = widget
                     break
             except (AttributeError, RuntimeError, TypeError):
-                logging.error("Caught exception in " + __file__, exc_info=True)
+                logging.warning("Caught exception in " + __file__, exc_info=True)
 
         if move_group_dialog and move_group_dialog.group_atoms:
             # Group drag if selected
@@ -401,7 +401,7 @@ class CustomInteractorStyle(vtkInteractorStyleTrackballCamera):
                     move_group_dialog = widget
                     break
         except (AttributeError, RuntimeError, TypeError):
-            logging.error("Caught exception in " + __file__, exc_info=True)
+            logging.warning("Caught exception in " + __file__, exc_info=True)
         if move_group_dialog and getattr(
             move_group_dialog, "is_dragging_group_vtk", False
         ):
@@ -497,7 +497,7 @@ class CustomInteractorStyle(vtkInteractorStyleTrackballCamera):
                     move_group_dialog = widget
                     break
         except (AttributeError, RuntimeError, TypeError):
-            logging.error("Caught exception in " + __file__, exc_info=True)
+            logging.warning("Caught exception in " + __file__, exc_info=True)
         # Prevent multi-click issues
         if move_group_dialog:
             if getattr(
@@ -509,7 +509,7 @@ class CustomInteractorStyle(vtkInteractorStyleTrackballCamera):
                     try:
                         move_group_dialog.on_atom_picked(clicked_atom)
                     except (AttributeError, RuntimeError, TypeError, ValueError) as e:
-                        logging.error(f"Error in toggle: {e}")
+                        logging.warning(f"Error in toggle: {e}")
                 # Reset if multi-clicked without drag
                 move_group_dialog.is_dragging_group_vtk = False
                 move_group_dialog.drag_start_pos_vtk = None
@@ -589,7 +589,7 @@ class CustomInteractorStyle(vtkInteractorStyleTrackballCamera):
 
                     QTimer.singleShot(0, _deferred_group_redraw)
                 except (AttributeError, RuntimeError, TypeError, ValueError):
-                    logging.exception("Error finalizing group drag")
+                    logging.warning("Error finalizing group drag", exc_info=True)
             else:
                 # No drag = click only -> toggle
                 clicked_atom = getattr(move_group_dialog, "drag_atom_idx_vtk", None)
@@ -597,7 +597,7 @@ class CustomInteractorStyle(vtkInteractorStyleTrackballCamera):
                     try:
                         move_group_dialog.on_atom_picked(clicked_atom)
                     except (AttributeError, RuntimeError, TypeError, ValueError):
-                        logging.exception("Error in toggle")
+                        logging.warning("Error in toggle", exc_info=True)
 
         # Background click: deselect Move Group
         if move_group_dialog and not getattr(
@@ -725,7 +725,7 @@ class CustomInteractorStyle(vtkInteractorStyleTrackballCamera):
                                 ),
                             )
                     except (AttributeError, RuntimeError, ValueError, TypeError):
-                        logging.error("Caught exception in " + __file__, exc_info=True)
+                        logging.warning("Caught exception in " + __file__, exc_info=True)
 
                     # Defer the redraw + undo push out of the VTK observer
                     # callback to prevent re-entrant plotter.render() deadlock.
@@ -735,7 +735,7 @@ class CustomInteractorStyle(vtkInteractorStyleTrackballCamera):
                         try:
                             mw.view_3d_manager.draw_molecule_3d(_atom_mol)
                         except (AttributeError, RuntimeError, ValueError, TypeError):
-                            logging.error(
+                            logging.warning(
                                 "Caught exception in " + __file__, exc_info=True
                             )
                         mw.edit_actions_manager.push_undo_state()
@@ -760,7 +760,7 @@ class CustomInteractorStyle(vtkInteractorStyleTrackballCamera):
                         try:
                             fn()
                         except (AttributeError, RuntimeError, ValueError, TypeError):
-                            logging.error(
+                            logging.warning(
                                 "Caught exception in " + __file__, exc_info=True
                             )
 
@@ -790,13 +790,13 @@ class CustomInteractorStyle(vtkInteractorStyleTrackballCamera):
                 if hasattr(move_group_dialog, "drag_atom_idx_vtk"):  # Safe
                     delattr(move_group_dialog, "drag_atom_idx_vtk")
         except (AttributeError, RuntimeError, ValueError, TypeError):
-            logging.error("Caught exception in " + __file__, exc_info=True)
+            logging.warning("Caught exception in " + __file__, exc_info=True)
 
         # Update cursor after release
         try:
             mw.view_3d_manager.plotter.setCursor(Qt.CursorShape.ArrowCursor)
         except (AttributeError, RuntimeError, ValueError, TypeError):
-            logging.error("Caught exception in " + __file__, exc_info=True)
+            logging.warning("Caught exception in " + __file__, exc_info=True)
 
         # Restore focus to 2D view
         if mw and mw.init_manager.view_2d:
@@ -820,7 +820,7 @@ class CustomInteractorStyle(vtkInteractorStyleTrackballCamera):
                     move_group_dialog = widget
                     break
         except (AttributeError, RuntimeError, TypeError):
-            logging.error("Caught exception in " + __file__, exc_info=True)
+            logging.warning("Caught exception in " + __file__, exc_info=True)
         if move_group_dialog and getattr(
             move_group_dialog, "is_rotating_group_vtk", False
         ):
@@ -935,7 +935,7 @@ class CustomInteractorStyle(vtkInteractorStyleTrackballCamera):
                             move_group_dialog.show_atom_labels()
                             mw.edit_actions_manager.push_undo_state()
                 except (AttributeError, RuntimeError, TypeError, ValueError):
-                    logging.exception("Error finalizing group rotation")
+                    logging.warning("Error finalizing group rotation", exc_info=True)
 
             # Reset state
             move_group_dialog.is_rotating_group_vtk = False

--- a/moleditpy/src/moleditpy/ui/dialog_3d_picking_mixin.py
+++ b/moleditpy/src/moleditpy/ui/dialog_3d_picking_mixin.py
@@ -100,7 +100,7 @@ class Dialog3DPickingMixin:
                 return False
 
             except (AttributeError, RuntimeError, ValueError, TypeError):
-                logging.exception("Error in eventFilter")
+                logging.warning("Error in eventFilter", exc_info=True)
                 return False
 
         # Add movement tracking for smart selection

--- a/moleditpy/src/moleditpy/ui/dialog_logic.py
+++ b/moleditpy/src/moleditpy/ui/dialog_logic.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 
 import json
+import logging
 import os
 import sys
 from typing import Any, List, Literal, Optional, cast
@@ -187,9 +188,7 @@ class DialogManager:
             )
 
         except (AttributeError, RuntimeError, ValueError) as e:
-            QMessageBox.critical(
-                self.host, "Error", f"Failed to save template: {str(e)}"
-            )
+            logging.exception("Failed to save template: %s", e)
 
     def _show_modeless_dialog(self, dialog: QDialog) -> None:
         """Show a modeless dialog on top, especially important for macOS."""

--- a/moleditpy/src/moleditpy/ui/edit_actions_logic.py
+++ b/moleditpy/src/moleditpy/ui/edit_actions_logic.py
@@ -986,7 +986,7 @@ class EditActionsManager:
                 ):
                     problem_map[atom_id] = True
         except (AttributeError, RuntimeError, ValueError, TypeError) as e:
-            logging.error(f"Error during chemistry problem detection: {e}")
+            logging.warning(f"Error during chemistry problem detection: {e}")
 
         return problem_map
 

--- a/moleditpy/src/moleditpy/ui/main_window.py
+++ b/moleditpy/src/moleditpy/ui/main_window.py
@@ -260,7 +260,7 @@ class MainWindow(QMainWindow):
                 self.state_manager.get_current_state()
             )
         except (RuntimeError, TypeError, ValueError, AttributeError) as e:
-            logging.error(f"save_state_snapshot failed: {e}")
+            logging.warning(f"save_state_snapshot failed: {e}")
 
     def update_window_title(self) -> None:
         """Update main window title to reflect file path and save status."""

--- a/moleditpy/src/moleditpy/ui/main_window_init.py
+++ b/moleditpy/src/moleditpy/ui/main_window_init.py
@@ -144,7 +144,7 @@ class MainInitManager:
             try:
                 self.host.plugin_manager = PluginManager()
             except (AttributeError, RuntimeError, ValueError) as e:
-                logging.error(f"Failed to initialize PluginManager: {e}")
+                logging.warning(f"Failed to initialize PluginManager: {e}")
                 self.host.plugin_manager = None
 
         # Dictionary holding data for plugins that haven't been loaded
@@ -189,7 +189,7 @@ class MainInitManager:
                 for atom in warmup_mol.GetAtoms():
                     atom.GetNumImplicitHs()
         except (AttributeError, RuntimeError, ValueError) as e:
-            logging.error(f"RDKit warm-up failed: {e}")
+            logging.warning(f"RDKit warm-up failed: {e}")
 
         self.host.state_manager.reset_undo_stack()
         self.scene.selectionChanged.connect(  # type: ignore[attr-defined]
@@ -304,10 +304,9 @@ class MainInitManager:
                     self.host.state_manager.update_window_title()
                     return  # Success
                 except Exception:  # plugins have full app access; any failure falls through to the next opener
-                    logging.exception(
+                    logging.warning(
                         "Plugin opener failed for '%s'",
-                        opener_info.get("plugin", "Unknown"),
-                    )
+                        opener_info.get("plugin", "Unknown"), exc_info=True)
                     continue
 
         if file_ext in ["mol", "sdf"]:
@@ -404,7 +403,7 @@ class MainInitManager:
                             c.blueF(),
                         ]
         except (AttributeError, RuntimeError, TypeError, ValueError) as e:
-            logging.error(f"Failed to update CPK colors from settings: {e}")
+            logging.warning(f"Failed to update CPK colors from settings: {e}")
 
     def open_settings_dialog(self) -> None:
         """Open the application settings dialog."""
@@ -567,7 +566,7 @@ class MainInitManager:
             self.settings_dirty = False
             self.host.initial_settings = self.settings.copy()
         except (AttributeError, RuntimeError, ValueError) as e:
-            logging.error(f"Error saving settings: {e}")
+            logging.warning(f"Error saving settings: {e}")
 
     # --- UI Initialization Helpers ---
     def _init_main_layout(self) -> None:

--- a/moleditpy/src/moleditpy/ui/main_window_init.py
+++ b/moleditpy/src/moleditpy/ui/main_window_init.py
@@ -306,7 +306,9 @@ class MainInitManager:
                 except Exception:  # plugins have full app access; any failure falls through to the next opener
                     logging.warning(
                         "Plugin opener failed for '%s'",
-                        opener_info.get("plugin", "Unknown"), exc_info=True)
+                        opener_info.get("plugin", "Unknown"),
+                        exc_info=True,
+                    )
                     continue
 
         if file_ext in ["mol", "sdf"]:

--- a/moleditpy/src/moleditpy/ui/mirror_dialog.py
+++ b/moleditpy/src/moleditpy/ui/mirror_dialog.py
@@ -141,6 +141,4 @@ class MirrorDialog(QDialog):
             )
 
         except (AttributeError, RuntimeError, ValueError, TypeError) as e:
-            QMessageBox.critical(
-                self, "Error", f"Failed to apply mirror transformation: {str(e)}"
-            )
+            logging.exception("Failed to apply mirror transformation: %s", e)

--- a/moleditpy/src/moleditpy/ui/mirror_dialog.py
+++ b/moleditpy/src/moleditpy/ui/mirror_dialog.py
@@ -125,7 +125,7 @@ class MirrorDialog(QDialog):
                     # Calculate new chiral tags from 3D coordinates
                     Chem.AssignAtomChiralTagsFromStructure(self.mol, confId=0)
             except (AttributeError, RuntimeError, ValueError, TypeError):
-                logging.exception("Error updating chiral tags")
+                logging.warning("Error updating chiral tags", exc_info=True)
 
             # Update 3D view (which also draws 3D chiral labels)
             self.main_window.view_3d_manager.draw_molecule_3d(self.mol)

--- a/moleditpy/src/moleditpy/ui/molecular_scene_handler.py
+++ b/moleditpy/src/moleditpy/ui/molecular_scene_handler.py
@@ -851,7 +851,7 @@ class KeyboardMixin:
 
                 QGraphicsScene.keyPressEvent(self, event)  # type: ignore[arg-type]
             except (ImportError, AttributeError, TypeError, RuntimeError):
-                logging.exception("Error delegating keyPressEvent")
+                logging.warning("Error delegating keyPressEvent", exc_info=True)
             return
 
         view = self.views()[0]
@@ -1065,7 +1065,7 @@ class KeyboardMixin:
                         event.accept()
                         return
                     except (AttributeError, RuntimeError, ValueError, TypeError) as e:
-                        logging.error(
+                        logging.warning(
                             f"Error changing atom symbol via key {key}: {e}",
                             exc_info=True,
                         )
@@ -1369,7 +1369,7 @@ class KeyboardMixin:
             QGraphicsScene.keyPressEvent(self, event)  # type: ignore[arg-type]
 
         except (AttributeError, RuntimeError, ValueError, TypeError) as e:
-            logging.error(
+            logging.warning(
                 f"Unexpected error in MoleculeScene.keyPressEvent: {e}", exc_info=True
             )
             event.ignore()
@@ -1417,7 +1417,7 @@ class SceneQueryMixin:
     ) -> Any:
         """Add a bond between two atom items in both data model and scene."""
         if start_atom is None or end_atom is None:
-            logging.error("Error: Cannot create bond with None atoms")
+            logging.warning("Error: Cannot create bond with None atoms")
             return
 
         try:
@@ -1443,7 +1443,7 @@ class SceneQueryMixin:
             end_atom.update_style()
 
         except (AttributeError, RuntimeError, ValueError) as e:
-            logging.error(f"Error creating bond: {e}", exc_info=True)
+            logging.warning(f"Error creating bond: {e}", exc_info=True)
             self.update_all_items()
 
     def delete_items(self, items_to_delete: Any) -> bool:
@@ -1578,7 +1578,7 @@ class SceneQueryMixin:
             return True
 
         except (AttributeError, RuntimeError, ValueError, TypeError) as e:
-            logging.error(f"Error during delete_items operation: {e}", exc_info=True)
+            logging.warning(f"Error during delete_items operation: {e}", exc_info=True)
             self.update_all_items()
             return False
 
@@ -1642,7 +1642,7 @@ class SceneQueryMixin:
             self.data_changed_in_event = True
 
         except (AttributeError, RuntimeError, ValueError, TypeError) as e:
-            logging.error(
+            logging.warning(
                 f"Error updating bond stereo for bond {bond_item}: {e}", exc_info=True
             )
             self.window.statusBar().showMessage(f"Error: {e}", 5000)

--- a/moleditpy/src/moleditpy/ui/molecule_scene.py
+++ b/moleditpy/src/moleditpy/ui/molecule_scene.py
@@ -393,7 +393,7 @@ class MoleculeScene(TemplateMixin, KeyboardMixin, SceneQueryMixin, QGraphicsScen
                             self.window.edit_actions_manager.push_undo_state()
                             data_changed = False  # Already added to undo stack, so skip redundant pushes later
                     except (AttributeError, RuntimeError, ValueError, TypeError) as e:
-                        logging.error(
+                        logging.warning(
                             f"Error in E/Z stereo toggle (mousePressEvent): {e}",
                             exc_info=True,
                         )
@@ -632,7 +632,7 @@ class MoleculeScene(TemplateMixin, KeyboardMixin, SceneQueryMixin, QGraphicsScen
                         self.update_all_items()  # Force redraw
                         self.window.edit_actions_manager.push_undo_state()  # Push to undo stack here
                 except (AttributeError, RuntimeError, ValueError, TypeError) as e:
-                    logging.error(
+                    logging.warning(
                         f"Error in E/Z stereo toggle (mouseReleaseEvent): {e}",
                         exc_info=True,
                     )
@@ -931,7 +931,7 @@ class MoleculeScene(TemplateMixin, KeyboardMixin, SceneQueryMixin, QGraphicsScen
                 return
             except (AttributeError, RuntimeError, ValueError, TypeError) as e:
                 # On any unexpected error, fall back to default handling
-                logging.error(f"Error in connected component selection: {e}")
+                logging.warning(f"Error in connected component selection: {e}")
 
         elif self.mode in ["bond_2_5"]:
             event.accept()

--- a/moleditpy/src/moleditpy/ui/move_group_dialog.py
+++ b/moleditpy/src/moleditpy/ui/move_group_dialog.py
@@ -474,7 +474,7 @@ class MoveGroupDialog(BasePickingDialog):
 
         selected_indices = list(self.group_atoms)
         if self.main_window.view_3d_manager.atom_positions_3d is None:
-            logging.error("atom_positions_3d is None in update_atom_labels")
+            logging.warning("atom_positions_3d is None in update_atom_labels")
             return
         selected_positions = self.main_window.view_3d_manager.atom_positions_3d[
             selected_indices

--- a/moleditpy/src/moleditpy/ui/move_selected_atoms_dialog.py
+++ b/moleditpy/src/moleditpy/ui/move_selected_atoms_dialog.py
@@ -502,7 +502,7 @@ class MoveSelectedAtomsDialog(BasePickingDialog):
 
         selected_indices = list(self.selected_atoms)
         if self.main_window.view_3d_manager.atom_positions_3d is None:
-            logging.error("atom_positions_3d is None in update_atom_labels")
+            logging.warning("atom_positions_3d is None in update_atom_labels")
             return
         selected_positions = self.main_window.view_3d_manager.atom_positions_3d[
             selected_indices

--- a/moleditpy/src/moleditpy/ui/planarize_dialog.py
+++ b/moleditpy/src/moleditpy/ui/planarize_dialog.py
@@ -217,4 +217,4 @@ class PlanarizeDialog(BasePickingDialog):
             )
 
         except (AttributeError, RuntimeError, ValueError) as e:
-            QMessageBox.critical(self, "Error", f"Failed to planarize: {e}")
+            logging.exception("Failed to planarize: %s", e)

--- a/moleditpy/src/moleditpy/ui/planarize_dialog.py
+++ b/moleditpy/src/moleditpy/ui/planarize_dialog.py
@@ -170,7 +170,7 @@ class PlanarizeDialog(BasePickingDialog):
             # Get positions of selected atoms
             selected_indices = list(sorted(self.selected_atoms))
             if self.main_window.view_3d_manager.atom_positions_3d is None:
-                logging.error("atom_positions_3d is None in apply_planarize")
+                logging.warning("atom_positions_3d is None in apply_planarize")
                 return
             selected_positions = self.main_window.view_3d_manager.atom_positions_3d[
                 selected_indices

--- a/moleditpy/src/moleditpy/ui/plugin_menu_manager.py
+++ b/moleditpy/src/moleditpy/ui/plugin_menu_manager.py
@@ -47,16 +47,8 @@ class PluginMenuManager:
         def _safe(*args: Any, **kwargs: Any) -> None:
             try:
                 callback()
-            except Exception as exc:
+            except Exception:
                 logging.exception("Plugin callback error (%s)", plugin_name)
-                try:
-                    QMessageBox.critical(
-                        self._im.host,
-                        "Plugin Error",
-                        f"An error occurred in plugin '{plugin_name}':\n{exc}",
-                    )
-                except Exception:
-                    logging.debug("Suppressed non-critical error", exc_info=True)
 
         return _safe
 
@@ -469,13 +461,8 @@ class PluginMenuManager:
                         if ext in m:
                             try:
                                 m[ext](fpath)
-                            except Exception as exc:
+                            except Exception:
                                 logging.exception("Plugin file opener error (%s)", n)
-                                QMessageBox.critical(
-                                    self._im.host,
-                                    "Plugin Error",
-                                    f"An error occurred in plugin '{n}':\n{exc}",
-                                )
                                 return
                             self._im.current_file_path = fpath
                             self._im.host.state_manager.update_window_title()

--- a/moleditpy/src/moleditpy/ui/plugin_menu_manager.py
+++ b/moleditpy/src/moleditpy/ui/plugin_menu_manager.py
@@ -34,6 +34,10 @@ class PluginMenuManager:
     can access shared state (host, buttons, toolbars) without duplicating them.
     """
 
+    # QAction.data() marker stamped on every plugin-owned menu entry/separator
+    # so the rebuild pass can find and remove exactly those on the next reload.
+    _PLUGIN_ACTION_TAG = "plugin_managed"
+
     def __init__(self, init_manager: MainInitManager) -> None:
         self._im = init_manager
 
@@ -55,6 +59,21 @@ class PluginMenuManager:
                     logging.debug("Suppressed non-critical error", exc_info=True)
 
         return _safe
+
+    @staticmethod
+    def _remove_action(menu: QMenu, action: QAction) -> None:
+        """Remove *action* from *menu* and from its QActionGroup, if any.
+
+        Checkable plugin actions (e.g. custom 3D styles) are added to an
+        exclusive QActionGroup. ``menu.removeAction`` alone leaves them in the
+        group — and, being parented to the host, alive — so each rebuild would
+        leak a stale member into the group and could drop the active item's
+        check state. Detaching from the group first keeps the group in sync.
+        """
+        group = action.actionGroup()
+        if group is not None:
+            group.removeAction(action)
+        menu.removeAction(action)
 
     def _get_plugin_target_menus(self) -> List[QMenu]:
         """Return a list of all menus that might contain plugin actions."""
@@ -115,7 +134,6 @@ class PluginMenuManager:
         re-populates every integration point: menus, toolbars, export,
         file-openers, analysis tools, and 3D styles.
         """
-        plugin_action_tag = "plugin_managed"
 
         def _clean_menu(menu: QMenu) -> None:
             for action in list(menu.actions()):
@@ -124,8 +142,8 @@ class PluginMenuManager:
                     _clean_menu(submenu)
                     if not any(not a.isSeparator() for a in submenu.actions()):
                         menu.removeAction(action)
-                elif action.data() == plugin_action_tag:
-                    menu.removeAction(action)
+                elif action.data() == self._PLUGIN_ACTION_TAG:
+                    self._remove_action(menu, action)
 
         try:
             for menu in self._get_plugin_target_menus():
@@ -151,7 +169,6 @@ class PluginMenuManager:
 
     def add_registered_plugin_actions(self) -> None:
         """Add menu actions explicitly registered by V3/V4 plugins."""
-        plugin_action_tag = "plugin_managed"
         if not self._im.host.plugin_manager.menu_actions:
             return
 
@@ -192,10 +209,10 @@ class PluginMenuManager:
             if (
                 actions
                 and not actions[-1].isSeparator()
-                and actions[-1].data() != plugin_action_tag
+                and actions[-1].data() != self._PLUGIN_ACTION_TAG
             ):
                 sep = current_menu.addSeparator()
-                sep.setData(plugin_action_tag)
+                sep.setData(self._PLUGIN_ACTION_TAG)
 
             action = QAction(text or parts[-1], self._im.host)
             action.triggered.connect(
@@ -203,7 +220,7 @@ class PluginMenuManager:
             )
             if action_def.get("shortcut"):
                 action.setShortcut(QKeySequence(action_def["shortcut"]))
-            action.setData(plugin_action_tag)
+            action.setData(self._PLUGIN_ACTION_TAG)
             current_menu.addAction(action)
 
     def add_plugin_toolbar_actions(self) -> None:
@@ -248,14 +265,13 @@ class PluginMenuManager:
 
     def _clear_all_plugin_actions(self, plugin_menu: QMenu) -> None:
         """Remove all tagged plugin actions from every menu and the export button."""
-        plugin_action_tag = "plugin_managed"
 
         def clear_menu(menu: Any) -> None:
             if not menu:
                 return
             for act in list(menu.actions()):
-                if act.data() == plugin_action_tag:
-                    menu.removeAction(act)
+                if act.data() == self._PLUGIN_ACTION_TAG:
+                    self._remove_action(menu, act)
                 elif act.menu():
                     clear_menu(act.menu())
 
@@ -265,7 +281,6 @@ class PluginMenuManager:
 
     def update_style_menu_with_plugins(self) -> None:
         """Append custom 3D styles registered by plugins to the style menu."""
-        plugin_action_tag = "plugin_managed"
         style_button = getattr(self._im, "style_button", None)
         if not style_button or not style_button.menu():
             return
@@ -278,7 +293,7 @@ class PluginMenuManager:
         if style_group and self._im.host.plugin_manager.custom_3d_styles:
             if style_menu.actions() and not style_menu.actions()[-1].isSeparator():
                 sep = style_menu.addSeparator()
-                sep.setData(plugin_action_tag)
+                sep.setData(self._PLUGIN_ACTION_TAG)
 
             for style_name in self._im.host.plugin_manager.custom_3d_styles:
                 if not any(a.text() == style_name for a in style_menu.actions()):
@@ -288,7 +303,7 @@ class PluginMenuManager:
                         lambda checked=False,
                         s=style_name: self._im.host.view_3d_manager.set_3d_style(s)
                     )
-                    action.setData(plugin_action_tag)
+                    action.setData(self._PLUGIN_ACTION_TAG)
                     style_menu.addAction(action)
                     style_group.addAction(action)
 
@@ -352,7 +367,6 @@ class PluginMenuManager:
         if not self._im.host.plugin_manager.export_actions:
             return
 
-        plugin_action_tag = "plugin_managed"
         main_export_menu = None
         for top_action in self._im.host.menuBar().actions():
             if top_action.menu() and top_action.text().replace("&", "") == "File":
@@ -376,7 +390,7 @@ class PluginMenuManager:
 
         for menu in targets:
             sep = menu.addSeparator()
-            sep.setData(plugin_action_tag)
+            sep.setData(self._PLUGIN_ACTION_TAG)
             for exp in self._im.host.plugin_manager.export_actions:
                 a = QAction(exp["label"], self._im.host)
                 a.triggered.connect(
@@ -384,7 +398,7 @@ class PluginMenuManager:
                         exp["callback"], exp.get("plugin", "Plugin")
                     )
                 )
-                a.setData(plugin_action_tag)
+                a.setData(self._PLUGIN_ACTION_TAG)
                 menu.addAction(a)
 
     def integrate_plugin_optimization_methods(self) -> None:
@@ -402,7 +416,7 @@ class PluginMenuManager:
             return
 
         for key, action in list(im.opt3d_actions.items()):
-            if action.data() == "plugin_managed":
+            if action.data() == self._PLUGIN_ACTION_TAG:
                 im.opt_group.removeAction(action)
                 im.optimization_menu.removeAction(action)
                 del im.opt3d_actions[key]
@@ -411,7 +425,7 @@ class PluginMenuManager:
         for key, entry in methods.items():
             im.add_optimization_method(entry["label"], key)
             if key in im.opt3d_actions:
-                im.opt3d_actions[key].setData("plugin_managed")
+                im.opt3d_actions[key].setData(self._PLUGIN_ACTION_TAG)
 
     def integrate_plugin_file_openers(self) -> None:
         """Inject plugin file-opener entries into the File > Import menu."""
@@ -424,9 +438,8 @@ class PluginMenuManager:
         if import_menu is None:
             return
 
-        plugin_action_tag = "plugin_managed"
         sep = import_menu.addSeparator()
-        sep.setData(plugin_action_tag)
+        sep.setData(self._PLUGIN_ACTION_TAG)
 
         plugin_map: Dict[str, Any] = {}
         for ext, openers in self._im.host.plugin_manager.file_openers.items():
@@ -471,7 +484,7 @@ class PluginMenuManager:
 
             a = QAction(f"Import {ext_str} ({p_name})...", self._im.host)
             a.triggered.connect(make_cb(ext_map, filter_str, p_name))
-            a.setData(plugin_action_tag)
+            a.setData(self._PLUGIN_ACTION_TAG)
             import_menu.addAction(a)
 
     def integrate_plugin_analysis_tools(self) -> None:
@@ -485,9 +498,8 @@ class PluginMenuManager:
             None,
         )
         if analysis_menu and self._im.host.plugin_manager.analysis_tools:
-            plugin_action_tag = "plugin_managed"
             sep = analysis_menu.addSeparator()
-            sep.setData(plugin_action_tag)
+            sep.setData(self._PLUGIN_ACTION_TAG)
             for tool in self._im.host.plugin_manager.analysis_tools:
                 a = QAction(
                     f"{tool['label']} ({tool.get('plugin', 'Plugin')})", self._im.host
@@ -497,7 +509,7 @@ class PluginMenuManager:
                         tool["callback"], tool.get("plugin", "Plugin")
                     )
                 )
-                a.setData(plugin_action_tag)
+                a.setData(self._PLUGIN_ACTION_TAG)
                 analysis_menu.addAction(a)
 
     def _clear_plugin_ui_elements(self, plugin_menu: QMenu) -> None:

--- a/moleditpy/src/moleditpy/ui/plugin_menu_manager.py
+++ b/moleditpy/src/moleditpy/ui/plugin_menu_manager.py
@@ -141,7 +141,7 @@ class PluginMenuManager:
             for menu in self._get_plugin_target_menus():
                 _clean_menu(menu)
         except Exception:
-            logging.exception("Plugin rebuild: menu cleanup error")
+            logging.warning("Plugin rebuild: menu cleanup error", exc_info=True)
 
         self._im.plugin_menubar_separator_added = False
 
@@ -157,7 +157,7 @@ class PluginMenuManager:
             try:
                 method()
             except Exception:
-                logging.exception("Plugin rebuild: %s error", label)
+                logging.warning("Plugin rebuild: %s error", label, exc_info=True)
 
     def add_registered_plugin_actions(self) -> None:
         """Add menu actions explicitly registered by V3/V4 plugins."""

--- a/moleditpy/src/moleditpy/ui/template_preview_view.py
+++ b/moleditpy/src/moleditpy/ui/template_preview_view.py
@@ -49,7 +49,7 @@ class TemplatePreviewView(QGraphicsView):
                     self.original_scene_rect, Qt.AspectRatioMode.KeepAspectRatio
                 )
         except (AttributeError, RuntimeError, ValueError, TypeError):
-            logging.exception("Failed to refit template preview")
+            logging.warning("Failed to refit template preview", exc_info=True)
 
     def showEvent(self, event: Optional[QShowEvent]) -> None:
         """Handle the show event to ensure the preview fits correctly upon display."""
@@ -88,4 +88,4 @@ class TemplatePreviewView(QGraphicsView):
                     ),
                 )
         except (AttributeError, RuntimeError, ValueError, TypeError):
-            logging.exception("Failed to redraw template preview")
+            logging.warning("Failed to redraw template preview", exc_info=True)

--- a/moleditpy/src/moleditpy/ui/translation_dialog.py
+++ b/moleditpy/src/moleditpy/ui/translation_dialog.py
@@ -283,7 +283,7 @@ class TranslationDialog(BasePickingDialog):
             self.show_atom_labels()
             self.update_display()
         except (AttributeError, RuntimeError, TypeError) as exc:
-            logging.exception("Failed to select all atoms: %s", exc)
+            logging.warning("Failed to select all atoms: %s", exc, exc_info=True)
 
     def _set_origin(self) -> None:
         self.abs_x_input.setText("0.0000")

--- a/moleditpy/src/moleditpy/ui/ui_manager.py
+++ b/moleditpy/src/moleditpy/ui/ui_manager.py
@@ -275,6 +275,11 @@ class UIManager(QObject):
             # Safe defensive fallback catching AttributeError, RuntimeError, TypeError, ValueError
             logging.debug("Suppressed non-critical error", exc_info=True)
 
+        # Mark shutdown so benign teardown errors don't pop an error dialog.
+        app = QApplication.instance()
+        if app is not None:
+            app.setProperty("moleditpy_shutting_down", True)
+
         return True
 
     def closeEvent(self, event: QEvent) -> None:

--- a/moleditpy/src/moleditpy/ui/ui_manager.py
+++ b/moleditpy/src/moleditpy/ui/ui_manager.py
@@ -365,7 +365,7 @@ class UIManager(QObject):
                     event.acceptProposedAction()
                     return
             except Exception:  # plugins have full app access; catch everything to prevent app-wide crash
-                logging.exception("Error in plugin drop handler")
+                logging.warning("Error in plugin drop handler", exc_info=True)
 
         # 2. Built-in Handlers
         file_lower = file_path.lower()

--- a/moleditpy/src/moleditpy/ui/user_template_dialog.py
+++ b/moleditpy/src/moleditpy/ui/user_template_dialog.py
@@ -122,7 +122,7 @@ class UserTemplateDialog(QDialog):
             if hasattr(self.main_window, "ui_manager") and self.main_window.ui_manager:
                 self.main_window.ui_manager.set_mode_and_update_toolbar(target_mode)
         except (AttributeError, RuntimeError, ValueError) as e:
-            logging.error(f"Error resetting main window mode: {e}")
+            logging.warning(f"Error resetting main window mode: {e}")
 
         # 3. Reset Scene State (The Source of Truth)
         try:
@@ -154,7 +154,7 @@ class UserTemplateDialog(QDialog):
 
                 scene.update()
         except (AttributeError, RuntimeError, ValueError) as e:
-            logging.error(f"Error cleaning up scene state: {e}")
+            logging.warning(f"Error cleaning up scene state: {e}")
 
     def resizeEvent(self, event: Any) -> None:
         """Refit template previews when the dialog is resized."""
@@ -208,7 +208,7 @@ class UserTemplateDialog(QDialog):
                         template_data["filepath"] = filepath
                         self.user_templates.append(template_data)
         except (AttributeError, RuntimeError, ValueError) as e:
-            logging.error(f"Error loading user templates: {e}")
+            logging.warning(f"Error loading user templates: {e}")
 
         self.update_template_grid()
 
@@ -218,7 +218,7 @@ class UserTemplateDialog(QDialog):
             with open(filepath, "r", encoding="utf-8") as f:
                 return json.load(f)
         except (OSError, json.JSONDecodeError) as e:
-            logging.error(f"Error loading template file {filepath}: {e}")
+            logging.warning(f"Error loading template file {filepath}: {e}")
             return None
 
     def save_template_file(self, filepath: str, template_data: Any) -> bool:
@@ -228,7 +228,7 @@ class UserTemplateDialog(QDialog):
                 json.dump(template_data, f, indent=2, ensure_ascii=False)
             return True
         except OSError as e:
-            logging.error(f"Error saving template file {filepath}: {e}")
+            logging.warning(f"Error saving template file {filepath}: {e}")
             return False
 
     def update_template_grid(self) -> None:

--- a/moleditpy/src/moleditpy/ui/user_template_dialog.py
+++ b/moleditpy/src/moleditpy/ui/user_template_dialog.py
@@ -593,7 +593,7 @@ class UserTemplateDialog(QDialog):
             self._activate_template_mode(template_data)
             self.selected_template = template_data
         except (AttributeError, RuntimeError, ValueError) as e:
-            QMessageBox.critical(self, "Error", f"Failed to apply template: {str(e)}")
+            logging.exception("Failed to apply template: %s", e)
 
     def save_current_as_template(self) -> None:
         """Save the current editor structure as a new user template."""
@@ -635,7 +635,7 @@ class UserTemplateDialog(QDialog):
                 QMessageBox.critical(self, "Error", "Failed to save template.")
 
         except (AttributeError, RuntimeError, ValueError) as e:
-            QMessageBox.critical(self, "Error", f"Failed to save template: {str(e)}")
+            logging.exception("Failed to save template: %s", e)
 
     def convert_structure_to_template(self, name: str) -> Any:
         """Convert the internal molecular data to template format."""
@@ -708,6 +708,4 @@ class UserTemplateDialog(QDialog):
                 self.selected_template = None
                 self.delete_button.setEnabled(False)
             except OSError as e:
-                QMessageBox.critical(
-                    self, "Error", f"Failed to delete template: {str(e)}"
-                )
+                logging.exception("Failed to delete template: %s", e)

--- a/moleditpy/src/moleditpy/ui/view_3d_logic.py
+++ b/moleditpy/src/moleditpy/ui/view_3d_logic.py
@@ -131,7 +131,10 @@ class View3DManager:
                     return
                 except Exception:  # plugins have full app access; catch everything to keep 3D view functional
                     logging.warning(
-                        "Error in custom 3D style '%s'", self.current_3d_style, exc_info=True)
+                        "Error in custom 3D style '%s'",
+                        self.current_3d_style,
+                        exc_info=True,
+                    )
 
         self.draw_standard_3d_style(mol)
 
@@ -1047,7 +1050,9 @@ class View3DManager:
                     z_off = 0
                     for idx, lbl in chiral_centers:
                         if self.atom_positions_3d is None:
-                            logging.warning("atom_positions_3d is None in _add_3d_labels")
+                            logging.warning(
+                                "atom_positions_3d is None in _add_3d_labels"
+                            )
                             continue
                         coord = self.atom_positions_3d[idx].copy()
                         coord[2] += z_off

--- a/moleditpy/src/moleditpy/ui/view_3d_logic.py
+++ b/moleditpy/src/moleditpy/ui/view_3d_logic.py
@@ -130,9 +130,8 @@ class View3DManager:
                     handler(mw, mol)
                     return
                 except Exception:  # plugins have full app access; catch everything to keep 3D view functional
-                    logging.exception(
-                        "Error in custom 3D style '%s'", self.current_3d_style
-                    )
+                    logging.warning(
+                        "Error in custom 3D style '%s'", self.current_3d_style, exc_info=True)
 
         self.draw_standard_3d_style(mol)
 
@@ -295,7 +294,7 @@ class View3DManager:
                     # Force a render so the change is visible immediately
                     self.plotter.render()  # type: ignore[union-attr]
                 except (AttributeError, RuntimeError, TypeError) as e:
-                    logging.error(f"Render failed: {e}")
+                    logging.warning(f"Render failed: {e}")
 
         # Re-display if AtomID or other atom info is shown
         if self.atom_info_display_mode is not None:
@@ -488,7 +487,7 @@ class View3DManager:
 
                     # Add normal atoms (excluding skip list)
                     if self.atom_positions_3d is None:
-                        logging.error(
+                        logging.warning(
                             "atom_positions_3d is None in _add_3d_atom_glyphs"
                         )
                         return
@@ -589,7 +588,7 @@ class View3DManager:
                     q = QColor(bs_hex)
                     bs_bond_rgb = [q.red(), q.green(), q.blue()]
                 except (AttributeError, RuntimeError, TypeError, ValueError) as e:
-                    logging.error(f"Failed to load bond color from settings: {e}")
+                    logging.warning(f"Failed to load bond color from settings: {e}")
 
             # Lists for batch processing
             all_points = []
@@ -899,7 +898,7 @@ class View3DManager:
                 for ring in aromatic_rings:
                     # Get atom positions
                     if self.atom_positions_3d is None:
-                        logging.error(
+                        logging.warning(
                             "atom_positions_3d is None in _update_atom_glyphs_internal"
                         )
                         continue
@@ -1036,7 +1035,7 @@ class View3DManager:
                     self.plotter.add_mesh(circle_line, color=torus_color, **mesh_props)  # type: ignore[union-attr]
 
             except (AttributeError, RuntimeError, TypeError, ValueError) as e:
-                logging.error(f"Error rendering aromatic circles: {e}")
+                logging.warning(f"Error rendering aromatic circles: {e}")
 
     def _add_3d_labels(self, mol: Any, mol_to_draw: Any) -> None:
         if getattr(self, "show_chiral_labels", False):
@@ -1048,7 +1047,7 @@ class View3DManager:
                     z_off = 0
                     for idx, lbl in chiral_centers:
                         if self.atom_positions_3d is None:
-                            logging.error("atom_positions_3d is None in _add_3d_labels")
+                            logging.warning("atom_positions_3d is None in _add_3d_labels")
                             continue
                         coord = self.atom_positions_3d[idx].copy()
                         coord[2] += z_off
@@ -1191,7 +1190,7 @@ class View3DManager:
             try:
                 self.plotter.remove_actor("ez_labels")  # type: ignore[union-attr]
             except (AttributeError, RuntimeError, TypeError) as e:
-                logging.error(f"Failed to remove EZ labels: {e}")
+                logging.warning(f"Failed to remove EZ labels: {e}")
 
         pts, labels = [], []
 
@@ -1210,7 +1209,7 @@ class View3DManager:
                 mol, cleanIt=True, force=True, flagPossibleStereoCenters=True
             )
         except (AttributeError, RuntimeError, TypeError, ValueError):
-            logging.error("Caught exception in " + __file__, exc_info=True)
+            logging.warning("Caught exception in " + __file__, exc_info=True)
 
         for bond in mol.GetBonds():
             if bond.GetBondType() == Chem.BondType.DOUBLE:
@@ -1329,7 +1328,7 @@ class View3DManager:
                 try:
                     Chem.AssignAtomChiralTagsFromStructure(mol_for_chirality, confId=0)
                 except (AttributeError, RuntimeError, TypeError, ValueError) as e:
-                    logging.error(f"AssignAtomChiralTagsFromStructure failed: {e}")
+                    logging.warning(f"AssignAtomChiralTagsFromStructure failed: {e}")
 
             # Get chiral centers (list of (idx, 'R'/'S'/'?'))
             chiral_centers = Chem.FindMolChiralCenters(
@@ -1462,7 +1461,7 @@ class View3DManager:
                 if atom.HasProp("_original_atom_id"):
                     return True
         except (AttributeError, RuntimeError, TypeError, ValueError) as e:
-            logging.error(f"Failed to check original atom IDs: {e}")
+            logging.warning(f"Failed to check original atom IDs: {e}")
         return False
 
     def update_atom_id_menu_text(self) -> None:
@@ -1655,7 +1654,7 @@ class View3DManager:
                 )
                 self.current_atom_info_labels.append(a)
         except (AttributeError, RuntimeError, TypeError, ValueError) as e:
-            logging.error(f"Error adding atom info labels: {e}")
+            logging.warning(f"Error adding atom info labels: {e}")
 
         # Display legend in the top-right (remove existing legends)
         try:

--- a/tests/assertion_catalog.md
+++ b/tests/assertion_catalog.md
@@ -815,6 +815,11 @@ _Test on_calculation_error for an ACTIVE worker._
 - assert compute.statusBar().showMessage.called
 - assert 'Real Error' in compute.statusBar().showMessage.call_args[0][0]
 
+### test_on_calculation_error_reenables_export
+_A failed optimization runs the full UI restore (which re-enables Export),_
+
+- refresh.assert_called_once()
+
 ### test_compute_set_optimization_method
 _Verify that setting the optimization method updates both settings and internal state._
 
@@ -3022,6 +3027,11 @@ _A worker-thread record must not queue a dialog (QMessageBox unsafe)._
 
 ### test_handler_honors_no_dialog_extra
 _extra={'no_dialog': True} opts a record out entirely._
+
+- qtimer.singleShot.assert_not_called()
+
+### test_handler_suppressed_during_shutdown
+_Benign teardown errors must not pop a dialog once the app is closing._
 
 - qtimer.singleShot.assert_not_called()
 

--- a/tests/assertion_catalog.md
+++ b/tests/assertion_catalog.md
@@ -301,6 +301,16 @@ _Test the internal binary state serialization used for Undo/Redo._
 - assert mw.state_manager.data.atoms[aid]['symbol'] == 'N'
 - assert mw.view_3d_manager.current_mol.GetAtomWithIdx(0).GetIntProp('_original_atom_id') == aid
 
+### test_undo_restore_preserves_camera
+_Undo/redo (is_restoring_state) must NOT reset the camera — draw_molecule_3d_
+
+- mw.view_3d_manager.plotter.reset_camera.assert_not_called()
+
+### test_fresh_load_refits_camera
+_A normal load (not restoring state) still refits the camera._
+
+- mw.view_3d_manager.plotter.reset_camera.assert_called_once()
+
 ### test_legacy_version_handling
 _Verify that version mismatch warnings are triggered (but don't crash)._
 
@@ -3015,10 +3025,15 @@ _extra={'no_dialog': True} opts a record out entirely._
 
 - qtimer.singleShot.assert_not_called()
 
-### test_handler_queues_once_then_dedups
-_Identical message+traceback queues one dialog; the repeat is suppressed._
+### test_handler_dedups_rapid_repeat_within_window
+_A fast repeat of the same error (within the dedup window) is collapsed_
 
 - assert qtimer.singleShot.call_count == 1
+
+### test_handler_reshows_same_error_after_window
+_The same error surfacing again after the dedup window DOES show a new_
+
+- assert qtimer.singleShot.call_count == 2
 
 ### test_handler_emit_never_raises
 _emit must swallow internal failures (logging contract)._
@@ -3971,7 +3986,7 @@ _MoveSelectedAtomsDialog pre-populates selected_atoms from preselected_atoms._
 - assert dlg.selected_atoms == {0, 1}
 
 ### test_show_atom_labels_none_positions
-_show_atom_labels logs an error and does nothing when atom_positions_3d is None._
+_show_atom_labels logs a warning and does nothing when atom_positions_3d is None._
 
 - mock_log.assert_called_once_with('atom_positions_3d is None in update_atom_labels')
 
@@ -4819,7 +4834,7 @@ _get_main_window returns the value set by set_main_window._
 - assert pm.get_main_window() == 'mw'
 
 ### TestPluginManagerExtended.test_ensure_plugin_dir_error
-_ensure_plugin_dir logs an error when os.makedirs raises OSError._
+_ensure_plugin_dir logs a warning when os.makedirs raises OSError._
 
 - mock_log.assert_called_with('Error creating plugin directory: test mkdir err')
 
@@ -4862,7 +4877,7 @@ _discover_plugins returns an empty list when the plugin directory does not exist
 - assert pm.discover_plugins() == []
 
 ### TestPluginManagerExtended.test_load_single_plugin_exceptions_and_stub
-__load_single_plugin logs errors on RuntimeError and handles a None spec._
+__load_single_plugin logs warnings on RuntimeError and handles a None spec._
 
 - assert 'Cat' in sys.modules
 - assert 'Cat.SubCat' in sys.modules
@@ -4913,7 +4928,7 @@ _register_window stores and get_window retrieves a plugin's named window._
 - assert pm.get_window('P1', 'w1') == 'WIN'
 
 ### TestPluginManagerExtended.test_invoke_document_reset_handlers_logs_error
-_invoke_document_reset_handlers logs an error when a handler raises._
+_invoke_document_reset_handlers logs a warning when a handler raises._
 
 - mock_log.assert_called()
 

--- a/tests/assertion_catalog.md
+++ b/tests/assertion_catalog.md
@@ -1723,9 +1723,9 @@ _save_2d_as_template leaves the existing file unchanged when user answers No._
 - assert json.loads(f.read_text()) == {'original': True}
 
 ### TestSave2DAsTemplate.test_shows_error_on_exception
-_save_2d_as_template shows a critical error dialog when serialisation raises._
+_save_2d_as_template logs the error when serialisation raises._
 
-- mock_crit.assert_called_once()
+- assert 'Failed to save template: boom' in caplog.text
 
 ### TestModelessGeometryDialogs.test_open_translation_dialog
 _open_translation_dialog shows a modeless dialog and wires up all signals._
@@ -2999,6 +2999,65 @@ _Test BondItem.update_position resilience when atoms exist._
 - assert line.length() == 0.0
 
 ## tests/unit/test_main_qt_handler.py
+
+### test_handler_skips_without_qapplication
+_No GUI event loop → nothing is queued (the log record is the surface)._
+
+- qtimer.singleShot.assert_not_called()
+
+### test_handler_skips_off_gui_thread
+_A worker-thread record must not queue a dialog (QMessageBox unsafe)._
+
+- qtimer.singleShot.assert_not_called()
+
+### test_handler_honors_no_dialog_extra
+_extra={'no_dialog': True} opts a record out entirely._
+
+- qtimer.singleShot.assert_not_called()
+
+### test_handler_queues_once_then_dedups
+_Identical message+traceback queues one dialog; the repeat is suppressed._
+
+- assert qtimer.singleShot.call_count == 1
+
+### test_handler_emit_never_raises
+_emit must swallow internal failures (logging contract)._
+
+- handle_err.assert_called_once()
+
+### test_show_yields_to_existing_modal
+_If a site/plugin QMessageBox.critical is already up, stay quiet._
+
+- qmb.assert_not_called()
+
+### test_show_displays_non_blocking_when_no_modal
+_With no other modal up, the dialog is shown non-blocking (show, not exec)_
+
+- qmb.return_value.setDetailedText.assert_called_once()
+- qmb.return_value.show.assert_called_once()
+- qmb.return_value.exec.assert_not_called()
+- assert qmb.return_value in handler._open_boxes
+
+### test_show_swallows_its_own_errors
+_A failure while building the dialog must not propagate._
+
+
+### test_details_names_log_file_when_file_logging_on
+_The informative text points at the log file only when one is active._
+
+- assert '/home/u/.moleditpy/moleditpy.log' in with_file._details()
+- assert 'terminal' in hint.lower()
+- assert 'moleditpy.log' not in hint
+
+### test_dialog_handler_not_attached_when_headless
+_MOLEDITPY_HEADLESS must suppress the modal dialog handler entirely,_
+
+- assert _dialog_handlers() == []
+
+### test_dialog_handler_attached_when_not_headless
+_A real (non-headless) run installs exactly one dialog handler._
+
+- assert len(_dialog_handlers()) == 1
 
 ### test_downgraded_pattern_routes_to_debug
 _Messages matching a downgraded pattern are logged at DEBUG, not WARNING._
@@ -4943,9 +5002,9 @@ _on_remove_plugin removes a package plugin by calling shutil.rmtree on its direc
 - mock_info.assert_called()
 
 ### test_on_remove_plugin_error
-_on_remove_plugin shows a critical error dialog when os.remove raises OSError._
+_on_remove_plugin logs the error when os.remove raises OSError._
 
-- mock_critical.assert_called_with(window, 'Error', 'Failed to delete plugin: Remove error')
+- assert 'Failed to delete plugin: Remove error' in caplog.text
 
 ### test_on_remove_plugin_not_exists
 _on_remove_plugin shows a warning when the plugin file does not exist._
@@ -7421,6 +7480,18 @@ _If one step raises, all subsequent steps still execute._
 _rebuild_plugin_menus must remove actions tagged with 'plugin_managed' from target menus._
 
 - export_menu.removeAction.assert_called_once_with(tagged_action)
+
+### TestRebuildCleanup.test_rebuild_detaches_tagged_action_from_its_action_group
+_A tagged action in a QActionGroup (e.g. a custom 3D style) must be_
+
+- group.removeAction.assert_called_once_with(tagged_action)
+- style_menu.removeAction.assert_called_once_with(tagged_action)
+
+### TestRebuildCleanup.test_untagged_action_in_group_is_left_alone
+_A non-plugin action sharing the style group must not be touched._
+
+- group.removeAction.assert_not_called()
+- style_menu.removeAction.assert_not_called()
 
 ### TestPluginMenuManagerRouting.test_main_window_proxy_returns_init_manager_pmm
 _MainWindow.plugin_menu_manager property reads from init_manager._

--- a/tests/coverage_report.md
+++ b/tests/coverage_report.md
@@ -7,8 +7,8 @@
 | File | Stmts | Miss | Cover |
 | :--- | :--- | :--- | :--- |
 | moleditpy\src\moleditpy\__init__.py                     |      6 |      2 |   66.7% |
-| moleditpy\src\moleditpy\main.py                         |    164 |     34 |   79.3% |
-| moleditpy\src\moleditpy\core\mol_geometry.py            |    292 |     42 |   85.6% |
+| moleditpy\src\moleditpy\main.py                         |    168 |     35 |   79.2% |
+| moleditpy\src\moleditpy\core\mol_geometry.py            |    292 |     43 |   85.3% |
 | moleditpy\src\moleditpy\core\molecular_data.py          |    258 |     28 |   89.1% |
 | moleditpy\src\moleditpy\plugins\plugin_interface.py     |    233 |      6 |   97.4% |
 | moleditpy\src\moleditpy\plugins\plugin_manager.py       |    378 |      8 |   97.9% |
@@ -67,7 +67,7 @@
 | moleditpy\src\moleditpy\utils\sip_isdeleted_safe.py     |     19 |      0 |  100.0% |
 | moleditpy\src\moleditpy\utils\suppress_log.py           |     10 |      0 |  100.0% |
 | moleditpy\src\moleditpy\utils\system_utils.py           |     39 |      0 |  100.0% |
-| **TOTAL** | **16097** | **2768** | **82.80%** |
+| **TOTAL** | **16101** | **2770** | **82.80%** |
 
 ## Test Suite Status
 - **Unit tests**: PASSED

--- a/tests/coverage_report.md
+++ b/tests/coverage_report.md
@@ -1,13 +1,13 @@
 # MoleditPy Coverage Report
 
-- **Overall Project Coverage**: **82.80%**
+- **Overall Project Coverage**: **82.81%**
 
 ### Coverage Breakdown
 
 | File | Stmts | Miss | Cover |
 | :--- | :--- | :--- | :--- |
 | moleditpy\src\moleditpy\__init__.py                     |      6 |      2 |   66.7% |
-| moleditpy\src\moleditpy\main.py                         |    168 |     35 |   79.2% |
+| moleditpy\src\moleditpy\main.py                         |    170 |     35 |   79.4% |
 | moleditpy\src\moleditpy\core\mol_geometry.py            |    292 |     43 |   85.3% |
 | moleditpy\src\moleditpy\core\molecular_data.py          |    258 |     28 |   89.1% |
 | moleditpy\src\moleditpy\plugins\plugin_interface.py     |    233 |      6 |   97.4% |
@@ -43,7 +43,7 @@
 | moleditpy\src\moleditpy\ui\main_window_init.py          |   1060 |     99 |   90.7% |
 | moleditpy\src\moleditpy\ui\mirror_dialog.py             |     72 |      7 |   90.3% |
 | moleditpy\src\moleditpy\ui\molecular_scene_handler.py   |    997 |    161 |   83.9% |
-| moleditpy\src\moleditpy\ui\molecule_scene.py            |    614 |    118 |   80.8% |
+| moleditpy\src\moleditpy\ui\molecule_scene.py            |    614 |    116 |   81.1% |
 | moleditpy\src\moleditpy\ui\move_group_dialog.py         |    386 |    130 |   66.3% |
 | moleditpy\src\moleditpy\ui\move_selected_atoms_dialog.py |    461 |     75 |   83.7% |
 | moleditpy\src\moleditpy\ui\periodic_table_dialog.py     |     37 |      2 |   94.6% |
@@ -54,7 +54,7 @@
 | moleditpy\src\moleditpy\ui\template_preview_item.py     |    102 |      3 |   97.1% |
 | moleditpy\src\moleditpy\ui\template_preview_view.py     |     46 |      4 |   91.3% |
 | moleditpy\src\moleditpy\ui\translation_dialog.py        |    276 |     21 |   92.4% |
-| moleditpy\src\moleditpy\ui\ui_manager.py                |    368 |     98 |   73.4% |
+| moleditpy\src\moleditpy\ui\ui_manager.py                |    371 |     98 |   73.6% |
 | moleditpy\src\moleditpy\ui\user_template_dialog.py      |    360 |     79 |   78.1% |
 | moleditpy\src\moleditpy\ui\view_3d_logic.py             |   1007 |    259 |   74.3% |
 | moleditpy\src\moleditpy\ui\zoomable_view.py             |     82 |      2 |   97.6% |
@@ -67,7 +67,7 @@
 | moleditpy\src\moleditpy\utils\sip_isdeleted_safe.py     |     19 |      0 |  100.0% |
 | moleditpy\src\moleditpy\utils\suppress_log.py           |     10 |      0 |  100.0% |
 | moleditpy\src\moleditpy\utils\system_utils.py           |     39 |      0 |  100.0% |
-| **TOTAL** | **16101** | **2770** | **82.80%** |
+| **TOTAL** | **16106** | **2768** | **82.81%** |
 
 ## Test Suite Status
 - **Unit tests**: PASSED

--- a/tests/coverage_report.md
+++ b/tests/coverage_report.md
@@ -1,22 +1,22 @@
 # MoleditPy Coverage Report
 
-- **Overall Project Coverage**: **82.73%**
+- **Overall Project Coverage**: **82.80%**
 
 ### Coverage Breakdown
 
 | File | Stmts | Miss | Cover |
 | :--- | :--- | :--- | :--- |
 | moleditpy\src\moleditpy\__init__.py                     |      6 |      2 |   66.7% |
-| moleditpy\src\moleditpy\main.py                         |    114 |     33 |   71.1% |
+| moleditpy\src\moleditpy\main.py                         |    164 |     34 |   79.3% |
 | moleditpy\src\moleditpy\core\mol_geometry.py            |    292 |     42 |   85.6% |
 | moleditpy\src\moleditpy\core\molecular_data.py          |    258 |     28 |   89.1% |
 | moleditpy\src\moleditpy\plugins\plugin_interface.py     |    233 |      6 |   97.4% |
 | moleditpy\src\moleditpy\plugins\plugin_manager.py       |    378 |      8 |   97.9% |
-| moleditpy\src\moleditpy\plugins\plugin_manager_window.py |    186 |      2 |   98.9% |
+| moleditpy\src\moleditpy\plugins\plugin_manager_window.py |    187 |      2 |   98.9% |
 | moleditpy\src\moleditpy\ui\__init__.py                  |      7 |      3 |   57.1% |
 | moleditpy\src\moleditpy\ui\about_dialog.py              |     64 |     13 |   79.7% |
-| moleditpy\src\moleditpy\ui\align_plane_dialog.py        |    152 |     16 |   89.5% |
-| moleditpy\src\moleditpy\ui\alignment_dialog.py          |    148 |     11 |   92.6% |
+| moleditpy\src\moleditpy\ui\align_plane_dialog.py        |    151 |     15 |   90.1% |
+| moleditpy\src\moleditpy\ui\alignment_dialog.py          |    147 |     10 |   93.2% |
 | moleditpy\src\moleditpy\ui\analysis_window.py           |    117 |     25 |   78.6% |
 | moleditpy\src\moleditpy\ui\angle_dialog.py              |    264 |     28 |   89.4% |
 | moleditpy\src\moleditpy\ui\app_state.py                 |    334 |     62 |   81.4% |
@@ -28,11 +28,11 @@
 | moleditpy\src\moleditpy\ui\calculation_worker.py        |    583 |    102 |   82.5% |
 | moleditpy\src\moleditpy\ui\color_settings_dialog.py     |    166 |     13 |   92.2% |
 | moleditpy\src\moleditpy\ui\compute_logic.py             |    431 |     88 |   79.6% |
-| moleditpy\src\moleditpy\ui\constrained_optimization_dialog.py |    472 |    120 |   74.6% |
+| moleditpy\src\moleditpy\ui\constrained_optimization_dialog.py |    471 |    119 |   74.7% |
 | moleditpy\src\moleditpy\ui\custom_interactor_style.py   |    470 |    247 |   47.4% |
 | moleditpy\src\moleditpy\ui\custom_qt_interactor.py      |     44 |     35 |   20.5% |
 | moleditpy\src\moleditpy\ui\dialog_3d_picking_mixin.py   |    137 |     19 |   86.1% |
-| moleditpy\src\moleditpy\ui\dialog_logic.py              |    229 |     25 |   89.1% |
+| moleditpy\src\moleditpy\ui\dialog_logic.py              |    230 |     25 |   89.1% |
 | moleditpy\src\moleditpy\ui\dihedral_dialog.py           |    268 |     32 |   88.1% |
 | moleditpy\src\moleditpy\ui\edit_3d_logic.py             |    221 |     32 |   85.5% |
 | moleditpy\src\moleditpy\ui\edit_actions_logic.py        |    815 |    199 |   75.6% |
@@ -43,12 +43,12 @@
 | moleditpy\src\moleditpy\ui\main_window_init.py          |   1060 |     99 |   90.7% |
 | moleditpy\src\moleditpy\ui\mirror_dialog.py             |     72 |      7 |   90.3% |
 | moleditpy\src\moleditpy\ui\molecular_scene_handler.py   |    997 |    161 |   83.9% |
-| moleditpy\src\moleditpy\ui\molecule_scene.py            |    614 |    116 |   81.1% |
+| moleditpy\src\moleditpy\ui\molecule_scene.py            |    614 |    118 |   80.8% |
 | moleditpy\src\moleditpy\ui\move_group_dialog.py         |    386 |    130 |   66.3% |
 | moleditpy\src\moleditpy\ui\move_selected_atoms_dialog.py |    461 |     75 |   83.7% |
 | moleditpy\src\moleditpy\ui\periodic_table_dialog.py     |     37 |      2 |   94.6% |
 | moleditpy\src\moleditpy\ui\planarize_dialog.py          |    112 |      9 |   92.0% |
-| moleditpy\src\moleditpy\ui\plugin_menu_manager.py       |    280 |     49 |   82.5% |
+| moleditpy\src\moleditpy\ui\plugin_menu_manager.py       |    275 |     44 |   84.0% |
 | moleditpy\src\moleditpy\ui\settings_dialog.py           |    101 |      3 |   97.0% |
 | moleditpy\src\moleditpy\ui\string_importers.py          |    121 |     24 |   80.2% |
 | moleditpy\src\moleditpy\ui\template_preview_item.py     |    102 |      3 |   97.1% |
@@ -67,7 +67,7 @@
 | moleditpy\src\moleditpy\utils\sip_isdeleted_safe.py     |     19 |      0 |  100.0% |
 | moleditpy\src\moleditpy\utils\suppress_log.py           |     10 |      0 |  100.0% |
 | moleditpy\src\moleditpy\utils\system_utils.py           |     39 |      0 |  100.0% |
-| **TOTAL** | **16053** | **2773** | **82.73%** |
+| **TOTAL** | **16097** | **2768** | **82.80%** |
 
 ## Test Suite Status
 - **Unit tests**: PASSED

--- a/tests/integration/test_plugin_menu_rebuild.py
+++ b/tests/integration/test_plugin_menu_rebuild.py
@@ -223,6 +223,48 @@ class TestRebuildCleanup:
         # The tagged action should be removed
         export_menu.removeAction.assert_called_once_with(tagged_action)
 
+    def test_rebuild_detaches_tagged_action_from_its_action_group(self):
+        """A tagged action in a QActionGroup (e.g. a custom 3D style) must be
+        removed from the group as well as the menu, otherwise it leaks into the
+        exclusive group across rebuilds and can drop the active check state."""
+        im = _make_im()
+
+        style_menu = MagicMock()
+        im.style_button.menu.return_value = style_menu
+
+        group = MagicMock()
+        tagged_action = MagicMock()
+        tagged_action.data.return_value = "plugin_managed"
+        tagged_action.menu.return_value = None
+        tagged_action.actionGroup.return_value = group
+        style_menu.actions.return_value = [tagged_action]
+
+        pmm = PluginMenuManager(im)
+        pmm.rebuild_plugin_menus()
+
+        group.removeAction.assert_called_once_with(tagged_action)
+        style_menu.removeAction.assert_called_once_with(tagged_action)
+
+    def test_untagged_action_in_group_is_left_alone(self):
+        """A non-plugin action sharing the style group must not be touched."""
+        im = _make_im()
+
+        style_menu = MagicMock()
+        im.style_button.menu.return_value = style_menu
+
+        group = MagicMock()
+        builtin_action = MagicMock()
+        builtin_action.data.return_value = None
+        builtin_action.menu.return_value = None
+        builtin_action.actionGroup.return_value = group
+        style_menu.actions.return_value = [builtin_action]
+
+        pmm = PluginMenuManager(im)
+        pmm.rebuild_plugin_menus()
+
+        group.removeAction.assert_not_called()
+        style_menu.removeAction.assert_not_called()
+
 
 # ---------------------------------------------------------------------------
 # MainWindow.plugin_menu_manager proxy and PluginManager call path

--- a/tests/unit/test_app_state.py
+++ b/tests/unit/test_app_state.py
@@ -446,6 +446,42 @@ def test_undo_state_binary_roundtrip(dummy_window):
     )
 
 
+def _state_with_3d_mol(mw):
+    aid = mw.state_manager.data.add_atom("N", QPointF(5, 5))
+    mol = Chem.AddHs(Chem.MolFromSmiles("N"))
+    AllChem.EmbedMolecule(mol)
+    mol.GetAtomWithIdx(0).SetIntProp("_original_atom_id", aid)
+    mw.view_3d_manager.current_mol = mol
+    return mw.get_current_state()
+
+
+def test_undo_restore_preserves_camera(dummy_window):
+    """Undo/redo (is_restoring_state) must NOT reset the camera — draw_molecule_3d
+    already preserves it, so the user's zoom survives the restore."""
+    mw = dummy_window
+    state = _state_with_3d_mol(mw)
+
+    mw.clear_2d_editor(push_to_undo=False)
+    mw.is_restoring_state = True
+    mw.view_3d_manager.plotter.reset_camera.reset_mock()
+    mw.set_state_from_data(state)
+
+    mw.view_3d_manager.plotter.reset_camera.assert_not_called()
+
+
+def test_fresh_load_refits_camera(dummy_window):
+    """A normal load (not restoring state) still refits the camera."""
+    mw = dummy_window
+    state = _state_with_3d_mol(mw)
+
+    mw.clear_2d_editor(push_to_undo=False)
+    mw.is_restoring_state = False
+    mw.view_3d_manager.plotter.reset_camera.reset_mock()
+    mw.set_state_from_data(state)
+
+    mw.view_3d_manager.plotter.reset_camera.assert_called_once()
+
+
 def test_legacy_version_handling(dummy_window):
     """Verify that version mismatch warnings are triggered (but don't crash)."""
     mw = dummy_window

--- a/tests/unit/test_compute_logic.py
+++ b/tests/unit/test_compute_logic.py
@@ -198,6 +198,16 @@ def test_on_calculation_error_basic(mock_parser_host):
     assert "Real Error" in compute.statusBar().showMessage.call_args[0][0]
 
 
+def test_on_calculation_error_reenables_export(mock_parser_host):
+    """A failed optimization runs the full UI restore (which re-enables Export),
+    not just the convert/optimize button restore."""
+    compute = DummyCompute(mock_parser_host)
+    compute.active_worker_ids = {"active_id"}
+    with patch.object(compute, "_refresh_ui_state") as refresh:
+        compute.on_calculation_error(("active_id", "Optimization failed"))
+    refresh.assert_called_once()
+
+
 def test_compute_set_optimization_method(mock_parser_host):
     """Verify that setting the optimization method updates both settings and internal state."""
     compute = DummyCompute(mock_parser_host)

--- a/tests/unit/test_dialog_manager.py
+++ b/tests/unit/test_dialog_manager.py
@@ -27,6 +27,7 @@ No local imports exist in dialog_logic.py so all classes are patchable at the
 module level.
 """
 
+import logging
 import os
 import sys
 import json
@@ -400,18 +401,18 @@ class TestSave2DAsTemplate:
             dm.save_2d_as_template()
         assert json.loads(f.read_text()) == {"original": True}
 
-    def test_shows_error_on_exception(self, dm):
-        """save_2d_as_template shows a critical error dialog when serialisation raises."""
+    def test_shows_error_on_exception(self, dm, caplog):
+        """save_2d_as_template logs the error when serialisation raises."""
         dm.host.state_manager.data.to_template_dict.side_effect = AttributeError("boom")
         with (
             patch(
                 "moleditpy.ui.dialog_logic.QInputDialog.getText",
                 return_value=("mytemplate", True),
             ),
-            patch("moleditpy.ui.dialog_logic.QMessageBox.critical") as mock_crit,
+            caplog.at_level(logging.ERROR),
         ):
             dm.save_2d_as_template()
-        mock_crit.assert_called_once()
+        assert "Failed to save template: boom" in caplog.text
 
 
 # ===========================================================================

--- a/tests/unit/test_main_qt_handler.py
+++ b/tests/unit/test_main_qt_handler.py
@@ -16,11 +16,82 @@ if _SRC not in sys.path:
 
 from PyQt6.QtCore import QtMsgType
 
+import moleditpy.main as main_mod
 from moleditpy.main import (
     _DOWNGRADED_QT_PATTERNS,
     _qt_message_handler,
     _read_startup_log_settings,
+    _show_exception_dialog,
 )
+
+
+def _exc_args(message="boom"):
+    """Build a (type, value, tb) triple for a real raised exception."""
+    try:
+        raise ValueError(message)
+    except ValueError as exc:
+        return type(exc), exc, exc.__traceback__
+
+
+@pytest.fixture(autouse=True)
+def _clear_shown_signatures():
+    """Isolate the module-level dedup set between tests."""
+    main_mod._shown_exception_signatures.clear()
+    yield
+    main_mod._shown_exception_signatures.clear()
+
+
+def test_exception_dialog_skipped_without_qapplication():
+    """No GUI event loop → no dialog (the log record is the only surface)."""
+    with patch.object(main_mod, "QApplication") as qapp, patch.object(
+        main_mod, "QMessageBox"
+    ) as qmb:
+        qapp.instance.return_value = None
+        _show_exception_dialog(*_exc_args())
+    qmb.assert_not_called()
+
+
+def test_exception_dialog_skipped_off_gui_thread():
+    """A worker-thread exception must not pop a QMessageBox (unsafe)."""
+    app = MagicMock()
+    with patch.object(main_mod, "QApplication") as qapp, patch.object(
+        main_mod, "QThread"
+    ) as qthread, patch.object(main_mod, "QMessageBox") as qmb:
+        qapp.instance.return_value = app
+        app.thread.return_value = "gui-thread"
+        qthread.currentThread.return_value = "worker-thread"
+        _show_exception_dialog(*_exc_args())
+    qmb.assert_not_called()
+
+
+def test_exception_dialog_shown_once_on_gui_thread():
+    """On the GUI thread the dialog is shown once, then deduped by traceback."""
+    app = MagicMock()
+    with patch.object(main_mod, "QApplication") as qapp, patch.object(
+        main_mod, "QThread"
+    ) as qthread, patch.object(main_mod, "QMessageBox") as qmb:
+        qapp.instance.return_value = app
+        app.thread.return_value = "gui-thread"
+        qthread.currentThread.return_value = "gui-thread"
+        args = _exc_args()
+        _show_exception_dialog(*args)
+        _show_exception_dialog(*args)  # identical traceback → suppressed
+    assert qmb.call_count == 1
+    qmb.return_value.exec.assert_called_once()
+
+
+def test_exception_dialog_swallows_its_own_errors():
+    """A failure while building the dialog must not escape the excepthook."""
+    app = MagicMock()
+    with patch.object(main_mod, "QApplication") as qapp, patch.object(
+        main_mod, "QThread"
+    ) as qthread, patch.object(main_mod, "QMessageBox") as qmb:
+        qapp.instance.return_value = app
+        app.thread.return_value = "gui-thread"
+        qthread.currentThread.return_value = "gui-thread"
+        qmb.side_effect = RuntimeError("Qt is gone")
+        # Must not raise.
+        _show_exception_dialog(*_exc_args())
 
 
 @pytest.mark.parametrize("pattern", _DOWNGRADED_QT_PATTERNS)

--- a/tests/unit/test_main_qt_handler.py
+++ b/tests/unit/test_main_qt_handler.py
@@ -19,79 +19,181 @@ from PyQt6.QtCore import QtMsgType
 import moleditpy.main as main_mod
 from moleditpy.main import (
     _DOWNGRADED_QT_PATTERNS,
+    _ErrorDialogHandler,
     _qt_message_handler,
     _read_startup_log_settings,
-    _show_exception_dialog,
 )
 
 
-def _exc_args(message="boom"):
-    """Build a (type, value, tb) triple for a real raised exception."""
-    try:
-        raise ValueError(message)
-    except ValueError as exc:
-        return type(exc), exc, exc.__traceback__
+def _record(message="boom", level=logging.ERROR, exc_info=None, **extra):
+    """Build a logging.LogRecord as the handler would receive it."""
+    rec = logging.LogRecord(
+        name="test", level=level, pathname=__file__, lineno=1,
+        msg=message, args=(), exc_info=exc_info,
+    )
+    for key, value in extra.items():
+        setattr(rec, key, value)
+    return rec
 
 
-@pytest.fixture(autouse=True)
-def _clear_shown_signatures():
-    """Isolate the module-level dedup set between tests."""
-    main_mod._shown_exception_signatures.clear()
-    yield
-    main_mod._shown_exception_signatures.clear()
+# ---------------------------------------------------------------------------
+# _ErrorDialogHandler.emit — guards, dedup, deferral (state is per-instance)
+# ---------------------------------------------------------------------------
 
 
-def test_exception_dialog_skipped_without_qapplication():
-    """No GUI event loop → no dialog (the log record is the only surface)."""
+def test_handler_skips_without_qapplication():
+    """No GUI event loop → nothing is queued (the log record is the surface)."""
+    with patch.object(main_mod, "QApplication") as qapp, patch.object(
+        main_mod, "QTimer"
+    ) as qtimer:
+        qapp.instance.return_value = None
+        _ErrorDialogHandler().emit(_record())
+    qtimer.singleShot.assert_not_called()
+
+
+def test_handler_skips_off_gui_thread():
+    """A worker-thread record must not queue a dialog (QMessageBox unsafe)."""
+    app = MagicMock()
+    app.thread.return_value = "gui"
+    with patch.object(main_mod, "QApplication") as qapp, patch.object(
+        main_mod, "QThread"
+    ) as qthread, patch.object(main_mod, "QTimer") as qtimer:
+        qapp.instance.return_value = app
+        qthread.currentThread.return_value = "worker"
+        _ErrorDialogHandler().emit(_record())
+    qtimer.singleShot.assert_not_called()
+
+
+def test_handler_honors_no_dialog_extra():
+    """extra={'no_dialog': True} opts a record out entirely."""
+    with patch.object(main_mod, "QTimer") as qtimer:
+        _ErrorDialogHandler().emit(_record(no_dialog=True))
+    qtimer.singleShot.assert_not_called()
+
+
+def test_handler_queues_once_then_dedups():
+    """Identical message+traceback queues one dialog; the repeat is suppressed."""
+    app = MagicMock()
+    app.thread.return_value = "gui"
+    with patch.object(main_mod, "QApplication") as qapp, patch.object(
+        main_mod, "QThread"
+    ) as qthread, patch.object(main_mod, "QTimer") as qtimer:
+        qapp.instance.return_value = app
+        qthread.currentThread.return_value = "gui"
+        handler = _ErrorDialogHandler()
+        handler.emit(_record("same error"))
+        handler.emit(_record("same error"))
+    assert qtimer.singleShot.call_count == 1
+
+
+def test_handler_emit_never_raises():
+    """emit must swallow internal failures (logging contract)."""
+    app = MagicMock()
+    app.thread.return_value = "gui"
+    with patch.object(main_mod, "QApplication") as qapp, patch.object(
+        main_mod, "QThread"
+    ) as qthread, patch.object(main_mod, "QTimer") as qtimer:
+        qapp.instance.return_value = app
+        qthread.currentThread.return_value = "gui"
+        qtimer.singleShot.side_effect = RuntimeError("boom")
+        handler = _ErrorDialogHandler()
+        with patch.object(handler, "handleError") as handle_err:
+            handler.emit(_record())  # must not raise
+        handle_err.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# _ErrorDialogHandler._show — duplicate suppression + safety
+# ---------------------------------------------------------------------------
+
+
+def test_show_yields_to_existing_modal():
+    """If a site/plugin QMessageBox.critical is already up, stay quiet."""
     with patch.object(main_mod, "QApplication") as qapp, patch.object(
         main_mod, "QMessageBox"
     ) as qmb:
-        qapp.instance.return_value = None
-        _show_exception_dialog(*_exc_args())
+        qapp.activeModalWidget.return_value = MagicMock()  # a modal is showing
+        _ErrorDialogHandler()._show("boom", "")
     qmb.assert_not_called()
 
 
-def test_exception_dialog_skipped_off_gui_thread():
-    """A worker-thread exception must not pop a QMessageBox (unsafe)."""
-    app = MagicMock()
+def test_show_displays_non_blocking_when_no_modal():
+    """With no other modal up, the dialog is shown non-blocking (show, not exec)
+    and held alive so it is not garbage-collected away."""
+    handler = _ErrorDialogHandler()
     with patch.object(main_mod, "QApplication") as qapp, patch.object(
-        main_mod, "QThread"
-    ) as qthread, patch.object(main_mod, "QMessageBox") as qmb:
-        qapp.instance.return_value = app
-        app.thread.return_value = "gui-thread"
-        qthread.currentThread.return_value = "worker-thread"
-        _show_exception_dialog(*_exc_args())
-    qmb.assert_not_called()
+        main_mod, "QMessageBox"
+    ) as qmb:
+        qapp.activeModalWidget.return_value = None
+        handler._show("boom", "Traceback (most recent call last): ...")
+    qmb.return_value.setDetailedText.assert_called_once()
+    qmb.return_value.show.assert_called_once()
+    qmb.return_value.exec.assert_not_called()  # never blocks the event loop
+    assert qmb.return_value in handler._open_boxes
 
 
-def test_exception_dialog_shown_once_on_gui_thread():
-    """On the GUI thread the dialog is shown once, then deduped by traceback."""
-    app = MagicMock()
+def test_show_swallows_its_own_errors():
+    """A failure while building the dialog must not propagate."""
+    handler = _ErrorDialogHandler()
     with patch.object(main_mod, "QApplication") as qapp, patch.object(
-        main_mod, "QThread"
-    ) as qthread, patch.object(main_mod, "QMessageBox") as qmb:
-        qapp.instance.return_value = app
-        app.thread.return_value = "gui-thread"
-        qthread.currentThread.return_value = "gui-thread"
-        args = _exc_args()
-        _show_exception_dialog(*args)
-        _show_exception_dialog(*args)  # identical traceback → suppressed
-    assert qmb.call_count == 1
-    qmb.return_value.exec.assert_called_once()
-
-
-def test_exception_dialog_swallows_its_own_errors():
-    """A failure while building the dialog must not escape the excepthook."""
-    app = MagicMock()
-    with patch.object(main_mod, "QApplication") as qapp, patch.object(
-        main_mod, "QThread"
-    ) as qthread, patch.object(main_mod, "QMessageBox") as qmb:
-        qapp.instance.return_value = app
-        app.thread.return_value = "gui-thread"
-        qthread.currentThread.return_value = "gui-thread"
+        main_mod, "QMessageBox"
+    ) as qmb:
+        qapp.activeModalWidget.return_value = None
         qmb.side_effect = RuntimeError("Qt is gone")
-        # Must not raise.
-        _show_exception_dialog(*_exc_args())
+        handler._show("boom", "")  # must not raise
+
+
+def test_details_names_log_file_when_file_logging_on():
+    """The informative text points at the log file only when one is active."""
+    with_file = _ErrorDialogHandler(log_path="/home/u/.moleditpy/moleditpy.log")
+    assert "/home/u/.moleditpy/moleditpy.log" in with_file._details()
+
+    without_file = _ErrorDialogHandler()
+    hint = without_file._details()
+    assert "terminal" in hint.lower()
+    assert "moleditpy.log" not in hint
+
+
+# ---------------------------------------------------------------------------
+# setup_logging — the dialog handler is a GUI feature, skipped when headless
+# ---------------------------------------------------------------------------
+
+
+def _dialog_handlers():
+    return [
+        h for h in logging.getLogger().handlers
+        if isinstance(h, _ErrorDialogHandler)
+    ]
+
+
+def test_dialog_handler_not_attached_when_headless(monkeypatch, tmp_path):
+    """MOLEDITPY_HEADLESS must suppress the modal dialog handler entirely,
+    otherwise an offscreen test run hangs on box.exec()."""
+    monkeypatch.setenv("MOLEDITPY_HEADLESS", "1")
+    monkeypatch.setattr("os.path.expanduser", lambda _p: str(tmp_path))
+    existing = _dialog_handlers()
+    for handler in existing:
+        logging.getLogger().removeHandler(handler)
+    try:
+        main_mod.setup_logging()
+        assert _dialog_handlers() == []
+    finally:
+        for handler in _dialog_handlers():
+            logging.getLogger().removeHandler(handler)
+
+
+def test_dialog_handler_attached_when_not_headless(monkeypatch, tmp_path):
+    """A real (non-headless) run installs exactly one dialog handler."""
+    monkeypatch.delenv("MOLEDITPY_HEADLESS", raising=False)
+    monkeypatch.setattr("os.path.expanduser", lambda _p: str(tmp_path))
+    for handler in _dialog_handlers():
+        logging.getLogger().removeHandler(handler)
+    try:
+        main_mod.setup_logging()
+        assert len(_dialog_handlers()) == 1
+    finally:
+        for handler in _dialog_handlers():
+            logging.getLogger().removeHandler(handler)
 
 
 @pytest.mark.parametrize("pattern", _DOWNGRADED_QT_PATTERNS)

--- a/tests/unit/test_main_qt_handler.py
+++ b/tests/unit/test_main_qt_handler.py
@@ -71,19 +71,43 @@ def test_handler_honors_no_dialog_extra():
     qtimer.singleShot.assert_not_called()
 
 
-def test_handler_queues_once_then_dedups():
-    """Identical message+traceback queues one dialog; the repeat is suppressed."""
+def test_handler_dedups_rapid_repeat_within_window():
+    """A fast repeat of the same error (within the dedup window) is collapsed
+    to one dialog, so a per-tick error can't storm the user with modals."""
     app = MagicMock()
     app.thread.return_value = "gui"
     with patch.object(main_mod, "QApplication") as qapp, patch.object(
         main_mod, "QThread"
-    ) as qthread, patch.object(main_mod, "QTimer") as qtimer:
+    ) as qthread, patch.object(main_mod, "QTimer") as qtimer, patch.object(
+        main_mod.time, "monotonic"
+    ) as mono:
         qapp.instance.return_value = app
         qthread.currentThread.return_value = "gui"
+        mono.side_effect = [100.0, 102.0]  # 2s apart, inside the 10s window
         handler = _ErrorDialogHandler()
         handler.emit(_record("same error"))
         handler.emit(_record("same error"))
     assert qtimer.singleShot.call_count == 1
+
+
+def test_handler_reshows_same_error_after_window():
+    """The same error surfacing again after the dedup window DOES show a new
+    dialog, so a genuine retry is not silently swallowed."""
+    app = MagicMock()
+    app.thread.return_value = "gui"
+    with patch.object(main_mod, "QApplication") as qapp, patch.object(
+        main_mod, "QThread"
+    ) as qthread, patch.object(main_mod, "QTimer") as qtimer, patch.object(
+        main_mod.time, "monotonic"
+    ) as mono:
+        qapp.instance.return_value = app
+        qthread.currentThread.return_value = "gui"
+        # 2nd occurrence is 15s later — past the 10s window.
+        mono.side_effect = [100.0, 115.0]
+        handler = _ErrorDialogHandler()
+        handler.emit(_record("same error"))
+        handler.emit(_record("same error"))
+    assert qtimer.singleShot.call_count == 2
 
 
 def test_handler_emit_never_raises():

--- a/tests/unit/test_main_qt_handler.py
+++ b/tests/unit/test_main_qt_handler.py
@@ -55,6 +55,7 @@ def test_handler_skips_off_gui_thread():
     """A worker-thread record must not queue a dialog (QMessageBox unsafe)."""
     app = MagicMock()
     app.thread.return_value = "gui"
+    app.property.return_value = None
     with patch.object(main_mod, "QApplication") as qapp, patch.object(
         main_mod, "QThread"
     ) as qthread, patch.object(main_mod, "QTimer") as qtimer:
@@ -71,11 +72,26 @@ def test_handler_honors_no_dialog_extra():
     qtimer.singleShot.assert_not_called()
 
 
+def test_handler_suppressed_during_shutdown():
+    """Benign teardown errors must not pop a dialog once the app is closing."""
+    app = MagicMock()
+    app.thread.return_value = "gui"
+    app.property.return_value = True  # moleditpy_shutting_down
+    with patch.object(main_mod, "QApplication") as qapp, patch.object(
+        main_mod, "QThread"
+    ) as qthread, patch.object(main_mod, "QTimer") as qtimer:
+        qapp.instance.return_value = app
+        qthread.currentThread.return_value = "gui"
+        _ErrorDialogHandler().emit(_record())
+    qtimer.singleShot.assert_not_called()
+
+
 def test_handler_dedups_rapid_repeat_within_window():
     """A fast repeat of the same error (within the dedup window) is collapsed
     to one dialog, so a per-tick error can't storm the user with modals."""
     app = MagicMock()
     app.thread.return_value = "gui"
+    app.property.return_value = None
     with patch.object(main_mod, "QApplication") as qapp, patch.object(
         main_mod, "QThread"
     ) as qthread, patch.object(main_mod, "QTimer") as qtimer, patch.object(
@@ -95,6 +111,7 @@ def test_handler_reshows_same_error_after_window():
     dialog, so a genuine retry is not silently swallowed."""
     app = MagicMock()
     app.thread.return_value = "gui"
+    app.property.return_value = None
     with patch.object(main_mod, "QApplication") as qapp, patch.object(
         main_mod, "QThread"
     ) as qthread, patch.object(main_mod, "QTimer") as qtimer, patch.object(
@@ -114,6 +131,7 @@ def test_handler_emit_never_raises():
     """emit must swallow internal failures (logging contract)."""
     app = MagicMock()
     app.thread.return_value = "gui"
+    app.property.return_value = None
     with patch.object(main_mod, "QApplication") as qapp, patch.object(
         main_mod, "QThread"
     ) as qthread, patch.object(main_mod, "QTimer") as qtimer:

--- a/tests/unit/test_main_qt_handler.py
+++ b/tests/unit/test_main_qt_handler.py
@@ -28,8 +28,13 @@ from moleditpy.main import (
 def _record(message="boom", level=logging.ERROR, exc_info=None, **extra):
     """Build a logging.LogRecord as the handler would receive it."""
     rec = logging.LogRecord(
-        name="test", level=level, pathname=__file__, lineno=1,
-        msg=message, args=(), exc_info=exc_info,
+        name="test",
+        level=level,
+        pathname=__file__,
+        lineno=1,
+        msg=message,
+        args=(),
+        exc_info=exc_info,
     )
     for key, value in extra.items():
         setattr(rec, key, value)
@@ -43,9 +48,10 @@ def _record(message="boom", level=logging.ERROR, exc_info=None, **extra):
 
 def test_handler_skips_without_qapplication():
     """No GUI event loop → nothing is queued (the log record is the surface)."""
-    with patch.object(main_mod, "QApplication") as qapp, patch.object(
-        main_mod, "QTimer"
-    ) as qtimer:
+    with (
+        patch.object(main_mod, "QApplication") as qapp,
+        patch.object(main_mod, "QTimer") as qtimer,
+    ):
         qapp.instance.return_value = None
         _ErrorDialogHandler().emit(_record())
     qtimer.singleShot.assert_not_called()
@@ -56,9 +62,11 @@ def test_handler_skips_off_gui_thread():
     app = MagicMock()
     app.thread.return_value = "gui"
     app.property.return_value = None
-    with patch.object(main_mod, "QApplication") as qapp, patch.object(
-        main_mod, "QThread"
-    ) as qthread, patch.object(main_mod, "QTimer") as qtimer:
+    with (
+        patch.object(main_mod, "QApplication") as qapp,
+        patch.object(main_mod, "QThread") as qthread,
+        patch.object(main_mod, "QTimer") as qtimer,
+    ):
         qapp.instance.return_value = app
         qthread.currentThread.return_value = "worker"
         _ErrorDialogHandler().emit(_record())
@@ -77,9 +85,11 @@ def test_handler_suppressed_during_shutdown():
     app = MagicMock()
     app.thread.return_value = "gui"
     app.property.return_value = True  # moleditpy_shutting_down
-    with patch.object(main_mod, "QApplication") as qapp, patch.object(
-        main_mod, "QThread"
-    ) as qthread, patch.object(main_mod, "QTimer") as qtimer:
+    with (
+        patch.object(main_mod, "QApplication") as qapp,
+        patch.object(main_mod, "QThread") as qthread,
+        patch.object(main_mod, "QTimer") as qtimer,
+    ):
         qapp.instance.return_value = app
         qthread.currentThread.return_value = "gui"
         _ErrorDialogHandler().emit(_record())
@@ -92,11 +102,12 @@ def test_handler_dedups_rapid_repeat_within_window():
     app = MagicMock()
     app.thread.return_value = "gui"
     app.property.return_value = None
-    with patch.object(main_mod, "QApplication") as qapp, patch.object(
-        main_mod, "QThread"
-    ) as qthread, patch.object(main_mod, "QTimer") as qtimer, patch.object(
-        main_mod.time, "monotonic"
-    ) as mono:
+    with (
+        patch.object(main_mod, "QApplication") as qapp,
+        patch.object(main_mod, "QThread") as qthread,
+        patch.object(main_mod, "QTimer") as qtimer,
+        patch.object(main_mod.time, "monotonic") as mono,
+    ):
         qapp.instance.return_value = app
         qthread.currentThread.return_value = "gui"
         mono.side_effect = [100.0, 102.0]  # 2s apart, inside the 10s window
@@ -112,11 +123,12 @@ def test_handler_reshows_same_error_after_window():
     app = MagicMock()
     app.thread.return_value = "gui"
     app.property.return_value = None
-    with patch.object(main_mod, "QApplication") as qapp, patch.object(
-        main_mod, "QThread"
-    ) as qthread, patch.object(main_mod, "QTimer") as qtimer, patch.object(
-        main_mod.time, "monotonic"
-    ) as mono:
+    with (
+        patch.object(main_mod, "QApplication") as qapp,
+        patch.object(main_mod, "QThread") as qthread,
+        patch.object(main_mod, "QTimer") as qtimer,
+        patch.object(main_mod.time, "monotonic") as mono,
+    ):
         qapp.instance.return_value = app
         qthread.currentThread.return_value = "gui"
         # 2nd occurrence is 15s later — past the 10s window.
@@ -132,9 +144,11 @@ def test_handler_emit_never_raises():
     app = MagicMock()
     app.thread.return_value = "gui"
     app.property.return_value = None
-    with patch.object(main_mod, "QApplication") as qapp, patch.object(
-        main_mod, "QThread"
-    ) as qthread, patch.object(main_mod, "QTimer") as qtimer:
+    with (
+        patch.object(main_mod, "QApplication") as qapp,
+        patch.object(main_mod, "QThread") as qthread,
+        patch.object(main_mod, "QTimer") as qtimer,
+    ):
         qapp.instance.return_value = app
         qthread.currentThread.return_value = "gui"
         qtimer.singleShot.side_effect = RuntimeError("boom")
@@ -151,9 +165,10 @@ def test_handler_emit_never_raises():
 
 def test_show_yields_to_existing_modal():
     """If a site/plugin QMessageBox.critical is already up, stay quiet."""
-    with patch.object(main_mod, "QApplication") as qapp, patch.object(
-        main_mod, "QMessageBox"
-    ) as qmb:
+    with (
+        patch.object(main_mod, "QApplication") as qapp,
+        patch.object(main_mod, "QMessageBox") as qmb,
+    ):
         qapp.activeModalWidget.return_value = MagicMock()  # a modal is showing
         _ErrorDialogHandler()._show("boom", "")
     qmb.assert_not_called()
@@ -163,9 +178,10 @@ def test_show_displays_non_blocking_when_no_modal():
     """With no other modal up, the dialog is shown non-blocking (show, not exec)
     and held alive so it is not garbage-collected away."""
     handler = _ErrorDialogHandler()
-    with patch.object(main_mod, "QApplication") as qapp, patch.object(
-        main_mod, "QMessageBox"
-    ) as qmb:
+    with (
+        patch.object(main_mod, "QApplication") as qapp,
+        patch.object(main_mod, "QMessageBox") as qmb,
+    ):
         qapp.activeModalWidget.return_value = None
         handler._show("boom", "Traceback (most recent call last): ...")
     qmb.return_value.setDetailedText.assert_called_once()
@@ -177,9 +193,10 @@ def test_show_displays_non_blocking_when_no_modal():
 def test_show_swallows_its_own_errors():
     """A failure while building the dialog must not propagate."""
     handler = _ErrorDialogHandler()
-    with patch.object(main_mod, "QApplication") as qapp, patch.object(
-        main_mod, "QMessageBox"
-    ) as qmb:
+    with (
+        patch.object(main_mod, "QApplication") as qapp,
+        patch.object(main_mod, "QMessageBox") as qmb,
+    ):
         qapp.activeModalWidget.return_value = None
         qmb.side_effect = RuntimeError("Qt is gone")
         handler._show("boom", "")  # must not raise
@@ -203,8 +220,7 @@ def test_details_names_log_file_when_file_logging_on():
 
 def _dialog_handlers():
     return [
-        h for h in logging.getLogger().handlers
-        if isinstance(h, _ErrorDialogHandler)
+        h for h in logging.getLogger().handlers if isinstance(h, _ErrorDialogHandler)
     ]
 
 

--- a/tests/unit/test_move_selected_atoms_dialog.py
+++ b/tests/unit/test_move_selected_atoms_dialog.py
@@ -299,10 +299,10 @@ def test_preselected_atoms_init(qapp):
 
 
 def test_show_atom_labels_none_positions(make_dialog):
-    """show_atom_labels logs an error and does nothing when atom_positions_3d is None."""
+    """show_atom_labels logs a warning and does nothing when atom_positions_3d is None."""
     dlg, mol, mw = make_dialog()
     mw.view_3d_manager.atom_positions_3d = None
-    with patch("moleditpy.ui.move_selected_atoms_dialog.logging.error") as mock_log:
+    with patch("moleditpy.ui.move_selected_atoms_dialog.logging.warning") as mock_log:
         dlg.selected_atoms.add(0)
         dlg.show_atom_labels()
         mock_log.assert_called_once_with(

--- a/tests/unit/test_plugin_manager.py
+++ b/tests/unit/test_plugin_manager.py
@@ -473,9 +473,9 @@ except BaseException:
 
     @patch("os.makedirs", side_effect=OSError("test mkdir err"))
     @patch("os.path.exists", return_value=False)
-    @patch("logging.error")
+    @patch("logging.warning")
     def test_ensure_plugin_dir_error(self, mock_log, mock_exists, mock_makedirs):
-        """ensure_plugin_dir logs an error when os.makedirs raises OSError."""
+        """ensure_plugin_dir logs a warning when os.makedirs raises OSError."""
         pm = PluginManager()
         pm.ensure_plugin_dir()
         mock_log.assert_called_with("Error creating plugin directory: test mkdir err")
@@ -589,10 +589,10 @@ except BaseException:
 
     @patch("importlib.util.spec_from_file_location")
     def test_load_single_plugin_exceptions_and_stub(self, mock_spec):
-        """_load_single_plugin logs errors on RuntimeError and handles a None spec."""
+        """_load_single_plugin logs warnings on RuntimeError and handles a None spec."""
         pm = PluginManager()
         mock_spec.side_effect = RuntimeError("Load err")
-        with patch("logging.error") as mock_log:
+        with patch("logging.warning") as mock_log:
             pm._load_single_plugin("test.py", "test", "cat")
             mock_log.assert_called()
 
@@ -721,14 +721,14 @@ except BaseException:
         assert pm.get_window("P1", "w1") == "WIN"
 
     def test_invoke_document_reset_handlers_logs_error(self):
-        """invoke_document_reset_handlers logs an error when a handler raises."""
+        """invoke_document_reset_handlers logs a warning when a handler raises."""
         pm = PluginManager()
 
         def bad_cb():
             raise RuntimeError("Reset err")
 
         pm.register_document_reset_handler("P1", bad_cb)
-        with patch("logging.error") as mock_log:
+        with patch("logging.warning") as mock_log:
             pm.invoke_document_reset_handlers()
             mock_log.assert_called()
 

--- a/tests/unit/test_plugin_manager_window.py
+++ b/tests/unit/test_plugin_manager_window.py
@@ -1,5 +1,6 @@
 """Unit tests for PluginManagerWindow drag-and-drop and UI behavior."""
 
+import logging
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -179,23 +180,21 @@ def test_on_remove_plugin_package(
 
 
 @patch("moleditpy.plugins.plugin_manager_window.QMessageBox.question")
-@patch("moleditpy.plugins.plugin_manager_window.QMessageBox.critical")
 @patch("os.path.exists", return_value=True)
 @patch("os.remove", side_effect=PermissionError("Remove error"))
 def test_on_remove_plugin_error(
-    mock_remove, mock_exists, mock_critical, mock_question, mock_plugin_manager, qtbot
+    mock_remove, mock_exists, mock_question, mock_plugin_manager, qtbot, caplog
 ):
-    """on_remove_plugin shows a critical error dialog when os.remove raises OSError."""
+    """on_remove_plugin logs the error when os.remove raises OSError."""
     mock_question.return_value = QMessageBox.StandardButton.Yes
     window = PluginManagerWindow(mock_plugin_manager)
     qtbot.addWidget(window)
 
     window.table.selectRow(0)
-    window.on_remove_plugin()
+    with caplog.at_level(logging.ERROR):
+        window.on_remove_plugin()
 
-    mock_critical.assert_called_with(
-        window, "Error", "Failed to delete plugin: Remove error"
-    )
+    assert "Failed to delete plugin: Remove error" in caplog.text
 
 
 @patch("moleditpy.plugins.plugin_manager_window.QMessageBox.warning")


### PR DESCRIPTION
## Summary

- **Centralized Exception & Error Dialogs**: Introduced a thread-safe, non-blocking central handler that surfaces uncaught exceptions and `ERROR`/`CRITICAL` log events in a GUI dialog (headless-safe). Included time-windowed deduplication to prevent dialog spam from rapid repetitive errors.
- **Camera Zoom Preservation**: Modified the undo/redo behavior to retain the user's current camera zoom instead of resetting/refitting the entire 3D scene.
- **Plugin Rebuild Leak Fix**: Hoisted the plugin identifier tag to a class constant (`plugin_action_tag`) and fixed a resource leak where plugin actions were not properly detached from their `QActionGroup` parents when menus were rebuilt.

## Type of change

- [x] Bug fix
- [ ] New feature
- [x] Refactor / code cleanup
- [ ] Documentation
- [x] Tests
- [ ] CI / build

## Related issues

*(Link related issues if any)*

## Test plan

- [x] Ran `python tests/run_all_tests.py` — all pass *(72/72 tests passed in offscreen/headless mode)*
- [ ] Manually tested in the GUI with the check list
- [x] Added new unit tests *(Added unit tests for the centralized Qt log handler and dialog deduplication, and expanded menu rebuild cleanup coverage)*

## Checklist

- [x] `python -m flake8 moleditpy/src/ --select=F` returns 0 issues *(Checked and returned 0 issues)*
- [x] No bare `except:` clauses added (use `except Exception as e:` and log the error)
- [x] No new unused imports or variables
- [x] Plugin API changes are backwards-compatible (or documented in Summary) *(All plugin hooks are completely backwards-compatible)*