### PR TITLE
Dev 4.3.1

### DIFF
--- a/moleditpy/pyproject.toml
+++ b/moleditpy/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "MoleditPy"
 
-version = "4.3.0"
+version = "4.3.1"
 
 license = {file = "LICENSE"}
 

--- a/moleditpy/src/moleditpy/ui/constrained_optimization_dialog.py
+++ b/moleditpy/src/moleditpy/ui/constrained_optimization_dialog.py
@@ -65,6 +65,9 @@ class ConstrainedOptimizationDialog(Dialog3DPickingMixin, QDialog):
         self.constraints: list[Any] = []  # (type, atoms_indices, value)
         self.constraint_labels: list[Any] = []  # 3D label actors
         self._opt_thread: Any = None
+        # Set when the dialog is closed; late results from a still-running
+        # optimization thread must be discarded, not applied to the document.
+        self._closed = False
         self.init_ui()
         self.enable_picking()
 
@@ -599,6 +602,11 @@ class ConstrainedOptimizationDialog(Dialog3DPickingMixin, QDialog):
             self.optimize_button.setEnabled(True)
 
     def _on_optimization_error(self, err_msg: str) -> None:
+        if self._closed:
+            logging.warning(
+                "Constrained optimization failed after dialog close: %s", err_msg
+            )
+            return
         self.optimize_button.setEnabled(True)
         status_bar = self.main_window.statusBar()
         if status_bar is not None:
@@ -606,6 +614,11 @@ class ConstrainedOptimizationDialog(Dialog3DPickingMixin, QDialog):
         QMessageBox.critical(self, "Error", f"Optimization error: {err_msg}")
 
     def _on_optimization_finished(self, ff_name: str, conf: Any) -> None:
+        if self._closed:
+            # The user closed the dialog while the thread was still running:
+            # treat the run as cancelled and leave the document untouched.
+            logging.info("Discarding constrained optimization result after close.")
+            return
         self.optimize_button.setEnabled(True)
         try:
             # Apply optimized coordinates to the main window's numpy array
@@ -619,25 +632,9 @@ class ConstrainedOptimizationDialog(Dialog3DPickingMixin, QDialog):
                         pos.z,
                     ]
 
-            # Update 3D view
-            self.main_window.view_3d_manager.draw_molecule_3d(self.mol)
-            self.main_window.view_3d_manager.update_chiral_labels()
-            self.main_window.edit_actions_manager.push_undo_state()
-            status_bar = self.main_window.statusBar()
-            if status_bar is not None:
-                status_bar.showMessage("Constrained optimization finished.")
-
-            try:
-                constrained_method_name = f"Constrained_{ff_name}"
-                self.main_window.compute_manager.last_successful_optimization_method = (
-                    constrained_method_name
-                )
-            except (AttributeError, RuntimeError, ValueError, TypeError) as e:
-                logging.warning(
-                    "Failed to set last_successful_optimization_method: %s", e
-                )
-
-            # Save constraints list to MainWindow on success (same logic as reject)
+            # Save constraints list to MainWindow on success (same logic as
+            # reject). This must happen BEFORE push_undo_state below, so the
+            # undo snapshot records the constraints actually used for this run.
             try:
                 # Save as list for JSON compatibility
                 json_safe_constraints = []
@@ -669,6 +666,24 @@ class ConstrainedOptimizationDialog(Dialog3DPickingMixin, QDialog):
             except (AttributeError, RuntimeError, ValueError, TypeError) as e:
                 logging.warning("Failed to save constraints post-optimization: %s", e)
 
+            # Update 3D view
+            self.main_window.view_3d_manager.draw_molecule_3d(self.mol)
+            self.main_window.view_3d_manager.update_chiral_labels()
+            self.main_window.edit_actions_manager.push_undo_state()
+            status_bar = self.main_window.statusBar()
+            if status_bar is not None:
+                status_bar.showMessage("Constrained optimization finished.")
+
+            try:
+                constrained_method_name = f"Constrained_{ff_name}"
+                self.main_window.compute_manager.last_successful_optimization_method = (
+                    constrained_method_name
+                )
+            except (AttributeError, RuntimeError, ValueError, TypeError) as e:
+                logging.warning(
+                    "Failed to set last_successful_optimization_method: %s", e
+                )
+
         except (AttributeError, RuntimeError, ValueError, TypeError) as e:
             logging.exception("Optimization failed: %s", e)
 
@@ -679,6 +694,9 @@ class ConstrainedOptimizationDialog(Dialog3DPickingMixin, QDialog):
 
     def reject(self) -> None:
         """Clear labels, disable picking, and save constraints before closing."""
+        # Cancel any in-flight optimization: its late result must not be
+        # applied to the document after the user has closed the dialog.
+        self._closed = True
         self.clear_constraint_labels()
         self.clear_selection_labels()
         self.disable_picking()
@@ -706,6 +724,9 @@ class ConstrainedOptimizationDialog(Dialog3DPickingMixin, QDialog):
                     True  # Mark as unsaved changes
                 )
                 self.main_window.state_manager.update_window_title()
+                # Constraint edits are document state: record them in history
+                # so Ctrl+Z can revert an add/edit/remove done in this dialog.
+                self.main_window.edit_actions_manager.push_undo_state()
 
         except (AttributeError, RuntimeError, ValueError, TypeError) as e:
             logging.warning("Failed to save constraints to main window: %s", e)

--- a/moleditpy/src/moleditpy/ui/constrained_optimization_dialog.py
+++ b/moleditpy/src/moleditpy/ui/constrained_optimization_dialog.py
@@ -65,8 +65,7 @@ class ConstrainedOptimizationDialog(Dialog3DPickingMixin, QDialog):
         self.constraints: list[Any] = []  # (type, atoms_indices, value)
         self.constraint_labels: list[Any] = []  # 3D label actors
         self._opt_thread: Any = None
-        # Set when the dialog is closed; late results from a still-running
-        # optimization thread must be discarded, not applied to the document.
+        # Closed dialogs must discard late optimization-thread results
         self._closed = False
         self.init_ui()
         self.enable_picking()
@@ -615,8 +614,6 @@ class ConstrainedOptimizationDialog(Dialog3DPickingMixin, QDialog):
 
     def _on_optimization_finished(self, ff_name: str, conf: Any) -> None:
         if self._closed:
-            # The user closed the dialog while the thread was still running:
-            # treat the run as cancelled and leave the document untouched.
             logging.info("Discarding constrained optimization result after close.")
             return
         self.optimize_button.setEnabled(True)
@@ -632,9 +629,7 @@ class ConstrainedOptimizationDialog(Dialog3DPickingMixin, QDialog):
                         pos.z,
                     ]
 
-            # Save constraints list to MainWindow on success (same logic as
-            # reject). This must happen BEFORE push_undo_state below, so the
-            # undo snapshot records the constraints actually used for this run.
+            # Sync constraints to MainWindow before push_undo_state so the snapshot records them
             try:
                 # Save as list for JSON compatibility
                 json_safe_constraints = []
@@ -694,8 +689,6 @@ class ConstrainedOptimizationDialog(Dialog3DPickingMixin, QDialog):
 
     def reject(self) -> None:
         """Clear labels, disable picking, and save constraints before closing."""
-        # Cancel any in-flight optimization: its late result must not be
-        # applied to the document after the user has closed the dialog.
         self._closed = True
         self.clear_constraint_labels()
         self.clear_selection_labels()
@@ -724,8 +717,6 @@ class ConstrainedOptimizationDialog(Dialog3DPickingMixin, QDialog):
                     True  # Mark as unsaved changes
                 )
                 self.main_window.state_manager.update_window_title()
-                # Constraint edits are document state: record them in history
-                # so Ctrl+Z can revert an add/edit/remove done in this dialog.
                 self.main_window.edit_actions_manager.push_undo_state()
 
         except (AttributeError, RuntimeError, ValueError, TypeError) as e:

--- a/moleditpy/src/moleditpy/ui/edit_actions_logic.py
+++ b/moleditpy/src/moleditpy/ui/edit_actions_logic.py
@@ -21,6 +21,7 @@ from typing import Any, Dict, List, Optional, TYPE_CHECKING
 import numpy as np
 
 from ..core.mol_geometry import identify_valence_problems
+from .app_state import _serialize_constraints
 
 # RDKit imports (explicit to satisfy flake8 and used features)
 from PyQt6.QtCore import QByteArray, QMimeData, QPointF, Qt, QTimer
@@ -116,6 +117,15 @@ class EditActionsManager:
         self.redo_stack.clear()
         self.push_undo_state()
 
+    def _constraints_for_comparison(self) -> List[Any]:
+        """Current 3D constraints in the serialized form stored in snapshots."""
+        constraints = getattr(
+            getattr(self.host, "edit_3d_manager", None), "constraints_3d", None
+        )
+        if not isinstance(constraints, list):
+            return []
+        return _serialize_constraints(constraints)
+
     def push_undo_state(self) -> None:
         """Saves current molecular state to undo stack for history tracking."""
         if getattr(self.host, "is_restoring_state", False):
@@ -150,6 +160,7 @@ class EditActionsManager:
             ]
             if self.host.view_3d_manager.current_mol
             else None,
+            "constraints_3d": self._constraints_for_comparison(),
         }
 
         last_state_for_comparison = None
@@ -174,6 +185,7 @@ class EditActionsManager:
                 "_next_atom_id": last_state.get("_next_atom_id"),
                 "mol_3d": last_state.get("mol_3d", None),
                 "mol_3d_atom_ids": last_state.get("mol_3d_atom_ids", None),
+                "constraints_3d": last_state.get("constraints_3d") or [],
             }
 
         if (

--- a/moleditpy/src/moleditpy/ui/export_logic.py
+++ b/moleditpy/src/moleditpy/ui/export_logic.py
@@ -116,8 +116,10 @@ class ExportManager:
             if not file_path.lower().endswith(".obj"):
                 file_path += ".obj"
 
-            # Save as OBJ+MTL with material per object
-            mtl_path = file_path.replace(".obj", ".mtl")
+            # Save as OBJ+MTL with material per object. splitext (not
+            # str.replace) so an upper-case ".OBJ" or a ".obj" substring in a
+            # directory name cannot make mtl_path collide with file_path.
+            mtl_path = os.path.splitext(file_path)[0] + ".mtl"
 
             self.create_multi_material_obj(meshes_with_colors, file_path, mtl_path)
 

--- a/moleditpy/src/moleditpy/ui/export_logic.py
+++ b/moleditpy/src/moleditpy/ui/export_logic.py
@@ -116,9 +116,7 @@ class ExportManager:
             if not file_path.lower().endswith(".obj"):
                 file_path += ".obj"
 
-            # Save as OBJ+MTL with material per object. splitext (not
-            # str.replace) so an upper-case ".OBJ" or a ".obj" substring in a
-            # directory name cannot make mtl_path collide with file_path.
+            # splitext, not str.replace: ".OBJ" must not make mtl_path collide with file_path
             mtl_path = os.path.splitext(file_path)[0] + ".mtl"
 
             self.create_multi_material_obj(meshes_with_colors, file_path, mtl_path)

--- a/moleditpy/src/moleditpy/ui/io_logic.py
+++ b/moleditpy/src/moleditpy/ui/io_logic.py
@@ -349,6 +349,19 @@ class IOManager:
             # Unreachable via OK (validated inline)
             return 0, True, False
 
+    @staticmethod
+    def _covalent_radius(symbol: str, atomic_num: int) -> float:
+        """Covalent radius from the local table, RDKit's periodic table for
+        elements the table lacks (it stops at V), or 1.0 as a last resort."""
+        radius = COVALENT_RADII.get(symbol)
+        if radius:
+            return radius
+        try:
+            radius = Chem.GetPeriodicTable().GetRcovalent(atomic_num)
+        except (ValueError, RuntimeError):
+            radius = 0.0
+        return radius if radius > 0.0 else 1.0
+
     def estimate_bonds_from_distances(self, mol: Chem.RWMol) -> int:
         """Estimate bonds based on interatomic distances using covalent radii."""
         conf = mol.GetConformer()
@@ -364,8 +377,8 @@ class IOManager:
                 distance = rdMolTransforms.GetBondLength(conf, i, j)
                 symbol_i = atom_i.GetSymbol()
                 symbol_j = atom_j.GetSymbol()
-                radius_i = COVALENT_RADII.get(symbol_i, 1.0)
-                radius_j = COVALENT_RADII.get(symbol_j, 1.0)
+                radius_i = self._covalent_radius(symbol_i, atom_i.GetAtomicNum())
+                radius_j = self._covalent_radius(symbol_j, atom_j.GetAtomicNum())
                 expected = radius_i + radius_j
                 tolerance = 1.2 if (symbol_i == "H" or symbol_j == "H") else 1.3
                 if expected * 0.5 <= distance <= expected * tolerance:

--- a/moleditpy/src/moleditpy/ui/io_logic.py
+++ b/moleditpy/src/moleditpy/ui/io_logic.py
@@ -242,6 +242,14 @@ class IOManager:
             final_mol.xyz_atom_data = atoms_data
         return final_mol
 
+    def _report_load_error(self, title: str, message: str) -> None:
+        """Report a load failure on the status bar and, in GUI mode, a dialog."""
+        status_bar = self.host.statusBar()
+        if status_bar is not None:
+            status_bar.showMessage(message)
+        if not os.environ.get("MOLEDITPY_HEADLESS"):
+            QMessageBox.warning(self.host, title, message)
+
     def load_xyz_file(self, file_path: str) -> Optional[Any]:
         """Load XYZ file and create RDKit Mol with charge prompt and bond determination."""
         if not self.host.state_manager.check_unsaved_changes():
@@ -506,8 +514,9 @@ class IOManager:
         elif file_path.lower().endswith(".pmeraw"):
             self.load_raw_data(file_path)
         else:
-            self.host.statusBar().showMessage(
-                "Error: Unable to determine file format or file corrupted."
+            self._report_load_error(
+                "Project Load Error",
+                "Error: Unable to determine file format or file corrupted.",
             )
 
     def save_as_json(self) -> None:
@@ -605,14 +614,23 @@ class IOManager:
             QTimer.singleShot(100, self.host.view_3d_manager.fit_to_view)
 
         except FileNotFoundError:
-            self.host.statusBar().showMessage(f"File not found: {file_path}")
+            self._report_load_error(
+                "Project Load Error", f"File not found: {file_path}"
+            )
         except json.JSONDecodeError as e:
-            self.host.statusBar().showMessage(f"Invalid JSON format: {e}")
+            self._report_load_error("Project Load Error", f"Invalid JSON format: {e}")
         except (OSError, IOError) as e:
-            self.host.statusBar().showMessage(f"File I/O error: {e}")
-        except (TypeError, ValueError, RuntimeError, AttributeError, KeyError) as e:
-            self.host.statusBar().showMessage(
-                f"Data corruption in PME Project file: {e}"
+            self._report_load_error("Project Load Error", f"File I/O error: {e}")
+        except (
+            TypeError,
+            ValueError,
+            RuntimeError,
+            AttributeError,
+            KeyError,
+            IndexError,
+        ) as e:
+            self._report_load_error(
+                "Project Load Error", f"Data corruption in PME Project file: {e}"
             )
 
     def save_raw_data(self) -> None:
@@ -770,7 +788,7 @@ class IOManager:
             AttributeError,
             KeyError,
         ) as e:
-            self.host.statusBar().showMessage(f"Error loading file: {e}")
+            self._report_load_error("MOL Import Error", f"Error loading file: {e}")
 
     def save_as_mol(self) -> None:
         """Save current 2D structure as MOL file."""
@@ -855,8 +873,7 @@ class IOManager:
             self.host.set_has_unsaved_changes(False)
             self.host.state_manager.update_window_title()
         except (OSError, IOError, ValueError, RuntimeError, AttributeError) as e:
-            if self.host.statusBar():
-                self.host.statusBar().showMessage(f"XYZ Load failed: {e}")
+            self._report_load_error("XYZ Load Error", f"XYZ Load failed: {e}")
 
     def load_mol_file_for_3d_viewing(self, file_path: Optional[str] = None) -> None:
         """Open MOL/SDF file in 3D viewer."""
@@ -910,7 +927,7 @@ class IOManager:
             self.host.set_has_unsaved_changes(False)
             self.host.state_manager.update_window_title()
         except (OSError, IOError, ValueError, RuntimeError, AttributeError) as e:
-            self.host.statusBar().showMessage(f"3D MOL Load failed: {e}")
+            self._report_load_error("3D MOL Load Error", f"3D MOL Load failed: {e}")
 
     def save_3d_as_mol(self) -> None:
         """Save current 3D structure as MOL file."""
@@ -1044,13 +1061,26 @@ class IOManager:
             QTimer.singleShot(100, self._plotter_render)
 
         except FileNotFoundError:
-            self.host.statusBar().showMessage(f"File not found: {file_path}")
+            self._report_load_error(
+                "Project Load Error", f"File not found: {file_path}"
+            )
         except (OSError, IOError) as e:
-            self.host.statusBar().showMessage(f"File I/O error: {e}")
-        except pickle.UnpicklingError as e:
-            self.host.statusBar().showMessage(f"Invalid project file format: {e}")
-        except (TypeError, ValueError, RuntimeError, AttributeError) as e:
-            self.host.statusBar().showMessage(f"Error loading project file: {e}")
+            self._report_load_error("Project Load Error", f"File I/O error: {e}")
+        except (pickle.UnpicklingError, EOFError, ImportError) as e:
+            self._report_load_error(
+                "Project Load Error", f"Invalid project file format: {e}"
+            )
+        except (
+            TypeError,
+            ValueError,
+            RuntimeError,
+            AttributeError,
+            KeyError,
+            IndexError,
+        ) as e:
+            self._report_load_error(
+                "Project Load Error", f"Error loading project file: {e}"
+            )
 
     def _set_mol_prop(self, mol: Chem.Mol, prop_name: str, value: Any) -> None:
         """Set an RDKit molecule property safely."""

--- a/moleditpy/src/moleditpy/ui/main_window_init.py
+++ b/moleditpy/src/moleditpy/ui/main_window_init.py
@@ -202,7 +202,8 @@ class MainInitManager:
         self.host.edit_actions_manager.update_edit_menu_actions()
 
         if initial_file:
-            self.load_command_line_file(initial_file)
+            # Deferred: a load-error dialog raised in the constructor would block the window from showing
+            QTimer.singleShot(0, lambda: self.load_command_line_file(initial_file))
 
         QTimer.singleShot(0, self.apply_initial_settings)
         # Camera initialization flag (permits reset only during the first draw)

--- a/moleditpy/src/moleditpy/ui/molecular_scene_handler.py
+++ b/moleditpy/src/moleditpy/ui/molecular_scene_handler.py
@@ -1099,9 +1099,7 @@ class KeyboardMixin:
                     # 3. Update BondItem properties based on key
                     if key == Qt.Key.Key_W:
                         if bond.stereo == 1:
-                            # Direction flip mutates the data model (swapped
-                            # key + atoms) without touching order/stereo, so
-                            # it must set the undo flag itself.
+                            # Flip mutates the model without changing order/stereo, so set the undo flag here
                             bond_data = self.data.bonds.pop(current_key)
                             new_key = (current_key[1], current_key[0])
                             self.data.bonds[new_key] = bond_data

--- a/moleditpy/src/moleditpy/ui/molecular_scene_handler.py
+++ b/moleditpy/src/moleditpy/ui/molecular_scene_handler.py
@@ -1099,11 +1099,15 @@ class KeyboardMixin:
                     # 3. Update BondItem properties based on key
                     if key == Qt.Key.Key_W:
                         if bond.stereo == 1:
+                            # Direction flip mutates the data model (swapped
+                            # key + atoms) without touching order/stereo, so
+                            # it must set the undo flag itself.
                             bond_data = self.data.bonds.pop(current_key)
                             new_key = (current_key[1], current_key[0])
                             self.data.bonds[new_key] = bond_data
                             bond.atom1, bond.atom2 = bond.atom2, bond.atom1
                             bond.update_position()
+                            any_bond_changed = True
                         else:
                             bond.order = 1
                             bond.stereo = 1
@@ -1115,6 +1119,7 @@ class KeyboardMixin:
                             self.data.bonds[new_key] = bond_data
                             bond.atom1, bond.atom2 = bond.atom2, bond.atom1
                             bond.update_position()
+                            any_bond_changed = True
                         else:
                             bond.order = 1
                             bond.stereo = 2

--- a/moleditpy/src/moleditpy/ui/plugin_menu_manager.py
+++ b/moleditpy/src/moleditpy/ui/plugin_menu_manager.py
@@ -143,9 +143,7 @@ class PluginMenuManager:
         except Exception:
             logging.warning("Plugin rebuild: menu cleanup error", exc_info=True)
 
-        # Plugin-created top-level menus (and the menu-bar separator) are
-        # tagged on creation; drop the ones the clean pass emptied so an
-        # uninstalled plugin doesn't leave a dead menu in the menu bar.
+        # Drop tagged (plugin-created) top-level menus the clean pass emptied
         try:
             menu_bar = self._im.host.menuBar()
             for top_action in list(menu_bar.actions()):
@@ -202,8 +200,6 @@ class PluginMenuManager:
                     sep.setData(self._PLUGIN_ACTION_TAG)
                     self._im.plugin_menubar_separator_added = True
                 current_menu = self._im.host.menuBar().addMenu(top_level_title)
-                # Tag the owning action so rebuild_plugin_menus can remove the
-                # whole top-level menu once its plugin actions are gone.
                 current_menu.menuAction().setData(self._PLUGIN_ACTION_TAG)
 
             for part in parts[1:-1]:

--- a/moleditpy/src/moleditpy/ui/plugin_menu_manager.py
+++ b/moleditpy/src/moleditpy/ui/plugin_menu_manager.py
@@ -143,6 +143,22 @@ class PluginMenuManager:
         except Exception:
             logging.warning("Plugin rebuild: menu cleanup error", exc_info=True)
 
+        # Plugin-created top-level menus (and the menu-bar separator) are
+        # tagged on creation; drop the ones the clean pass emptied so an
+        # uninstalled plugin doesn't leave a dead menu in the menu bar.
+        try:
+            menu_bar = self._im.host.menuBar()
+            for top_action in list(menu_bar.actions()):
+                if top_action.data() != self._PLUGIN_ACTION_TAG:
+                    continue
+                submenu = top_action.menu()
+                if submenu is None or not any(
+                    not a.isSeparator() for a in submenu.actions()
+                ):
+                    menu_bar.removeAction(top_action)
+        except Exception:
+            logging.warning("Plugin rebuild: menubar cleanup error", exc_info=True)
+
         self._im.plugin_menubar_separator_added = False
 
         for method, label in [
@@ -182,9 +198,13 @@ class PluginMenuManager:
 
             if not current_menu:
                 if not self._im.plugin_menubar_separator_added:
-                    self._im.host.menuBar().addSeparator()
+                    sep = self._im.host.menuBar().addSeparator()
+                    sep.setData(self._PLUGIN_ACTION_TAG)
                     self._im.plugin_menubar_separator_added = True
                 current_menu = self._im.host.menuBar().addMenu(top_level_title)
+                # Tag the owning action so rebuild_plugin_menus can remove the
+                # whole top-level menu once its plugin actions are gone.
+                current_menu.menuAction().setData(self._PLUGIN_ACTION_TAG)
 
             for part in parts[1:-1]:
                 sub = next(

--- a/tests/assertion_catalog.md
+++ b/tests/assertion_catalog.md
@@ -1358,6 +1358,34 @@ __on_optimization_error re-enables the button and shows a critical dialog._
 - mock_mb.critical.assert_called_once()
 - assert 'Test Error' in mock_mb.critical.call_args[0][2]
 
+### TestCancelAndUndoIntegrity.test_finished_after_close_discards_result
+_A result arriving after the dialog was closed must not touch the doc._
+
+- assert dlg._closed is True
+- mock_conf.GetAtomPosition.assert_not_called()
+- dlg.main_window.view_3d_manager.draw_molecule_3d.assert_not_called()
+- dlg.main_window.edit_actions_manager.push_undo_state.assert_not_called()
+
+### TestCancelAndUndoIntegrity.test_error_after_close_is_suppressed
+_An error arriving after close must not pop a message box._
+
+- mock_mb.critical.assert_not_called()
+
+### TestCancelAndUndoIntegrity.test_reject_pushes_undo_when_constraints_changed
+_Closing the dialog after editing constraints must record an undo step._
+
+- dlg.main_window.edit_actions_manager.push_undo_state.assert_called_once()
+
+### TestCancelAndUndoIntegrity.test_reject_no_change_does_not_push_undo
+_Closing without touching constraints must not create an undo entry._
+
+- dlg.main_window.edit_actions_manager.push_undo_state.assert_not_called()
+
+### TestCancelAndUndoIntegrity.test_finished_syncs_constraints_before_undo_push
+_The undo snapshot must capture the constraints used for the run._
+
+- assert seen_at_push == [[['Distance', [0, 1], 1.54, 100000.0]]]
+
 ## tests/unit/test_custom_interactor_style.py
 
 ### test_custom_interactor_style_left_click_atom_selection
@@ -2245,6 +2273,13 @@ _The undo stack drops its oldest entries beyond UNDO_STACK_MAX_DEPTH._
 - assert len(mgr.undo_stack) == UNDO_STACK_MAX_DEPTH
 - assert mgr.undo_stack[-1]['_next_atom_id'] == UNDO_STACK_MAX_DEPTH + 24
 - assert mgr.undo_stack[0]['_next_atom_id'] == 25
+
+### test_push_undo_state_detects_constraint_change
+_Two states identical except for constraints_3d must both be pushed._
+
+- assert len(mgr.undo_stack) == 1
+- assert len(mgr.undo_stack) == 1
+- assert len(mgr.undo_stack) == 2
 
 ## tests/unit/test_export_logic.py
 
@@ -3198,6 +3233,11 @@ _Test create_multi_material_obj with Triangle Strips and Quads._
 - assert 'f 5 6 7 8' in content
 - assert 'f 1 2 3' in content
 - assert 'f 3 2 4' in content
+
+### test_export_obj_mtl_uppercase_extension_keeps_paths_distinct
+_Regression: an upper-case .OBJ filename made mtl_path identical to_
+
+- mock_create.assert_called_once_with(meshes, '/path/to/MODEL.OBJ', '/path/to/MODEL.mtl')
 
 ## tests/unit/test_main_window_init_coverage.py
 
@@ -4309,6 +4349,18 @@ _Verify skip chemistry check flag is set when user chooses to skip._
 
 - assert mol is not None
 - assert mol.HasProp('_xyz_skip_checks') or getattr(mol, '_xyz_skip_checks', False)
+
+### test_estimate_bonds_heavy_elements_beyond_radii_table
+_Regression: COVALENT_RADII stops at V; missing elements fell back to a_
+
+- assert added == 1
+- assert mol.GetBondBetweenAtoms(0, 1) is not None
+
+### test_report_load_error_dialog_gating
+_Dialog shown in GUI mode, suppressed under MOLEDITPY_HEADLESS._
+
+- mb.warning.assert_not_called()
+- mb.warning.assert_called_once()
 
 ## tests/unit/test_periodic_table_dialog.py
 
@@ -5609,6 +5661,13 @@ _Test Template preview logic._
 _Test benzene template rotation alignment._
 
 - assert data.add_atom.called
+
+### test_wedge_flip_via_key_w_pushes_undo
+_Regression: pressing W on an already-wedge bond flips its direction_
+
+- assert (1, 0) in data.bonds and (0, 1) not in data.bonds
+- assert bond.atom1 is a2 and bond.atom2 is a1
+- win.edit_actions_manager.push_undo_state.assert_called_once()
 
 ## tests/unit/test_scene_interactions.py
 
@@ -7572,6 +7631,24 @@ _Registered analysis tools appear as actions in the Analysis menu after rebuild.
 - assert 'NMR Predict' in added.text()
 - assert 'NMRPro' in added.text()
 
+### TestTopLevelMenuCleanup.test_emptied_plugin_toplevel_menu_removed_on_rebuild
+_Regression: a plugin-created top-level menu stayed in the menu bar_
+
+- assert 'MyPluginMenu' in self._titles(bar)
+- assert 'MyPluginMenu' not in self._titles(bar)
+- assert bar.actions() == []
+
+### TestTopLevelMenuCleanup.test_still_registered_toplevel_menu_survives_rebuild
+_No description provided._
+
+- assert self._titles(bar) == ['MyPluginMenu']
+- assert labels == ['Do Thing']
+
+### TestTopLevelMenuCleanup.test_builtin_menus_never_removed
+_Untagged (application-owned) menus must survive even when empty._
+
+- assert 'File' in self._titles(bar)
+
 ## tests/integration/test_plugin_opt_method_rebuild.py
 
 ### test_plugin_method_readded_after_rebuild
@@ -8165,6 +8242,13 @@ _Test integration of plugin openers into the Import menu._
 - assert 'Import .fake' in import_action.text()
 - cb.assert_called_once_with('data.fake')
 - assert window.init_manager.current_file_path == 'data.fake'
+
+### test_quit_action_has_ctrl_q_shortcut
+_File > Quit must carry the Ctrl+Q shortcut documented in the manual._
+
+- assert file_action is not None
+- assert quit_action is not None
+- assert quit_action.shortcut().toString() == 'Ctrl+Q'
 
 ## tests/gui/test_molecule_scene_events.py
 

--- a/tests/coverage_report.md
+++ b/tests/coverage_report.md
@@ -1,6 +1,6 @@
 # MoleditPy Coverage Report
 
-- **Overall Project Coverage**: **82.81%**
+- **Overall Project Coverage**: **83.08%**
 
 ### Coverage Breakdown
 
@@ -27,36 +27,36 @@
 | moleditpy\src\moleditpy\ui\bond_length_dialog.py        |    238 |     17 |   92.9% |
 | moleditpy\src\moleditpy\ui\calculation_worker.py        |    583 |    102 |   82.5% |
 | moleditpy\src\moleditpy\ui\color_settings_dialog.py     |    166 |     13 |   92.2% |
-| moleditpy\src\moleditpy\ui\compute_logic.py             |    431 |     88 |   79.6% |
-| moleditpy\src\moleditpy\ui\constrained_optimization_dialog.py |    471 |    119 |   74.7% |
+| moleditpy\src\moleditpy\ui\compute_logic.py             |    431 |     87 |   79.8% |
+| moleditpy\src\moleditpy\ui\constrained_optimization_dialog.py |    480 |    114 |   76.2% |
 | moleditpy\src\moleditpy\ui\custom_interactor_style.py   |    470 |    247 |   47.4% |
-| moleditpy\src\moleditpy\ui\custom_qt_interactor.py      |     44 |     35 |   20.5% |
+| moleditpy\src\moleditpy\ui\custom_qt_interactor.py      |     44 |     30 |   31.8% |
 | moleditpy\src\moleditpy\ui\dialog_3d_picking_mixin.py   |    137 |     19 |   86.1% |
 | moleditpy\src\moleditpy\ui\dialog_logic.py              |    230 |     25 |   89.1% |
 | moleditpy\src\moleditpy\ui\dihedral_dialog.py           |    268 |     32 |   88.1% |
 | moleditpy\src\moleditpy\ui\edit_3d_logic.py             |    221 |     32 |   85.5% |
-| moleditpy\src\moleditpy\ui\edit_actions_logic.py        |    815 |    199 |   75.6% |
+| moleditpy\src\moleditpy\ui\edit_actions_logic.py        |    821 |    199 |   75.8% |
 | moleditpy\src\moleditpy\ui\export_logic.py              |    520 |    153 |   70.6% |
 | moleditpy\src\moleditpy\ui\geometry_base_dialog.py      |     52 |      1 |   98.1% |
-| moleditpy\src\moleditpy\ui\io_logic.py                  |    679 |    113 |   83.4% |
-| moleditpy\src\moleditpy\ui\main_window.py               |    195 |     14 |   92.8% |
-| moleditpy\src\moleditpy\ui\main_window_init.py          |   1060 |     99 |   90.7% |
+| moleditpy\src\moleditpy\ui\io_logic.py                  |    694 |    100 |   85.6% |
+| moleditpy\src\moleditpy\ui\main_window.py               |    195 |     13 |   93.3% |
+| moleditpy\src\moleditpy\ui\main_window_init.py          |   1061 |     94 |   91.1% |
 | moleditpy\src\moleditpy\ui\mirror_dialog.py             |     72 |      7 |   90.3% |
-| moleditpy\src\moleditpy\ui\molecular_scene_handler.py   |    997 |    161 |   83.9% |
-| moleditpy\src\moleditpy\ui\molecule_scene.py            |    614 |    116 |   81.1% |
+| moleditpy\src\moleditpy\ui\molecular_scene_handler.py   |    999 |    156 |   84.4% |
+| moleditpy\src\moleditpy\ui\molecule_scene.py            |    614 |    118 |   80.8% |
 | moleditpy\src\moleditpy\ui\move_group_dialog.py         |    386 |    130 |   66.3% |
 | moleditpy\src\moleditpy\ui\move_selected_atoms_dialog.py |    461 |     75 |   83.7% |
 | moleditpy\src\moleditpy\ui\periodic_table_dialog.py     |     37 |      2 |   94.6% |
 | moleditpy\src\moleditpy\ui\planarize_dialog.py          |    112 |      9 |   92.0% |
-| moleditpy\src\moleditpy\ui\plugin_menu_manager.py       |    275 |     44 |   84.0% |
+| moleditpy\src\moleditpy\ui\plugin_menu_manager.py       |    287 |     46 |   84.0% |
 | moleditpy\src\moleditpy\ui\settings_dialog.py           |    101 |      3 |   97.0% |
 | moleditpy\src\moleditpy\ui\string_importers.py          |    121 |     24 |   80.2% |
 | moleditpy\src\moleditpy\ui\template_preview_item.py     |    102 |      3 |   97.1% |
 | moleditpy\src\moleditpy\ui\template_preview_view.py     |     46 |      4 |   91.3% |
 | moleditpy\src\moleditpy\ui\translation_dialog.py        |    276 |     21 |   92.4% |
-| moleditpy\src\moleditpy\ui\ui_manager.py                |    371 |     98 |   73.6% |
+| moleditpy\src\moleditpy\ui\ui_manager.py                |    371 |     97 |   73.9% |
 | moleditpy\src\moleditpy\ui\user_template_dialog.py      |    360 |     79 |   78.1% |
-| moleditpy\src\moleditpy\ui\view_3d_logic.py             |   1007 |    259 |   74.3% |
+| moleditpy\src\moleditpy\ui\view_3d_logic.py             |   1007 |    255 |   74.7% |
 | moleditpy\src\moleditpy\ui\zoomable_view.py             |     82 |      2 |   97.6% |
 | moleditpy\src\moleditpy\ui\settings_tabs\settings_2d_tab.py |    144 |      0 |  100.0% |
 | moleditpy\src\moleditpy\ui\settings_tabs\settings_3d_tabs.py |    142 |      0 |  100.0% |
@@ -67,7 +67,7 @@
 | moleditpy\src\moleditpy\utils\sip_isdeleted_safe.py     |     19 |      0 |  100.0% |
 | moleditpy\src\moleditpy\utils\suppress_log.py           |     10 |      0 |  100.0% |
 | moleditpy\src\moleditpy\utils\system_utils.py           |     39 |      0 |  100.0% |
-| **TOTAL** | **16106** | **2768** | **82.81%** |
+| **TOTAL** | **16151** | **2732** | **83.08%** |
 
 ## Test Suite Status
 - **Unit tests**: PASSED

--- a/tests/e2e/test_corrupt_files.py
+++ b/tests/e2e/test_corrupt_files.py
@@ -1,0 +1,128 @@
+# -*- coding: utf-8 -*-
+"""E2E robustness: corrupted input files must never raise unhandled
+exceptions out of the loaders — every case must land in a handler that
+reports the failure (status bar + dialog in GUI mode) and leaves the app
+alive. Added with the dev-4.3.1 fix for the empty-.pmeraw EOFError crash."""
+
+import pickle
+
+import pytest
+from PyQt6.QtWidgets import QMessageBox
+
+CASES = {
+    "empty": b"",
+    "binary_garbage": bytes(range(256)) * 4,
+    "text_garbage": b"this is not a molecule file at all\nrandom text\n",
+}
+
+VALID_XYZ = b"3\nwater\nO 0.0 0.0 0.117\nH 0.0 0.757 -0.469\nH 0.0 -0.757 -0.469\n"
+
+
+def _xyz_cases():
+    c = dict(CASES)
+    c["bad_count"] = b"abc\ncomment\nO 0.0 0.0 0.0\n"
+    c["count_too_large"] = b"999\ncomment\nO 0.0 0.0 0.0\n"
+    c["letters_as_coords"] = b"1\ncomment\nO x y z\n"
+    c["truncated"] = VALID_XYZ[: len(VALID_XYZ) // 2]
+    c["negative_count"] = b"-5\ncomment\nO 0.0 0.0 0.0\n"
+    return c
+
+
+def _mol_cases():
+    from rdkit import Chem
+    from rdkit.Chem import AllChem
+
+    mol = Chem.AddHs(Chem.MolFromSmiles("CCO"))
+    AllChem.Compute2DCoords(mol)
+    block = Chem.MolToMolBlock(mol).encode()
+    c = dict(CASES)
+    c["truncated"] = block[: len(block) // 2]
+    c["bad_counts_line"] = block.replace(b"V2000", b"XXXXX", 1)
+    return c
+
+
+def _pmeprj_cases():
+    c = dict(CASES)
+    c["invalid_json"] = b"{ not json !!"
+    c["wrong_format_field"] = b'{"format": "Something Else", "version": "1.0"}'
+    c["right_format_wrong_types"] = (
+        b'{"format": "PME Project", "version": "1.0", "atoms": "garbage",'
+        b' "bonds": 42, "structure_2d": [1, 2, 3]}'
+    )
+    return c
+
+
+def _pmeraw_cases():
+    c = dict(CASES)
+    c["pickle_of_list"] = pickle.dumps([1, 2, 3])
+    c["truncated_pickle"] = pickle.dumps({"a": 1})[:-3]
+    return c
+
+
+def _batteries(window):
+    return [
+        ("xyz3d", ".xyz", _xyz_cases(), window.io_manager.load_xyz_for_3d_viewing),
+        ("mol2d", ".mol", _mol_cases(), window.io_manager.load_mol_file),
+        ("mol3d", ".mol", _mol_cases(), window.io_manager.load_mol_file_for_3d_viewing),
+        ("sdf3d", ".sdf", _mol_cases(), window.io_manager.load_mol_file_for_3d_viewing),
+        ("pmeprj", ".pmeprj", _pmeprj_cases(), window.io_manager.load_json_data),
+        ("pmeraw", ".pmeraw", _pmeraw_cases(), window.io_manager.load_raw_data),
+    ]
+
+
+@pytest.mark.gui
+def test_corrupted_files_never_crash_loaders(window, qtbot, tmp_path, monkeypatch):
+    for name in ("critical", "warning", "information", "question"):
+        monkeypatch.setattr(
+            QMessageBox,
+            name,
+            staticmethod(lambda *a, **k: QMessageBox.StandardButton.No),
+        )
+    monkeypatch.setattr(
+        window.state_manager, "check_unsaved_changes", lambda: True, raising=False
+    )
+    window.init_manager.settings["skip_chemistry_checks"] = True
+
+    crashes = []
+    for battery, ext, cases, loader in _batteries(window):
+        for case_name, payload in cases.items():
+            p = tmp_path / f"{battery}_{case_name}{ext}"
+            p.write_bytes(payload)
+            try:
+                loader(str(p))
+                qtbot.wait(30)
+            except Exception as e:  # noqa: BLE001 - collecting every escape
+                crashes.append(f"{battery}:{case_name} -> {type(e).__name__}: {e}")
+
+    assert crashes == [], "Unhandled exceptions escaped the loaders:\n" + "\n".join(
+        crashes
+    )
+
+
+@pytest.mark.gui
+def test_corrupt_startup_file_does_not_block_window_construction(
+    app, qtbot, tmp_path, monkeypatch
+):
+    """Regression: initial_file was loaded synchronously in the constructor,
+    so the invalid-format dialog for a '{}' .pmeprj blocked MainWindow from
+    opening until dismissed. The load is now deferred to the event loop."""
+    import importlib
+
+    warnings_shown = []
+    monkeypatch.setattr(
+        QMessageBox, "warning", lambda *a, **k: warnings_shown.append(a)
+    )
+    monkeypatch.setattr(QMessageBox, "information", lambda *a, **k: None)
+
+    bad = tmp_path / "bad.pmeprj"
+    bad.write_text("{}", encoding="utf-8")
+
+    MainWindow = importlib.import_module("moleditpy.ui.main_window").MainWindow
+    win = MainWindow(initial_file=str(bad), safe_mode=True)
+    qtbot.addWidget(win)
+
+    assert warnings_shown == []  # constructor finished without raising the dialog
+
+    qtbot.wait(150)
+    assert warnings_shown, "deferred load must still report the invalid file"
+    win.close()

--- a/tests/e2e/test_import_workflows.py
+++ b/tests/e2e/test_import_workflows.py
@@ -87,3 +87,42 @@ def test_xyz_load_enters_viewer_mode(window, qtbot, tmp_path, monkeypatch):
     assert mol.GetNumAtoms() == 3
     assert sorted(a.GetSymbol() for a in mol.GetAtoms()) == ["H", "H", "O"]
     assert window.ui_manager.is_2d_editable is False
+
+
+@pytest.mark.gui
+def test_3d_imports_invoke_plugin_document_reset(window, qtbot, tmp_path, monkeypatch):
+    """XYZ and MOL 3D-viewer imports replace the document, so the plugin
+    document-reset dispatch must fire (plugins rely on it to drop state tied
+    to the previous structure). The dispatch loop itself is unit-tested in
+    test_plugin_manager.py; here we pin that the import paths reach it."""
+    from rdkit import Chem
+    from rdkit.Chem import AllChem
+
+    monkeypatch.setattr(
+        f"{_PKG}.ui.app_state.QMessageBox.question",
+        lambda *a, **k: QMessageBox.StandardButton.No,
+        raising=True,
+    )
+    window.init_manager.settings["skip_chemistry_checks"] = True
+
+    resets = []
+    monkeypatch.setattr(
+        window.plugin_manager,
+        "invoke_document_reset_handlers",
+        lambda: resets.append(True),
+        raising=True,
+    )
+
+    xyz_path = tmp_path / "water.xyz"
+    xyz_path.write_text(WATER_XYZ, encoding="utf-8")
+    window.io_manager.load_xyz_for_3d_viewing(str(xyz_path))
+    qtbot.wait(200)
+    assert len(resets) == 1, "XYZ 3D import must invoke document reset"
+
+    mol = Chem.AddHs(Chem.MolFromSmiles("C"))
+    AllChem.EmbedMolecule(mol, randomSeed=42)
+    mol_path = tmp_path / "methane.mol"
+    mol_path.write_text(Chem.MolToMolBlock(mol), encoding="utf-8")
+    window.io_manager.load_mol_file_for_3d_viewing(str(mol_path))
+    qtbot.wait(200)
+    assert len(resets) == 2, "MOL 3D import must invoke document reset"

--- a/tests/integration/test_plugin_menu_rebuild.py
+++ b/tests/integration/test_plugin_menu_rebuild.py
@@ -460,3 +460,84 @@ class TestAnalysisToolEndToEnd:
         added = analysis_menu.addAction.call_args[0][0]
         assert "NMR Predict" in added.text()
         assert "NMRPro" in added.text()
+
+
+# ---------------------------------------------------------------------------
+# rebuild_plugin_menus — plugin-created top-level menu removal (dev-4.3.1)
+# ---------------------------------------------------------------------------
+
+
+class TestTopLevelMenuCleanup:
+    def _make_im_with_real_menubar(self, pm):
+        from PyQt6.QtWidgets import QMenuBar
+
+        bar = QMenuBar()
+        im = _make_im(pm)
+        im.host.menuBar = lambda: bar
+        return im, bar
+
+    def _titles(self, bar):
+        return [a.text() for a in bar.actions() if a.menu() is not None]
+
+    def test_emptied_plugin_toplevel_menu_removed_on_rebuild(self, app):
+        """Regression: a plugin-created top-level menu stayed in the menu bar
+        forever (dead and empty) after the plugin was uninstalled/reloaded."""
+        pm = _make_plugin_manager(
+            menu_actions=[
+                {
+                    "plugin": "TestPlugin",
+                    "path": "MyPluginMenu/Do Thing",
+                    "callback": lambda: None,
+                    "text": "Do Thing",
+                    "icon": None,
+                    "shortcut": None,
+                }
+            ]
+        )
+        im, bar = self._make_im_with_real_menubar(pm)
+        mgr = PluginMenuManager(im)
+
+        mgr.add_registered_plugin_actions()
+        assert "MyPluginMenu" in self._titles(bar)
+
+        pm.menu_actions = []  # plugin uninstalled, registries re-discovered
+        mgr.rebuild_plugin_menus()
+
+        assert "MyPluginMenu" not in self._titles(bar)
+        # No orphaned menu-bar separator either
+        assert bar.actions() == []
+
+    def test_still_registered_toplevel_menu_survives_rebuild(self, app):
+        pm = _make_plugin_manager(
+            menu_actions=[
+                {
+                    "plugin": "TestPlugin",
+                    "path": "MyPluginMenu/Do Thing",
+                    "callback": lambda: None,
+                    "text": "Do Thing",
+                    "icon": None,
+                    "shortcut": None,
+                }
+            ]
+        )
+        im, bar = self._make_im_with_real_menubar(pm)
+        mgr = PluginMenuManager(im)
+
+        mgr.add_registered_plugin_actions()
+        mgr.rebuild_plugin_menus()
+
+        assert self._titles(bar) == ["MyPluginMenu"]
+        menu = bar.actions()[-1].menu()
+        labels = [a.text() for a in menu.actions() if not a.isSeparator()]
+        assert labels == ["Do Thing"]
+
+    def test_builtin_menus_never_removed(self, app):
+        """Untagged (application-owned) menus must survive even when empty."""
+        pm = _make_plugin_manager()
+        im, bar = self._make_im_with_real_menubar(pm)
+        bar.addMenu("File")  # built-in, untagged, currently empty
+        mgr = PluginMenuManager(im)
+
+        mgr.rebuild_plugin_menus()
+
+        assert "File" in self._titles(bar)

--- a/tests/unit/test_constrained_optimization_dialog.py
+++ b/tests/unit/test_constrained_optimization_dialog.py
@@ -605,3 +605,87 @@ class TestOptimizationExecution:
         assert dlg.optimize_button.isEnabled()
         mock_mb.critical.assert_called_once()
         assert "Test Error" in mock_mb.critical.call_args[0][2]
+
+
+# ---------------------------------------------------------------------------
+# Cancellation & undo integrity (dev-4.3.1 bug fixes)
+# ---------------------------------------------------------------------------
+
+
+class TestCancelAndUndoIntegrity:
+    def _close_quietly(self, dlg):
+        dlg.picking_enabled = False
+        dlg.constraint_labels = []
+        dlg.selection_labels = []
+        dlg.reject()
+
+    def test_finished_after_close_discards_result(self, make_dialog):
+        """A result arriving after the dialog was closed must not touch the doc."""
+        dlg = make_dialog()
+        self._close_quietly(dlg)
+        assert dlg._closed is True
+
+        dlg.main_window.reset_mock()
+        mock_conf = MagicMock()
+        dlg._on_optimization_finished("MMFF94s", mock_conf)
+
+        mock_conf.GetAtomPosition.assert_not_called()
+        dlg.main_window.view_3d_manager.draw_molecule_3d.assert_not_called()
+        dlg.main_window.edit_actions_manager.push_undo_state.assert_not_called()
+
+    def test_error_after_close_is_suppressed(self, make_dialog):
+        """An error arriving after close must not pop a message box."""
+        dlg = make_dialog()
+        self._close_quietly(dlg)
+
+        with patch(
+            "moleditpy.ui.constrained_optimization_dialog.QMessageBox"
+        ) as mock_mb:
+            dlg._on_optimization_error("late failure")
+
+        mock_mb.critical.assert_not_called()
+
+    def test_reject_pushes_undo_when_constraints_changed(self, make_dialog):
+        """Closing the dialog after editing constraints must record an undo step."""
+        dlg = make_dialog()
+        dlg.constraints = [("Distance", (0, 1), 1.54, 1.0e5)]
+        dlg.main_window.edit_3d_manager.constraints_3d = []
+        self._close_quietly(dlg)
+
+        dlg.main_window.edit_actions_manager.push_undo_state.assert_called_once()
+
+    def test_reject_no_change_does_not_push_undo(self, make_dialog):
+        """Closing without touching constraints must not create an undo entry."""
+        dlg = make_dialog()
+        dlg.constraints = [("Distance", (0, 1), 1.54, 1.0e5)]
+        dlg.main_window.edit_3d_manager.constraints_3d = [
+            ["Distance", [0, 1], 1.54, 1.0e5]
+        ]
+        self._close_quietly(dlg)
+
+        dlg.main_window.edit_actions_manager.push_undo_state.assert_not_called()
+
+    def test_finished_syncs_constraints_before_undo_push(self, make_dialog):
+        """The undo snapshot must capture the constraints used for the run."""
+        dlg = make_dialog()
+        dlg.constraints = [("Distance", (0, 1), 1.54, 1.0e5)]
+        dlg.main_window.edit_3d_manager.constraints_3d = []
+
+        seen_at_push = []
+        dlg.main_window.edit_actions_manager.push_undo_state.side_effect = (
+            lambda: seen_at_push.append(
+                list(dlg.main_window.edit_3d_manager.constraints_3d)
+            )
+        )
+
+        mock_conf = MagicMock()
+        pos_mock = MagicMock()
+        pos_mock.x = pos_mock.y = pos_mock.z = 0.0
+        mock_conf.GetAtomPosition.return_value = pos_mock
+        dlg.main_window.view_3d_manager.atom_positions_3d = {
+            i: [0, 0, 0] for i in range(dlg.mol.GetNumAtoms())
+        }
+
+        dlg._on_optimization_finished("MMFF94s", mock_conf)
+
+        assert seen_at_push == [[["Distance", [0, 1], 1.54, 1.0e5]]]

--- a/tests/unit/test_edit_actions.py
+++ b/tests/unit/test_edit_actions.py
@@ -553,3 +553,47 @@ def test_push_undo_state_caps_stack_depth(monkeypatch):
     # Newest state kept, oldest dropped
     assert mgr.undo_stack[-1]["_next_atom_id"] == UNDO_STACK_MAX_DEPTH + 24
     assert mgr.undo_stack[0]["_next_atom_id"] == 25
+
+
+def test_push_undo_state_detects_constraint_change(monkeypatch):
+    """Two states identical except for constraints_3d must both be pushed.
+
+    Regression: the dedup comparison ignored constraints_3d, so a
+    constraints-only edit (e.g. added in the Constrained Optimization
+    dialog and saved on close) was silently deduplicated away.
+    """
+    host = MagicMock()
+    host.is_restoring_state = False
+    host.view_3d_manager.current_mol = None
+    host.state_manager.data.atoms = {}
+    host.state_manager.data.bonds = {}
+    host.state_manager.data.next_atom_id = 0
+    host.edit_3d_manager.constraints_3d = []
+
+    mgr = EditActionsManager(host)
+    monkeypatch.setattr(mgr, "update_implicit_hydrogens", lambda: None)
+    monkeypatch.setattr(mgr, "update_undo_redo_actions", lambda: None)
+
+    def _state():
+        return {
+            "atoms": {},
+            "bonds": {},
+            "_next_atom_id": 0,
+            "constraints_3d": [
+                list(c) for c in host.edit_3d_manager.constraints_3d
+            ],
+        }
+
+    host.state_manager.get_current_state.side_effect = _state
+
+    mgr.push_undo_state()
+    assert len(mgr.undo_stack) == 1
+
+    # Identical state: deduplicated
+    mgr.push_undo_state()
+    assert len(mgr.undo_stack) == 1
+
+    # Same atoms/bonds, new constraint: must create a new entry
+    host.edit_3d_manager.constraints_3d = [["Distance", [0, 1], 1.54, 1.0e5]]
+    mgr.push_undo_state()
+    assert len(mgr.undo_stack) == 2

--- a/tests/unit/test_main_window_export_extended.py
+++ b/tests/unit/test_main_window_export_extended.py
@@ -413,3 +413,36 @@ def test_create_multi_material_obj_complex_cells(window):
         assert "f 5 6 7 8" in content
         assert "f 1 2 3" in content
         assert "f 3 2 4" in content
+
+
+def test_export_obj_mtl_uppercase_extension_keeps_paths_distinct(
+    window, mock_file_dialog
+):
+    """Regression: an upper-case .OBJ filename made mtl_path identical to
+    file_path (case-sensitive str.replace found nothing to replace), so the
+    MTL content was written to the .OBJ path and then overwritten — silent
+    material data loss."""
+    mock_file_dialog.getSaveFileName.return_value = (
+        "/path/to/MODEL.OBJ",
+        "OBJ Files (*.obj)",
+    )
+
+    meshes = [
+        {
+            "mesh": MagicMock(),
+            "color": [255, 0, 0],
+            "name": "test_mesh",
+            "type": "actor",
+            "actor_name": "test",
+        }
+    ]
+
+    with (
+        patch.object(window, "export_from_3d_view_with_colors", return_value=meshes),
+        patch.object(window, "create_multi_material_obj") as mock_create,
+    ):
+        window.export_obj_mtl()
+
+        mock_create.assert_called_once_with(
+            meshes, "/path/to/MODEL.OBJ", "/path/to/MODEL.mtl"
+        )

--- a/tests/unit/test_parsers.py
+++ b/tests/unit/test_parsers.py
@@ -518,3 +518,26 @@ def test_load_xyz_skip_chemistry_via_button(mock_parser_host, tmp_path):
     mol = parser.load_xyz_file(str(xyz_path))
     assert mol is not None
     assert mol.HasProp("_xyz_skip_checks") or getattr(mol, "_xyz_skip_checks", False)
+
+
+def test_estimate_bonds_heavy_elements_beyond_radii_table(mock_parser_host):
+    """Regression: COVALENT_RADII stops at V; missing elements fell back to a
+    1.0 A radius, so an I-I bond (~2.66 A) exceeded the 2*1.0*1.3 = 2.6 A
+    window and was silently dropped. RDKit's periodic table now backfills."""
+    from rdkit import Chem
+    from rdkit.Geometry import Point3D
+
+    parser = DummyParser(mock_parser_host)
+
+    mol = Chem.RWMol()
+    for _ in range(2):
+        mol.AddAtom(Chem.Atom(53))  # iodine
+    conf = Chem.Conformer(2)
+    conf.SetAtomPosition(0, Point3D(0.0, 0.0, 0.0))
+    conf.SetAtomPosition(1, Point3D(2.66, 0.0, 0.0))
+    mol.AddConformer(conf)
+
+    added = parser.estimate_bonds_from_distances(mol)
+
+    assert added == 1
+    assert mol.GetBondBetweenAtoms(0, 1) is not None

--- a/tests/unit/test_parsers.py
+++ b/tests/unit/test_parsers.py
@@ -541,3 +541,18 @@ def test_estimate_bonds_heavy_elements_beyond_radii_table(mock_parser_host):
 
     assert added == 1
     assert mol.GetBondBetweenAtoms(0, 1) is not None
+
+
+def test_report_load_error_dialog_gating(mock_parser_host, monkeypatch):
+    """Dialog shown in GUI mode, suppressed under MOLEDITPY_HEADLESS."""
+    from unittest.mock import patch as _patch
+
+    parser = DummyParser(mock_parser_host)
+    with _patch("moleditpy.ui.io_logic.QMessageBox") as mb:
+        monkeypatch.setenv("MOLEDITPY_HEADLESS", "1")
+        parser._report_load_error("Load Error", "broken file")
+        mb.warning.assert_not_called()
+
+        monkeypatch.delenv("MOLEDITPY_HEADLESS")
+        parser._report_load_error("Load Error", "broken file")
+        mb.warning.assert_called_once()

--- a/tests/unit/test_scene_extended_logic.py
+++ b/tests/unit/test_scene_extended_logic.py
@@ -181,3 +181,37 @@ def test_benzene_template_rotation_logic(scene_setup):
 
     scene.add_user_template_fragment(context)
     assert data.add_atom.called
+
+
+def test_wedge_flip_via_key_w_pushes_undo(scene_setup):
+    """Regression: pressing W on an already-wedge bond flips its direction
+    (swaps the data-model key and the bond's atoms) but left order/stereo
+    unchanged, so any_bond_changed stayed False and no undo checkpoint was
+    recorded for a real data mutation."""
+    scene, data, win = scene_setup
+
+    a1 = AtomItem(0, "C", QPointF(0, 0))
+    a2 = AtomItem(1, "C", QPointF(50, 0))
+    a1.atom_id, a2.atom_id = 0, 1
+    bond = BondItem(a1, a2, order=1, stereo=1)  # already a wedge
+    data.bonds[(0, 1)] = {"order": 1, "stereo": 1, "item": bond}
+
+    event = MagicMock()
+    event.key.return_value = Qt.Key.Key_W
+    event.modifiers.return_value = Qt.KeyboardModifier.NoModifier
+
+    win.ui_manager.is_2d_editable = True
+    win.edit_actions_manager.push_undo_state.reset_mock()
+
+    with (
+        patch.object(MoleculeScene, "itemAt", return_value=bond),
+        patch.object(scene, "find_atom_near", return_value=None),
+        patch.object(scene, "update_all_items"),
+    ):
+        scene.keyPressEvent(event)
+
+    # Direction flipped: key swapped in the data model, atoms swapped on item
+    assert (1, 0) in data.bonds and (0, 1) not in data.bonds
+    assert bond.atom1 is a2 and bond.atom2 is a1
+    # The mutation must be recorded in undo history
+    win.edit_actions_manager.push_undo_state.assert_called_once()


### PR DESCRIPTION
# dev-4.3.1: bug fixes for undo integrity, file export/import, and corrupted-file handling

## Summary

<!-- What does this PR do? List the key changes in 2–4 bullet points. -->

- Fix 7 latent bugs: OBJ/MTL export silently losing material data on `.OBJ` filenames; covalent-radius fallback dropping real bonds for elements beyond V (I, Br, Fe, …) in XYZ bond estimation; wedge/hash direction flips (`W`/`D`) skipping the undo checkpoint; plugin-created top-level menus leaking in the menu bar after uninstall/reload.
- Constrained Optimization dialog: closing now cancels an in-flight minimization (late results discarded), constraints sync to the main window before the undo push, Cancel-after-edit records an undo entry, and `push_undo_state` dedup now compares `constraints_3d`.
- Corrupted-file robustness: fix uncaught `EOFError` on empty/truncated `.pmeraw`; load failures now show a warning dialog (suppressed under `MOLEDITPY_HEADLESS`) in addition to the status bar; `initial_file` load deferred out of the `MainWindow` constructor so an error dialog for a corrupt startup file (e.g. a `{}` `.pmeprj`) no longer blocks the window from opening.
- New regression tests: 34-case corrupted-file battery (e2e), 3D-import → plugin document-reset contract, startup-deferral, and per-fix pinning tests. Coverage 82.81% → 83.08%. Version bumped to 4.3.1.

## Type of change

<!-- Check all that apply. -->

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation
- [x] Tests
- [ ] CI / build

## Related issues

<!-- Link any related issues, e.g. Closes #123 -->

None (found by internal code audit, 2026-07-15).

## Test plan

<!-- How did you verify the change works? -->

- [x] Ran `python tests/run_all_tests.py` — all pass (unit, integration, E2E, GUI)
- [ ] Manually tested in the GUI with the check list
- [x] Added new unit tests

## Checklist

- [x] `python -m flake8 moleditpy/src/ --select=F` returns 0 issues
- [x] No bare `except:` clauses added (use `except Exception as e:` and log the error)
- [x] No new unused imports or variables (ruff `F` clean on all changed files)
- [x] Plugin API changes are backwards-compatible (or documented in Summary) — no `PluginContext` changes; plugin-menu tagging is internal to `PluginMenuManager`
