### PR TITLE
Dev 4.3.2

### DIFF
--- a/moleditpy/src/moleditpy/ui/custom_interactor_style.py
+++ b/moleditpy/src/moleditpy/ui/custom_interactor_style.py
@@ -101,13 +101,6 @@ class CustomInteractorStyle(vtkInteractorStyleTrackballCamera):
 
         mw = self.main_window
 
-        logging.debug(
-            "3D press: measurement=%s edit3d=%s mol=%s",
-            mw.edit_3d_manager.measurement_mode,
-            mw.edit_3d_manager.is_3d_edit_mode,
-            mw.view_3d_manager.current_mol is not None,
-        )
-
         # Clear previous drag state
         self._is_dragging_atom = False
         self.is_dragging = False

--- a/moleditpy/src/moleditpy/ui/custom_interactor_style.py
+++ b/moleditpy/src/moleditpy/ui/custom_interactor_style.py
@@ -13,7 +13,6 @@ DOI: 10.5281/zenodo.17268532
 from __future__ import annotations
 
 import logging
-import time
 from typing import Any, Optional
 
 import numpy as np
@@ -39,7 +38,6 @@ class CustomInteractorStyle(vtkInteractorStyleTrackballCamera):
         self._mouse_moved_during_drag = False
         self._mouse_press_pos: Optional[tuple[int, int]] = None
         self._suppress_next_left_button_up = False
-        self._last_pick_miss_log = 0.0
 
         self.AddObserver("LeftButtonPressEvent", self.on_left_button_down)  # type: ignore[arg-type]
         # self.AddObserver("LeftButtonDoubleClickEvent", self.on_left_button_down)
@@ -83,78 +81,6 @@ class CustomInteractorStyle(vtkInteractorStyleTrackballCamera):
                 # Safe defensive fallback catching AttributeError, RuntimeError
                 logging.debug("Suppressed non-critical error", exc_info=True)
 
-    def _log_pick_miss(self, click_pos: Any, mode: str) -> None:
-        """Diagnostic (rate-limited): a click in an active pick mode hit no atom.
-
-        A healthy background click also lands here, but a persistent stream of
-        misses while the user is clicking directly on atoms indicates the pick
-        pipeline is broken (stale atom_positions_3d, coordinate offset, etc.).
-        """
-        now = time.monotonic()
-        if now - self._last_pick_miss_log < 1.0:
-            return
-        self._last_pick_miss_log = now
-        try:
-            v3m = self.main_window.view_3d_manager
-            positions = getattr(v3m, "atom_positions_3d", None)
-            n_pos = len(positions) if positions is not None else -1
-            mol = getattr(v3m, "current_mol", None)
-            n_atoms = int(mol.GetNumAtoms()) if mol is not None else -1
-            renderer = v3m.plotter.renderer
-            size = renderer.GetSize()
-
-            # Project all atoms to display coords with the same renderer the
-            # picker uses, so the log shows where picking THINKS the atoms are.
-            bbox = "n/a"
-            if positions is not None and n_pos > 0:
-                display_pts = []
-                for pos in positions:
-                    renderer.SetWorldPoint(
-                        float(pos[0]), float(pos[1]), float(pos[2]), 1.0
-                    )
-                    renderer.WorldToDisplay()
-                    d = renderer.GetDisplayPoint()
-                    display_pts.append((float(d[0]), float(d[1])))
-                xs = [p[0] for p in display_pts]
-                ys = [p[1] for p in display_pts]
-                bbox = (
-                    f"x[{min(xs):.0f}..{max(xs):.0f}] y[{min(ys):.0f}..{max(ys):.0f}]"
-                )
-
-            interactor = self.GetInteractor()
-            iren_size = tuple(interactor.GetSize()) if interactor else "n/a"
-            rw = interactor.GetRenderWindow() if interactor else None
-            rw_size = tuple(rw.GetSize()) if rw else "n/a"
-            widget = getattr(v3m.plotter, "interactor", None)
-            if widget is not None:
-                qt_geo = (widget.width(), widget.height())
-                dpr = round(float(widget.devicePixelRatioF()), 3)
-            else:
-                qt_geo, dpr = "n/a", "n/a"
-
-            logging.debug(
-                "3D pick miss (%s): click=%s atoms=%d positions=%d "
-                "atom_display_bbox=%s renderer_size=%s iren_size=%s rw_size=%s "
-                "qt_widget=%s dpr=%s",
-                mode,
-                tuple(click_pos),
-                n_atoms,
-                n_pos,
-                bbox,
-                tuple(size),
-                iren_size,
-                rw_size,
-                qt_geo,
-                dpr,
-            )
-        except (AttributeError, RuntimeError, TypeError, ValueError):
-            logging.debug(
-                "3D pick miss (%s): click=%s (state unavailable)",
-                mode,
-                click_pos,
-                exc_info=True,
-            )
-
     def _stop_vtk_left_button_state(self) -> None:
         """Clear VTK's button/drag state after a custom-handled left click."""
         try:
@@ -175,20 +101,12 @@ class CustomInteractorStyle(vtkInteractorStyleTrackballCamera):
 
         mw = self.main_window
 
-        if logging.getLogger().isEnabledFor(logging.DEBUG):
-            try:
-                logging.debug(
-                    "3D press: pos=%s measurement=%s edit3d=%s mol=%s style=%s",
-                    tuple(self.GetInteractor().GetEventPosition()),
-                    mw.edit_3d_manager.measurement_mode,
-                    mw.edit_3d_manager.is_3d_edit_mode,
-                    mw.view_3d_manager.current_mol is not None,
-                    type(
-                        self.GetInteractor().GetInteractorStyle()
-                    ).__name__,
-                )
-            except (AttributeError, RuntimeError, TypeError):
-                logging.debug("3D press: state unavailable", exc_info=True)
+        logging.debug(
+            "3D press: measurement=%s edit3d=%s mol=%s",
+            mw.edit_3d_manager.measurement_mode,
+            mw.edit_3d_manager.is_3d_edit_mode,
+            mw.view_3d_manager.current_mol is not None,
+        )
 
         # Clear previous drag state
         self._is_dragging_atom = False
@@ -354,10 +272,6 @@ class CustomInteractorStyle(vtkInteractorStyleTrackballCamera):
                     )
                     if atom:
                         if True:
-                            logging.debug(
-                                "3D pick hit (measurement): atom=%d",
-                                int(closest_atom_idx),
-                            )
 
                             def _deferred_measure() -> None:
                                 try:
@@ -374,7 +288,6 @@ class CustomInteractorStyle(vtkInteractorStyleTrackballCamera):
                             return  # Selection complete, disable camera rotation
 
             # Clear measurement if not dragging
-            self._log_pick_miss(click_pos, "measurement")
             self._is_dragging_atom = False
             self._mouse_press_pos = click_pos
             super().OnLeftButtonDown()
@@ -398,10 +311,6 @@ class CustomInteractorStyle(vtkInteractorStyleTrackballCamera):
                     )
                     if atom:
                         if True:
-                            logging.debug(
-                                "3D pick hit (3d-edit): atom=%d",
-                                int(closest_atom_idx),
-                            )
                             # Successfully grabbed atom
                             self._is_dragging_atom = True
                             self.is_dragging = False
@@ -411,8 +320,6 @@ class CustomInteractorStyle(vtkInteractorStyleTrackballCamera):
                             )
                             self._suppress_next_left_button_up = True
                             return  # Prevent camera rotation
-            else:
-                self._log_pick_miss(click_pos, "3d-edit")
 
         # Track mouse event to distinguish rotation from click
         self._mouse_press_pos = self.GetInteractor().GetEventPosition()

--- a/moleditpy/src/moleditpy/ui/custom_interactor_style.py
+++ b/moleditpy/src/moleditpy/ui/custom_interactor_style.py
@@ -175,6 +175,21 @@ class CustomInteractorStyle(vtkInteractorStyleTrackballCamera):
 
         mw = self.main_window
 
+        if logging.getLogger().isEnabledFor(logging.DEBUG):
+            try:
+                logging.debug(
+                    "3D press: pos=%s measurement=%s edit3d=%s mol=%s style=%s",
+                    tuple(self.GetInteractor().GetEventPosition()),
+                    mw.edit_3d_manager.measurement_mode,
+                    mw.edit_3d_manager.is_3d_edit_mode,
+                    mw.view_3d_manager.current_mol is not None,
+                    type(
+                        self.GetInteractor().GetInteractorStyle()
+                    ).__name__,
+                )
+            except (AttributeError, RuntimeError, TypeError):
+                logging.debug("3D press: state unavailable", exc_info=True)
+
         # Clear previous drag state
         self._is_dragging_atom = False
         self.is_dragging = False
@@ -339,6 +354,10 @@ class CustomInteractorStyle(vtkInteractorStyleTrackballCamera):
                     )
                     if atom:
                         if True:
+                            logging.debug(
+                                "3D pick hit (measurement): atom=%d",
+                                int(closest_atom_idx),
+                            )
 
                             def _deferred_measure() -> None:
                                 try:
@@ -379,6 +398,10 @@ class CustomInteractorStyle(vtkInteractorStyleTrackballCamera):
                     )
                     if atom:
                         if True:
+                            logging.debug(
+                                "3D pick hit (3d-edit): atom=%d",
+                                int(closest_atom_idx),
+                            )
                             # Successfully grabbed atom
                             self._is_dragging_atom = True
                             self.is_dragging = False

--- a/moleditpy/src/moleditpy/ui/custom_interactor_style.py
+++ b/moleditpy/src/moleditpy/ui/custom_interactor_style.py
@@ -100,17 +100,60 @@ class CustomInteractorStyle(vtkInteractorStyleTrackballCamera):
             n_pos = len(positions) if positions is not None else -1
             mol = getattr(v3m, "current_mol", None)
             n_atoms = int(mol.GetNumAtoms()) if mol is not None else -1
-            size = v3m.plotter.renderer.GetSize()
-            logging.info(
-                "3D pick miss (%s): click=%s atoms=%d positions=%d renderer_size=%s",
+            renderer = v3m.plotter.renderer
+            size = renderer.GetSize()
+
+            # Project all atoms to display coords with the same renderer the
+            # picker uses, so the log shows where picking THINKS the atoms are.
+            bbox = "n/a"
+            if positions is not None and n_pos > 0:
+                display_pts = []
+                for pos in positions:
+                    renderer.SetWorldPoint(
+                        float(pos[0]), float(pos[1]), float(pos[2]), 1.0
+                    )
+                    renderer.WorldToDisplay()
+                    d = renderer.GetDisplayPoint()
+                    display_pts.append((float(d[0]), float(d[1])))
+                xs = [p[0] for p in display_pts]
+                ys = [p[1] for p in display_pts]
+                bbox = (
+                    f"x[{min(xs):.0f}..{max(xs):.0f}] y[{min(ys):.0f}..{max(ys):.0f}]"
+                )
+
+            interactor = self.GetInteractor()
+            iren_size = tuple(interactor.GetSize()) if interactor else "n/a"
+            rw = interactor.GetRenderWindow() if interactor else None
+            rw_size = tuple(rw.GetSize()) if rw else "n/a"
+            widget = getattr(v3m.plotter, "interactor", None)
+            if widget is not None:
+                qt_geo = (widget.width(), widget.height())
+                dpr = round(float(widget.devicePixelRatioF()), 3)
+            else:
+                qt_geo, dpr = "n/a", "n/a"
+
+            logging.debug(
+                "3D pick miss (%s): click=%s atoms=%d positions=%d "
+                "atom_display_bbox=%s renderer_size=%s iren_size=%s rw_size=%s "
+                "qt_widget=%s dpr=%s",
                 mode,
                 tuple(click_pos),
                 n_atoms,
                 n_pos,
+                bbox,
                 tuple(size),
+                iren_size,
+                rw_size,
+                qt_geo,
+                dpr,
             )
         except (AttributeError, RuntimeError, TypeError, ValueError):
-            logging.info("3D pick miss (%s): click=%s (state unavailable)", mode, click_pos)
+            logging.debug(
+                "3D pick miss (%s): click=%s (state unavailable)",
+                mode,
+                click_pos,
+                exc_info=True,
+            )
 
     def _stop_vtk_left_button_state(self) -> None:
         """Clear VTK's button/drag state after a custom-handled left click."""

--- a/moleditpy/src/moleditpy/ui/custom_interactor_style.py
+++ b/moleditpy/src/moleditpy/ui/custom_interactor_style.py
@@ -383,6 +383,54 @@ class CustomInteractorStyle(vtkInteractorStyleTrackballCamera):
         # Standard right-click
         super().OnRightButtonDown()
 
+    def _heal_stuck_pointer_state(self, move_group_dialog: Any) -> None:
+        """Self-heal drag/rotate state whose release event was lost.
+
+        Fast clicking can make the Qt layer swallow a release whose press
+        already reached VTK, leaving this style (or a Move Group dialog) in a
+        permanent drag/rotate state that blocks all further interaction. Since
+        the healing press may itself be swallowed, verify against the real
+        button state on every move and reset when no button is held.
+        """
+        try:
+            buttons = QApplication.mouseButtons()
+            left_held = bool(buttons & Qt.MouseButton.LeftButton)
+            right_held = bool(buttons & Qt.MouseButton.RightButton)
+            any_held = buttons != Qt.MouseButton.NoButton
+        except (AttributeError, RuntimeError, TypeError):
+            return
+
+        if self._is_dragging_atom and not left_held:
+            self.reset_interactor_state()
+
+        if not any_held:
+            try:
+                if self.GetState() != 0:  # stuck ROTATE/PAN/etc. without a button
+                    self.reset_interactor_state()
+            except (AttributeError, RuntimeError, TypeError):
+                # Safe defensive fallback catching AttributeError, RuntimeError, TypeError
+                logging.debug("Suppressed non-critical error", exc_info=True)
+
+        if move_group_dialog is not None:
+            try:
+                if (
+                    getattr(move_group_dialog, "is_dragging_group_vtk", False)
+                    and not left_held
+                ):
+                    move_group_dialog.is_dragging_group_vtk = False
+                    move_group_dialog.drag_start_pos_vtk = None
+                    move_group_dialog.mouse_moved_vtk = False
+                if (
+                    getattr(move_group_dialog, "is_rotating_group_vtk", False)
+                    and not right_held
+                ):
+                    move_group_dialog.is_rotating_group_vtk = False
+                    move_group_dialog.rotation_start_pos = None
+                    move_group_dialog.rotation_mouse_moved = False
+            except (AttributeError, RuntimeError, TypeError):
+                # Safe defensive fallback catching AttributeError, RuntimeError, TypeError
+                logging.debug("Suppressed non-critical error", exc_info=True)
+
     def on_mouse_move(self, obj: Any, event: Any) -> None:
         """
         Handle mouse move (drag vs camera/hover).
@@ -402,6 +450,8 @@ class CustomInteractorStyle(vtkInteractorStyleTrackballCamera):
                     break
         except (AttributeError, RuntimeError, TypeError):
             logging.warning("Caught exception in " + __file__, exc_info=True)
+
+        self._heal_stuck_pointer_state(move_group_dialog)
         if move_group_dialog and getattr(
             move_group_dialog, "is_dragging_group_vtk", False
         ):

--- a/moleditpy/src/moleditpy/ui/custom_interactor_style.py
+++ b/moleditpy/src/moleditpy/ui/custom_interactor_style.py
@@ -384,11 +384,11 @@ class CustomInteractorStyle(vtkInteractorStyleTrackballCamera):
     def _heal_stuck_pointer_state(self, move_group_dialog: Any) -> None:
         """Self-heal drag/rotate state whose release event was lost.
 
-        Fast clicking can make the Qt layer swallow a release whose press
-        already reached VTK, leaving this style (or a Move Group dialog) in a
-        permanent drag/rotate state that blocks all further interaction. Since
-        the healing press may itself be swallowed, verify against the real
-        button state on every move and reset when no button is held.
+        A release can be lost mid-gesture (e.g. pyvista temporarily swapping
+        the interactor style, a dialog grabbing events), leaving this style or
+        a Move Group dialog in a permanent drag/rotate state that blocks
+        interaction. Verify against the real button state on every move and
+        reset when the button is not actually held.
         """
         try:
             buttons = QApplication.mouseButtons()

--- a/moleditpy/src/moleditpy/ui/custom_interactor_style.py
+++ b/moleditpy/src/moleditpy/ui/custom_interactor_style.py
@@ -13,6 +13,7 @@ DOI: 10.5281/zenodo.17268532
 from __future__ import annotations
 
 import logging
+import time
 from typing import Any, Optional
 
 import numpy as np
@@ -38,6 +39,7 @@ class CustomInteractorStyle(vtkInteractorStyleTrackballCamera):
         self._mouse_moved_during_drag = False
         self._mouse_press_pos: Optional[tuple[int, int]] = None
         self._suppress_next_left_button_up = False
+        self._last_pick_miss_log = 0.0
 
         self.AddObserver("LeftButtonPressEvent", self.on_left_button_down)  # type: ignore[arg-type]
         # self.AddObserver("LeftButtonDoubleClickEvent", self.on_left_button_down)
@@ -80,6 +82,35 @@ class CustomInteractorStyle(vtkInteractorStyleTrackballCamera):
             except (AttributeError, RuntimeError):
                 # Safe defensive fallback catching AttributeError, RuntimeError
                 logging.debug("Suppressed non-critical error", exc_info=True)
+
+    def _log_pick_miss(self, click_pos: Any, mode: str) -> None:
+        """Diagnostic (rate-limited): a click in an active pick mode hit no atom.
+
+        A healthy background click also lands here, but a persistent stream of
+        misses while the user is clicking directly on atoms indicates the pick
+        pipeline is broken (stale atom_positions_3d, coordinate offset, etc.).
+        """
+        now = time.monotonic()
+        if now - self._last_pick_miss_log < 1.0:
+            return
+        self._last_pick_miss_log = now
+        try:
+            v3m = self.main_window.view_3d_manager
+            positions = getattr(v3m, "atom_positions_3d", None)
+            n_pos = len(positions) if positions is not None else -1
+            mol = getattr(v3m, "current_mol", None)
+            n_atoms = int(mol.GetNumAtoms()) if mol is not None else -1
+            size = v3m.plotter.renderer.GetSize()
+            logging.info(
+                "3D pick miss (%s): click=%s atoms=%d positions=%d renderer_size=%s",
+                mode,
+                tuple(click_pos),
+                n_atoms,
+                n_pos,
+                tuple(size),
+            )
+        except (AttributeError, RuntimeError, TypeError, ValueError):
+            logging.info("3D pick miss (%s): click=%s (state unavailable)", mode, click_pos)
 
     def _stop_vtk_left_button_state(self) -> None:
         """Clear VTK's button/drag state after a custom-handled left click."""
@@ -159,9 +190,8 @@ class CustomInteractorStyle(vtkInteractorStyleTrackballCamera):
                             try:
                                 move_group_dialog.on_atom_picked(clicked_atom_idx)
                             except (AttributeError, RuntimeError):
-                                # Safe defensive fallback catching AttributeError, RuntimeError
-                                logging.debug(
-                                    "Suppressed non-critical error", exc_info=True
+                                logging.warning(
+                                    "Move-dialog atom toggle failed", exc_info=True
                                 )
 
                         QTimer.singleShot(0, _deferred_toggle)
@@ -273,9 +303,8 @@ class CustomInteractorStyle(vtkInteractorStyleTrackballCamera):
                                         closest_atom_idx
                                     )
                                 except (AttributeError, RuntimeError):
-                                    # Safe defensive fallback catching AttributeError, RuntimeError
-                                    logging.debug(
-                                        "Suppressed non-critical error", exc_info=True
+                                    logging.warning(
+                                        "Measurement selection failed", exc_info=True
                                     )
 
                             QTimer.singleShot(0, _deferred_measure)
@@ -283,6 +312,7 @@ class CustomInteractorStyle(vtkInteractorStyleTrackballCamera):
                             return  # Selection complete, disable camera rotation
 
             # Clear measurement if not dragging
+            self._log_pick_miss(click_pos, "measurement")
             self._is_dragging_atom = False
             self._mouse_press_pos = click_pos
             super().OnLeftButtonDown()
@@ -315,6 +345,8 @@ class CustomInteractorStyle(vtkInteractorStyleTrackballCamera):
                             )
                             self._suppress_next_left_button_up = True
                             return  # Prevent camera rotation
+            else:
+                self._log_pick_miss(click_pos, "3d-edit")
 
         # Track mouse event to distinguish rotation from click
         self._mouse_press_pos = self.GetInteractor().GetEventPosition()

--- a/moleditpy/src/moleditpy/ui/custom_qt_interactor.py
+++ b/moleditpy/src/moleditpy/ui/custom_qt_interactor.py
@@ -11,11 +11,10 @@ DOI: 10.5281/zenodo.17268532
 """
 
 import logging
-import time
 from typing import Any, Optional
 
-from PyQt6.QtCore import Qt
-from PyQt6.QtWidgets import QApplication
+from PyQt6.QtCore import QEvent
+from PyQt6.QtGui import QMouseEvent
 from pyvistaqt import QtInteractor
 
 
@@ -30,11 +29,6 @@ class CustomQtInteractor(QtInteractor):
     ) -> None:
         super().__init__(parent, **kwargs)
         self.main_window = main_window
-        self._last_click_time = 0.0
-        self._click_count = 0
-        # Buttons whose press was swallowed; their release must be swallowed
-        # too so VTK never sees an unpaired press/release.
-        self._swallowed_buttons: set = set()
 
     def wheelEvent(self, event: Any) -> None:
         """
@@ -50,66 +44,32 @@ class CustomQtInteractor(QtInteractor):
     def mouseReleaseEvent(self, event: Any) -> None:
         """
         Override the Qt mouse release event to return focus to the 2D view after
-        all 3D view operations. Also swallows the release of any press that was
-        swallowed, so VTK never receives an unpaired release.
+        all 3D view operations.
         """
-        if event.button() in self._swallowed_buttons:
-            self._swallowed_buttons.discard(event.button())
-            event.accept()
-            return
-
         super().mouseReleaseEvent(event)  # Process parent class event first
         if self.main_window and hasattr(self.main_window.init_manager, "view_2d"):
             self.main_window.init_manager.view_2d.setFocus()
 
-    def mousePressEvent(self, event: Any) -> None:
-        """
-        Custom mouse press handling to track accumulated left-clicks and filter
-        out triple-clicks (rapid clicking desyncs VTK's internal state).
-        """
-        if event.button() == Qt.MouseButton.LeftButton:
-            current_time = time.time()
-            # Reset count if too much time has passed (0.5s is standard double-click time)
-            if current_time - self._last_click_time > 0.5:
-                self._click_count = 0
-
-            self._click_count += 1
-            self._last_click_time = current_time
-
-            # If this is the 3rd click (or more), swallow it to prevent
-            # the internal state desync that happens with rapid clicking sequences.
-            if self._click_count >= 3:
-                self._swallowed_buttons.add(event.button())
-                event.accept()
-                return
-
-        super().mousePressEvent(event)
-
     def mouseDoubleClickEvent(self, event: Any) -> None:
-        """Ignore mouse double-clicks on the 3D widget to avoid accidental actions.
+        """Re-dispatch double-clicks as plain presses so fast clicking works.
 
-        Swallow the double-click event so it doesn't trigger selection, editing,
-        or camera jumps. We intentionally do not call the superclass handler.
-        Crucially, the matching release is also swallowed, preventing a "Ghost
-        Release" (Release without Press) from reaching VTK.
+        Qt turns every second fast click into a double-click event. Forwarding
+        it unchanged would reach VTK with a repeat count and be dropped by the
+        interactor style, so the click would be lost (e.g. when rapidly
+        selecting atoms in measurement mode). Synthesizing a normal press keeps
+        press/release pairing intact and makes each fast click act as a click.
         """
-        self._last_click_time = time.time()
-        self._click_count = 2  # The next fast click counts as the 3rd
-        self._swallowed_buttons.add(event.button())
-
         try:
-            # Accept the event to mark it handled and prevent further processing.
+            synthetic_press = QMouseEvent(
+                QEvent.Type.MouseButtonPress,
+                event.position(),
+                event.globalPosition(),
+                event.button(),
+                event.buttons(),
+                event.modifiers(),
+            )
+            super().mousePressEvent(synthetic_press)
             event.accept()
-        except (AttributeError, RuntimeError, TypeError):
-            # If event doesn't support accept for some reason, just return.
-            return
-
-    def leaveEvent(self, event: Any) -> None:
-        """Clear stale swallow latches when the pointer leaves with no button held."""
-        try:
-            if QApplication.mouseButtons() == Qt.MouseButton.NoButton:
-                self._swallowed_buttons.clear()
         except (AttributeError, RuntimeError, TypeError):
             # Safe defensive fallback catching AttributeError, RuntimeError, TypeError
             logging.debug("Suppressed non-critical error", exc_info=True)
-        super().leaveEvent(event)

--- a/moleditpy/src/moleditpy/ui/custom_qt_interactor.py
+++ b/moleditpy/src/moleditpy/ui/custom_qt_interactor.py
@@ -10,9 +10,12 @@ Repo: https://github.com/HiroYokoyama/python_molecular_editor
 DOI: 10.5281/zenodo.17268532
 """
 
+import logging
 import time
 from typing import Any, Optional
 
+from PyQt6.QtCore import Qt
+from PyQt6.QtWidgets import QApplication
 from pyvistaqt import QtInteractor
 
 
@@ -29,7 +32,9 @@ class CustomQtInteractor(QtInteractor):
         self.main_window = main_window
         self._last_click_time = 0.0
         self._click_count = 0
-        self._ignore_next_release = False
+        # Buttons whose press was swallowed; their release must be swallowed
+        # too so VTK never sees an unpaired press/release.
+        self._swallowed_buttons: set = set()
 
     def wheelEvent(self, event: Any) -> None:
         """
@@ -45,11 +50,11 @@ class CustomQtInteractor(QtInteractor):
     def mouseReleaseEvent(self, event: Any) -> None:
         """
         Override the Qt mouse release event to return focus to the 2D view after
-        all 3D view operations. Also filters out "Ghost Release" (release without
-        a corresponding press).
+        all 3D view operations. Also swallows the release of any press that was
+        swallowed, so VTK never receives an unpaired release.
         """
-        if self._ignore_next_release:
-            self._ignore_next_release = False
+        if event.button() in self._swallowed_buttons:
+            self._swallowed_buttons.discard(event.button())
             event.accept()
             return
 
@@ -59,23 +64,24 @@ class CustomQtInteractor(QtInteractor):
 
     def mousePressEvent(self, event: Any) -> None:
         """
-        Custom mouse press handling to track accumulated clicks and filter out
-        triple-clicks.
+        Custom mouse press handling to track accumulated left-clicks and filter
+        out triple-clicks (rapid clicking desyncs VTK's internal state).
         """
-        current_time = time.time()
-        # Reset count if too much time has passed (0.5s is standard double-click time)
-        if current_time - self._last_click_time > 0.5:
-            self._click_count = 0
+        if event.button() == Qt.MouseButton.LeftButton:
+            current_time = time.time()
+            # Reset count if too much time has passed (0.5s is standard double-click time)
+            if current_time - self._last_click_time > 0.5:
+                self._click_count = 0
 
-        self._click_count += 1
-        self._last_click_time = current_time
+            self._click_count += 1
+            self._last_click_time = current_time
 
-        # If this is the 3rd click (or more), swallow it to prevent
-        # the internal state desync that happens with rapid clicking sequences.
-        if self._click_count >= 3:
-            self._ignore_next_release = True
-            event.accept()
-            return
+            # If this is the 3rd click (or more), swallow it to prevent
+            # the internal state desync that happens with rapid clicking sequences.
+            if self._click_count >= 3:
+                self._swallowed_buttons.add(event.button())
+                event.accept()
+                return
 
         super().mousePressEvent(event)
 
@@ -84,18 +90,12 @@ class CustomQtInteractor(QtInteractor):
 
         Swallow the double-click event so it doesn't trigger selection, editing,
         or camera jumps. We intentionally do not call the superclass handler.
-        Crucially, we also flag the NEXT release event to be swallowed, preventing
-        a "Ghost Release" (Release without Press) from reaching VTK.
+        Crucially, the matching release is also swallowed, preventing a "Ghost
+        Release" (Release without Press) from reaching VTK.
         """
-        current_time = time.time()
-        self._last_click_time = current_time
-        # Set to 2 to ensure the next click counts as 3rd
-        if current_time - self._last_click_time < 0.5:
-            self._click_count = 2
-        else:
-            self._click_count = 2  # Force sync
-
-        self._ignore_next_release = True
+        self._last_click_time = time.time()
+        self._click_count = 2  # The next fast click counts as the 3rd
+        self._swallowed_buttons.add(event.button())
 
         try:
             # Accept the event to mark it handled and prevent further processing.
@@ -103,3 +103,13 @@ class CustomQtInteractor(QtInteractor):
         except (AttributeError, RuntimeError, TypeError):
             # If event doesn't support accept for some reason, just return.
             return
+
+    def leaveEvent(self, event: Any) -> None:
+        """Clear stale swallow latches when the pointer leaves with no button held."""
+        try:
+            if QApplication.mouseButtons() == Qt.MouseButton.NoButton:
+                self._swallowed_buttons.clear()
+        except (AttributeError, RuntimeError, TypeError):
+            # Safe defensive fallback catching AttributeError, RuntimeError, TypeError
+            logging.debug("Suppressed non-critical error", exc_info=True)
+        super().leaveEvent(event)

--- a/moleditpy/src/moleditpy/ui/custom_qt_interactor.py
+++ b/moleditpy/src/moleditpy/ui/custom_qt_interactor.py
@@ -11,10 +11,11 @@ DOI: 10.5281/zenodo.17268532
 """
 
 import logging
+import time
 from typing import Any, Optional
 
-from PyQt6.QtCore import QEvent
-from PyQt6.QtGui import QMouseEvent
+from PyQt6.QtCore import Qt
+from PyQt6.QtWidgets import QApplication
 from pyvistaqt import QtInteractor
 
 
@@ -29,6 +30,11 @@ class CustomQtInteractor(QtInteractor):
     ) -> None:
         super().__init__(parent, **kwargs)
         self.main_window = main_window
+        self._last_click_time = 0.0
+        self._click_count = 0
+        # Buttons whose press was swallowed; their release must be swallowed
+        # too so VTK never sees an unpaired press/release.
+        self._swallowed_buttons: set = set()
 
     def wheelEvent(self, event: Any) -> None:
         """
@@ -44,32 +50,66 @@ class CustomQtInteractor(QtInteractor):
     def mouseReleaseEvent(self, event: Any) -> None:
         """
         Override the Qt mouse release event to return focus to the 2D view after
-        all 3D view operations.
+        all 3D view operations. Also swallows the release of any press that was
+        swallowed, so VTK never receives an unpaired release.
         """
+        if event.button() in self._swallowed_buttons:
+            self._swallowed_buttons.discard(event.button())
+            event.accept()
+            return
+
         super().mouseReleaseEvent(event)  # Process parent class event first
         if self.main_window and hasattr(self.main_window.init_manager, "view_2d"):
             self.main_window.init_manager.view_2d.setFocus()
 
-    def mouseDoubleClickEvent(self, event: Any) -> None:
-        """Re-dispatch double-clicks as plain presses so fast clicking works.
-
-        Qt turns every second fast click into a double-click event. Forwarding
-        it unchanged would reach VTK with a repeat count and be dropped by the
-        interactor style, so the click would be lost (e.g. when rapidly
-        selecting atoms in measurement mode). Synthesizing a normal press keeps
-        press/release pairing intact and makes each fast click act as a click.
+    def mousePressEvent(self, event: Any) -> None:
         """
+        Custom mouse press handling to track accumulated left-clicks and filter
+        out triple-clicks (rapid clicking desyncs VTK's internal state).
+        """
+        if event.button() == Qt.MouseButton.LeftButton:
+            current_time = time.time()
+            # Reset count if too much time has passed (0.5s is standard double-click time)
+            if current_time - self._last_click_time > 0.5:
+                self._click_count = 0
+
+            self._click_count += 1
+            self._last_click_time = current_time
+
+            # If this is the 3rd click (or more), swallow it to prevent
+            # the internal state desync that happens with rapid clicking sequences.
+            if self._click_count >= 3:
+                self._swallowed_buttons.add(event.button())
+                event.accept()
+                return
+
+        super().mousePressEvent(event)
+
+    def mouseDoubleClickEvent(self, event: Any) -> None:
+        """Ignore mouse double-clicks on the 3D widget to avoid accidental actions.
+
+        Swallow the double-click event so it doesn't trigger selection, editing,
+        or camera jumps. We intentionally do not call the superclass handler.
+        Crucially, the matching release is also swallowed, preventing a "Ghost
+        Release" (Release without Press) from reaching VTK.
+        """
+        self._last_click_time = time.time()
+        self._click_count = 2  # The next fast click counts as the 3rd
+        self._swallowed_buttons.add(event.button())
+
         try:
-            synthetic_press = QMouseEvent(
-                QEvent.Type.MouseButtonPress,
-                event.position(),
-                event.globalPosition(),
-                event.button(),
-                event.buttons(),
-                event.modifiers(),
-            )
-            super().mousePressEvent(synthetic_press)
+            # Accept the event to mark it handled and prevent further processing.
             event.accept()
+        except (AttributeError, RuntimeError, TypeError):
+            # If event doesn't support accept for some reason, just return.
+            return
+
+    def leaveEvent(self, event: Any) -> None:
+        """Clear stale swallow latches when the pointer leaves with no button held."""
+        try:
+            if QApplication.mouseButtons() == Qt.MouseButton.NoButton:
+                self._swallowed_buttons.clear()
         except (AttributeError, RuntimeError, TypeError):
             # Safe defensive fallback catching AttributeError, RuntimeError, TypeError
             logging.debug("Suppressed non-critical error", exc_info=True)
+        super().leaveEvent(event)

--- a/moleditpy/src/moleditpy/ui/dialog_3d_picking_mixin.py
+++ b/moleditpy/src/moleditpy/ui/dialog_3d_picking_mixin.py
@@ -82,9 +82,8 @@ class Dialog3DPickingMixin:
                             try:
                                 self.on_atom_picked(int(closest_atom_idx))
                             except (AttributeError, RuntimeError):
-                                # Safe defensive fallback catching AttributeError, RuntimeError
-                                logging.debug(
-                                    "Suppressed non-critical error", exc_info=True
+                                logging.warning(
+                                    "Dialog atom pick failed", exc_info=True
                                 )
 
                         from PyQt6.QtCore import QTimer

--- a/moleditpy/src/moleditpy/ui/move_selected_atoms_dialog.py
+++ b/moleditpy/src/moleditpy/ui/move_selected_atoms_dialog.py
@@ -696,9 +696,13 @@ class MoveSelectedAtomsDialog(BasePickingDialog):
         else:
             btn.setText("Box Selection: OFF")
             plotter.disable_picking()
-            # Restore original style
+            # Restore original style via pyvista's bookkeeping so its
+            # update_style() re-asserts ours instead of RubberBandPick
             if self.original_style is not None:
-                plotter.interactor.SetInteractorStyle(self.original_style)
+                try:
+                    plotter.iren.style = self.original_style
+                except AttributeError:
+                    plotter.interactor.SetInteractorStyle(self.original_style)
 
     def on_rectangle_picked(self, selection: Any) -> None:
         """Handle PyVista rectangle picking callback."""

--- a/moleditpy/src/moleditpy/ui/ui_manager.py
+++ b/moleditpy/src/moleditpy/ui/ui_manager.py
@@ -325,6 +325,33 @@ class UIManager(QObject):
         self.host.view_3d_manager.plotter.interactor.SetInteractorStyle(style)
         self.host.view_3d_manager.plotter.interactor.Initialize()
 
+        # Watchdog: if anything silently replaces the custom style (observed as
+        # "rotation works but pick/select is dead"), report it and reinstall.
+        self._expected_style = style
+        self._style_watchdog = QTimer(self)
+        self._style_watchdog.setInterval(2000)
+        self._style_watchdog.timeout.connect(self._check_interactor_style)
+        self._style_watchdog.start()
+
+    def _check_interactor_style(self) -> None:
+        """Reinstall CustomInteractorStyle if it was silently replaced."""
+        try:
+            interactor = self.host.view_3d_manager.plotter.interactor
+            current = interactor.GetInteractorStyle()
+            if current is self._expected_style:
+                return
+            name = type(current).__name__
+            if "RubberBand" in name:  # legitimate temporary box-selection style
+                return
+            logging.warning(
+                "3D interactor style was replaced by %s — reinstalling "
+                "CustomInteractorStyle",
+                name,
+            )
+            interactor.SetInteractorStyle(self._expected_style)
+        except (AttributeError, RuntimeError):
+            logging.debug("Style watchdog check failed", exc_info=True)
+
     def handle_drag_enter_event(self, event: QDragEnterEvent) -> None:
         """Internal handler for drag enter event (bypasses PyQt type checks in tests)."""
         mime_data = event.mimeData()

--- a/moleditpy/src/moleditpy/ui/ui_manager.py
+++ b/moleditpy/src/moleditpy/ui/ui_manager.py
@@ -322,7 +322,7 @@ class UIManager(QObject):
         style = CustomInteractorStyle(self.host)
 
         # Set interactor style
-        self.host.view_3d_manager.plotter.interactor.SetInteractorStyle(style)
+        self._install_interactor_style(style)
         self.host.view_3d_manager.plotter.interactor.Initialize()
 
         # Watchdog: if anything silently replaces the custom style (observed as
@@ -332,6 +332,21 @@ class UIManager(QObject):
         self._style_watchdog.setInterval(2000)
         self._style_watchdog.timeout.connect(self._check_interactor_style)
         self._style_watchdog.start()
+
+    def _install_interactor_style(self, style: Any) -> None:
+        """Install *style* through pyvista's bookkeeping, not raw VTK.
+
+        pyvista's RenderWindowInteractor re-asserts its own ``_style_class``
+        via ``update_style()`` whenever its built-in double-click chart
+        handler fires (fast clicks!). Installing through the ``iren.style``
+        property keeps that bookkeeping pointing at our style so the
+        re-assert is a no-op instead of an eviction.
+        """
+        plotter = self.host.view_3d_manager.plotter
+        try:
+            plotter.iren.style = style
+        except AttributeError:
+            plotter.interactor.SetInteractorStyle(style)
 
     def _check_interactor_style(self) -> None:
         """Reinstall CustomInteractorStyle if it was silently replaced."""
@@ -343,12 +358,12 @@ class UIManager(QObject):
             name = type(current).__name__
             if "RubberBand" in name:  # legitimate temporary box-selection style
                 return
-            logging.warning(
+            logging.debug(
                 "3D interactor style was replaced by %s — reinstalling "
                 "CustomInteractorStyle",
                 name,
             )
-            interactor.SetInteractorStyle(self._expected_style)
+            self._install_interactor_style(self._expected_style)
         except (AttributeError, RuntimeError):
             logging.debug("Style watchdog check failed", exc_info=True)
 

--- a/tests/assertion_catalog.md
+++ b/tests/assertion_catalog.md
@@ -1421,6 +1421,28 @@ _Verify that clicking outside selection in MoveSelectedAtomsDialog toggles only 
 - mock_timer.assert_called_once()
 - mock_dialog.on_atom_picked.assert_called_once_with(1)
 
+### test_heal_resets_stuck_atom_drag_when_left_button_not_held
+_A lost release must not leave _is_dragging_atom stuck when no button is held._
+
+- assert interactor_style._is_dragging_atom is False
+
+### test_heal_resets_stuck_camera_state_when_no_button_held
+_A stuck VTK ROTATE/PAN state with no button held must be stopped._
+
+- interactor_style.StopState.assert_called()
+
+### test_heal_keeps_active_drag_while_left_button_held
+_A genuine in-progress atom drag must not be reset._
+
+- assert interactor_style._is_dragging_atom is True
+- interactor_style.StopState.assert_not_called()
+
+### test_heal_clears_stuck_move_group_drag_flags
+_Stuck Move Group drag/rotate latches are cleared when buttons are not held._
+
+- assert mock_dialog.is_dragging_group_vtk is False
+- assert mock_dialog.is_rotating_group_vtk is False
+
 ### test_custom_interactor_style_right_click_rotation
 _Verify right-click triggers group rotation and release finalizes it._
 
@@ -1433,6 +1455,25 @@ _Verify right-click triggers group rotation and release finalizes it._
 - assert mock_dialog.is_rotating_group_vtk is False
 - assert mock_dialog.rotation_start_pos is None
 - mock_parser_host.view_3d_manager.draw_molecule_3d.assert_called_once()
+
+## tests/unit/test_custom_qt_interactor.py
+
+### test_double_click_redispatched_as_plain_press
+_No description provided._
+
+- assert mock_press.call_count == 1
+- assert forwarded.type() == QEvent.Type.MouseButtonPress
+- assert forwarded.button() == Qt.MouseButton.LeftButton
+
+### test_fast_consecutive_presses_all_pass_through
+_No description provided._
+
+- assert mock_press.call_count == 4
+
+### test_release_passes_through_unconditionally
+_No description provided._
+
+- assert mock_release.call_count == 2
 
 ## tests/unit/test_dialog_3d_picking_mixin.py
 
@@ -4167,6 +4208,13 @@ _Test that the Box Selection toggle enables/disables rectangle picking._
 _Test that a single click clears the selection when Box Selection is ON._
 
 - mock_clear.assert_called_once()
+
+### test_box_selection_off_restores_style_via_pyvista
+_Restore must go through iren.style so pyvista bookkeeping tracks it._
+
+- plotter.disable_picking.assert_called_once()
+- assert plotter.iren.style is sentinel
+- plotter.interactor.SetInteractorStyle.assert_not_called()
 
 ## tests/unit/test_optimization_method_restore.py
 
@@ -6980,6 +7028,32 @@ _Test that set_mode handles template preview visibility._
 
 - assert ui.host.init_manager.scene.mode == 'atom_C'
 - assert ui.host.init_manager.scene.template_preview.hide.called
+
+### test_install_interactor_style_registers_via_pyvista
+_Style must go through iren.style so pyvista's update_style() keeps it._
+
+- assert plotter.iren.style is style
+- plotter.interactor.SetInteractorStyle.assert_not_called()
+
+### test_install_interactor_style_falls_back_to_raw_vtk
+_No description provided._
+
+- plotter.interactor.SetInteractorStyle.assert_called_once_with(style)
+
+### test_style_watchdog_reinstalls_replaced_style
+_A style evicted by pyvista (e.g. its double-click chart handler) is reinstalled._
+
+- assert plotter.iren.style is expected
+
+### test_style_watchdog_keeps_installed_style
+_No description provided._
+
+- assert plotter.iren.style is not expected
+
+### test_style_watchdog_ignores_rubberband_style
+_pyvista's temporary box-selection style must not be fought by the watchdog._
+
+- assert plotter.iren.style is not ui._expected_style
 
 ## tests/unit/test_utils_sip.py
 

--- a/tests/coverage_report.md
+++ b/tests/coverage_report.md
@@ -1,13 +1,13 @@
 # MoleditPy Coverage Report
 
-- **Overall Project Coverage**: **83.08%**
+- **Overall Project Coverage**: **83.28%**
 
 ### Coverage Breakdown
 
 | File | Stmts | Miss | Cover |
 | :--- | :--- | :--- | :--- |
 | moleditpy\src\moleditpy\__init__.py                     |      6 |      2 |   66.7% |
-| moleditpy\src\moleditpy\main.py                         |    170 |     35 |   79.4% |
+| moleditpy\src\moleditpy\main.py                         |    170 |     25 |   85.3% |
 | moleditpy\src\moleditpy\core\mol_geometry.py            |    292 |     43 |   85.3% |
 | moleditpy\src\moleditpy\core\molecular_data.py          |    258 |     28 |   89.1% |
 | moleditpy\src\moleditpy\plugins\plugin_interface.py     |    233 |      6 |   97.4% |
@@ -29,8 +29,8 @@
 | moleditpy\src\moleditpy\ui\color_settings_dialog.py     |    166 |     13 |   92.2% |
 | moleditpy\src\moleditpy\ui\compute_logic.py             |    431 |     87 |   79.8% |
 | moleditpy\src\moleditpy\ui\constrained_optimization_dialog.py |    480 |    114 |   76.2% |
-| moleditpy\src\moleditpy\ui\custom_interactor_style.py   |    470 |    247 |   47.4% |
-| moleditpy\src\moleditpy\ui\custom_qt_interactor.py      |     44 |     30 |   31.8% |
+| moleditpy\src\moleditpy\ui\custom_interactor_style.py   |    499 |    254 |   49.1% |
+| moleditpy\src\moleditpy\ui\custom_qt_interactor.py      |     24 |      6 |   75.0% |
 | moleditpy\src\moleditpy\ui\dialog_3d_picking_mixin.py   |    137 |     19 |   86.1% |
 | moleditpy\src\moleditpy\ui\dialog_logic.py              |    230 |     25 |   89.1% |
 | moleditpy\src\moleditpy\ui\dihedral_dialog.py           |    268 |     32 |   88.1% |
@@ -45,7 +45,7 @@
 | moleditpy\src\moleditpy\ui\molecular_scene_handler.py   |    999 |    156 |   84.4% |
 | moleditpy\src\moleditpy\ui\molecule_scene.py            |    614 |    118 |   80.8% |
 | moleditpy\src\moleditpy\ui\move_group_dialog.py         |    386 |    130 |   66.3% |
-| moleditpy\src\moleditpy\ui\move_selected_atoms_dialog.py |    461 |     75 |   83.7% |
+| moleditpy\src\moleditpy\ui\move_selected_atoms_dialog.py |    464 |     77 |   83.4% |
 | moleditpy\src\moleditpy\ui\periodic_table_dialog.py     |     37 |      2 |   94.6% |
 | moleditpy\src\moleditpy\ui\planarize_dialog.py          |    112 |      9 |   92.0% |
 | moleditpy\src\moleditpy\ui\plugin_menu_manager.py       |    287 |     46 |   84.0% |
@@ -54,7 +54,7 @@
 | moleditpy\src\moleditpy\ui\template_preview_item.py     |    102 |      3 |   97.1% |
 | moleditpy\src\moleditpy\ui\template_preview_view.py     |     46 |      4 |   91.3% |
 | moleditpy\src\moleditpy\ui\translation_dialog.py        |    276 |     21 |   92.4% |
-| moleditpy\src\moleditpy\ui\ui_manager.py                |    371 |     97 |   73.9% |
+| moleditpy\src\moleditpy\ui\ui_manager.py                |    395 |     97 |   75.4% |
 | moleditpy\src\moleditpy\ui\user_template_dialog.py      |    360 |     79 |   78.1% |
 | moleditpy\src\moleditpy\ui\view_3d_logic.py             |   1007 |    255 |   74.7% |
 | moleditpy\src\moleditpy\ui\zoomable_view.py             |     82 |      2 |   97.6% |
@@ -67,7 +67,7 @@
 | moleditpy\src\moleditpy\utils\sip_isdeleted_safe.py     |     19 |      0 |  100.0% |
 | moleditpy\src\moleditpy\utils\suppress_log.py           |     10 |      0 |  100.0% |
 | moleditpy\src\moleditpy\utils\system_utils.py           |     39 |      0 |  100.0% |
-| **TOTAL** | **16151** | **2732** | **83.08%** |
+| **TOTAL** | **16187** | **2707** | **83.28%** |
 
 ## Test Suite Status
 - **Unit tests**: PASSED

--- a/tests/unit/test_custom_interactor_style.py
+++ b/tests/unit/test_custom_interactor_style.py
@@ -213,6 +213,66 @@ def test_custom_interactor_style_move_selected_atoms_no_bfs(app, mock_parser_hos
         mock_dialog.on_atom_picked.assert_called_once_with(1)
 
 
+def test_heal_resets_stuck_atom_drag_when_left_button_not_held(app, mock_parser_host):
+    """A lost release must not leave _is_dragging_atom stuck when no button is held."""
+    interactor_style = CustomInteractorStyle(mock_parser_host)
+    interactor_style.GetState = MagicMock(return_value=0)
+    interactor_style.StopState = MagicMock()
+    interactor_style._is_dragging_atom = True
+
+    with patch("moleditpy.ui.custom_interactor_style.QApplication") as mock_qapp:
+        mock_qapp.mouseButtons.return_value = Qt.MouseButton.NoButton
+        interactor_style._heal_stuck_pointer_state(None)
+
+    assert interactor_style._is_dragging_atom is False
+
+
+def test_heal_resets_stuck_camera_state_when_no_button_held(app, mock_parser_host):
+    """A stuck VTK ROTATE/PAN state with no button held must be stopped."""
+    interactor_style = CustomInteractorStyle(mock_parser_host)
+    interactor_style.GetState = MagicMock(return_value=1)  # VTKIS_ROTATE
+    interactor_style.StopState = MagicMock()
+
+    with patch("moleditpy.ui.custom_interactor_style.QApplication") as mock_qapp:
+        mock_qapp.mouseButtons.return_value = Qt.MouseButton.NoButton
+        interactor_style._heal_stuck_pointer_state(None)
+
+    interactor_style.StopState.assert_called()
+
+
+def test_heal_keeps_active_drag_while_left_button_held(app, mock_parser_host):
+    """A genuine in-progress atom drag must not be reset."""
+    interactor_style = CustomInteractorStyle(mock_parser_host)
+    interactor_style.GetState = MagicMock(return_value=0)
+    interactor_style.StopState = MagicMock()
+    interactor_style._is_dragging_atom = True
+
+    with patch("moleditpy.ui.custom_interactor_style.QApplication") as mock_qapp:
+        mock_qapp.mouseButtons.return_value = Qt.MouseButton.LeftButton
+        interactor_style._heal_stuck_pointer_state(None)
+
+    assert interactor_style._is_dragging_atom is True
+    interactor_style.StopState.assert_not_called()
+
+
+def test_heal_clears_stuck_move_group_drag_flags(app, mock_parser_host):
+    """Stuck Move Group drag/rotate latches are cleared when buttons are not held."""
+    interactor_style = CustomInteractorStyle(mock_parser_host)
+    interactor_style.GetState = MagicMock(return_value=0)
+    interactor_style.StopState = MagicMock()
+
+    mock_dialog = MagicMock()
+    mock_dialog.is_dragging_group_vtk = True
+    mock_dialog.is_rotating_group_vtk = True
+
+    with patch("moleditpy.ui.custom_interactor_style.QApplication") as mock_qapp:
+        mock_qapp.mouseButtons.return_value = Qt.MouseButton.NoButton
+        interactor_style._heal_stuck_pointer_state(mock_dialog)
+
+    assert mock_dialog.is_dragging_group_vtk is False
+    assert mock_dialog.is_rotating_group_vtk is False
+
+
 def test_custom_interactor_style_right_click_rotation(app, mock_parser_host):
     """Verify right-click triggers group rotation and release finalizes it."""
     interactor_style = CustomInteractorStyle(mock_parser_host)

--- a/tests/unit/test_custom_qt_interactor.py
+++ b/tests/unit/test_custom_qt_interactor.py
@@ -1,0 +1,111 @@
+"""Unit tests for CustomQtInteractor fast-click swallow pairing."""
+
+from unittest.mock import MagicMock, patch
+
+from PyQt6.QtCore import Qt
+
+from moleditpy.ui.custom_qt_interactor import CustomQtInteractor
+
+_BASE = CustomQtInteractor.__mro__[1]
+
+
+def _make_widget():
+    widget = CustomQtInteractor(main_window=None)
+    widget._click_count = 0
+    widget._last_click_time = 0.0
+    widget._swallowed_buttons = set()
+    return widget
+
+
+def _event(button=Qt.MouseButton.LeftButton):
+    event = MagicMock()
+    event.button.return_value = button
+    return event
+
+
+def test_third_fast_left_click_and_its_release_are_swallowed(app):
+    widget = _make_widget()
+    with (
+        patch.object(_BASE, "mousePressEvent", create=True) as mock_press,
+        patch.object(_BASE, "mouseReleaseEvent", create=True) as mock_release,
+    ):
+        widget.mousePressEvent(_event())
+        widget.mousePressEvent(_event())
+        third = _event()
+        widget.mousePressEvent(third)
+
+        assert mock_press.call_count == 2
+        third.accept.assert_called_once()
+        assert Qt.MouseButton.LeftButton in widget._swallowed_buttons
+
+        # The paired release is swallowed exactly once
+        widget.mouseReleaseEvent(_event())
+        mock_release.assert_not_called()
+        assert Qt.MouseButton.LeftButton not in widget._swallowed_buttons
+
+        # The next release passes through again
+        widget.mouseReleaseEvent(_event())
+        assert mock_release.call_count == 1
+
+
+def test_double_click_swallows_press_release_pair(app):
+    widget = _make_widget()
+    with patch.object(_BASE, "mouseReleaseEvent", create=True) as mock_release:
+        event = _event()
+        widget.mouseDoubleClickEvent(event)
+
+        event.accept.assert_called_once()
+        assert widget._click_count == 2
+        assert Qt.MouseButton.LeftButton in widget._swallowed_buttons
+
+        widget.mouseReleaseEvent(_event())
+        mock_release.assert_not_called()
+        assert not widget._swallowed_buttons
+
+
+def test_right_click_not_counted_toward_triple_click_filter(app):
+    widget = _make_widget()
+    with patch.object(_BASE, "mousePressEvent", create=True) as mock_press:
+        widget.mousePressEvent(_event())
+        widget.mousePressEvent(_event())
+        widget.mousePressEvent(_event(Qt.MouseButton.RightButton))
+
+        assert mock_press.call_count == 3
+        assert not widget._swallowed_buttons
+
+
+def test_release_of_other_button_passes_while_left_latched(app):
+    widget = _make_widget()
+    widget._swallowed_buttons = {Qt.MouseButton.LeftButton}
+    with patch.object(_BASE, "mouseReleaseEvent", create=True) as mock_release:
+        widget.mouseReleaseEvent(_event(Qt.MouseButton.RightButton))
+
+        assert mock_release.call_count == 1
+        assert Qt.MouseButton.LeftButton in widget._swallowed_buttons
+
+
+def test_leave_event_clears_stale_latches_when_no_button_held(app):
+    widget = _make_widget()
+    widget._swallowed_buttons = {Qt.MouseButton.LeftButton}
+    with (
+        patch.object(_BASE, "leaveEvent", create=True) as mock_leave,
+        patch("moleditpy.ui.custom_qt_interactor.QApplication") as mock_qapp,
+    ):
+        mock_qapp.mouseButtons.return_value = Qt.MouseButton.NoButton
+        widget.leaveEvent(MagicMock())
+
+        assert not widget._swallowed_buttons
+        mock_leave.assert_called_once()
+
+
+def test_leave_event_keeps_latches_while_button_held(app):
+    widget = _make_widget()
+    widget._swallowed_buttons = {Qt.MouseButton.LeftButton}
+    with (
+        patch.object(_BASE, "leaveEvent", create=True),
+        patch("moleditpy.ui.custom_qt_interactor.QApplication") as mock_qapp,
+    ):
+        mock_qapp.mouseButtons.return_value = Qt.MouseButton.LeftButton
+        widget.leaveEvent(MagicMock())
+
+        assert Qt.MouseButton.LeftButton in widget._swallowed_buttons

--- a/tests/unit/test_custom_qt_interactor.py
+++ b/tests/unit/test_custom_qt_interactor.py
@@ -1,9 +1,8 @@
-"""Unit tests for CustomQtInteractor fast-click handling."""
+"""Unit tests for CustomQtInteractor fast-click swallow pairing."""
 
 from unittest.mock import MagicMock, patch
 
-from PyQt6.QtCore import QEvent, QPointF, Qt
-from PyQt6.QtGui import QMouseEvent
+from PyQt6.QtCore import Qt
 
 from moleditpy.ui.custom_qt_interactor import CustomQtInteractor
 
@@ -11,44 +10,102 @@ _BASE = CustomQtInteractor.__mro__[1]
 
 
 def _make_widget():
-    return CustomQtInteractor(main_window=None)
+    widget = CustomQtInteractor(main_window=None)
+    widget._click_count = 0
+    widget._last_click_time = 0.0
+    widget._swallowed_buttons = set()
+    return widget
 
 
-def _double_click_event():
-    return QMouseEvent(
-        QEvent.Type.MouseButtonDblClick,
-        QPointF(10.0, 10.0),
-        QPointF(10.0, 10.0),
-        Qt.MouseButton.LeftButton,
-        Qt.MouseButton.LeftButton,
-        Qt.KeyboardModifier.NoModifier,
-    )
+def _event(button=Qt.MouseButton.LeftButton):
+    event = MagicMock()
+    event.button.return_value = button
+    return event
 
 
-def test_double_click_redispatched_as_plain_press(app):
+def test_third_fast_left_click_and_its_release_are_swallowed(app):
     widget = _make_widget()
-    with patch.object(_BASE, "mousePressEvent", create=True) as mock_press:
-        widget.mouseDoubleClickEvent(_double_click_event())
+    with (
+        patch.object(_BASE, "mousePressEvent", create=True) as mock_press,
+        patch.object(_BASE, "mouseReleaseEvent", create=True) as mock_release,
+    ):
+        widget.mousePressEvent(_event())
+        widget.mousePressEvent(_event())
+        third = _event()
+        widget.mousePressEvent(third)
 
-        assert mock_press.call_count == 1
-        forwarded = mock_press.call_args[0][0]
-        assert forwarded.type() == QEvent.Type.MouseButtonPress
-        assert forwarded.button() == Qt.MouseButton.LeftButton
+        assert mock_press.call_count == 2
+        third.accept.assert_called_once()
+        assert Qt.MouseButton.LeftButton in widget._swallowed_buttons
+
+        # The paired release is swallowed exactly once
+        widget.mouseReleaseEvent(_event())
+        mock_release.assert_not_called()
+        assert Qt.MouseButton.LeftButton not in widget._swallowed_buttons
+
+        # The next release passes through again
+        widget.mouseReleaseEvent(_event())
+        assert mock_release.call_count == 1
 
 
-def test_fast_consecutive_presses_all_pass_through(app):
-    widget = _make_widget()
-    with patch.object(_BASE, "mousePressEvent", create=True) as mock_press:
-        for _ in range(4):
-            widget.mousePressEvent(MagicMock())
-
-        assert mock_press.call_count == 4
-
-
-def test_release_passes_through_unconditionally(app):
+def test_double_click_swallows_press_release_pair(app):
     widget = _make_widget()
     with patch.object(_BASE, "mouseReleaseEvent", create=True) as mock_release:
-        widget.mouseReleaseEvent(MagicMock())
-        widget.mouseReleaseEvent(MagicMock())
+        event = _event()
+        widget.mouseDoubleClickEvent(event)
 
-        assert mock_release.call_count == 2
+        event.accept.assert_called_once()
+        assert widget._click_count == 2
+        assert Qt.MouseButton.LeftButton in widget._swallowed_buttons
+
+        widget.mouseReleaseEvent(_event())
+        mock_release.assert_not_called()
+        assert not widget._swallowed_buttons
+
+
+def test_right_click_not_counted_toward_triple_click_filter(app):
+    widget = _make_widget()
+    with patch.object(_BASE, "mousePressEvent", create=True) as mock_press:
+        widget.mousePressEvent(_event())
+        widget.mousePressEvent(_event())
+        widget.mousePressEvent(_event(Qt.MouseButton.RightButton))
+
+        assert mock_press.call_count == 3
+        assert not widget._swallowed_buttons
+
+
+def test_release_of_other_button_passes_while_left_latched(app):
+    widget = _make_widget()
+    widget._swallowed_buttons = {Qt.MouseButton.LeftButton}
+    with patch.object(_BASE, "mouseReleaseEvent", create=True) as mock_release:
+        widget.mouseReleaseEvent(_event(Qt.MouseButton.RightButton))
+
+        assert mock_release.call_count == 1
+        assert Qt.MouseButton.LeftButton in widget._swallowed_buttons
+
+
+def test_leave_event_clears_stale_latches_when_no_button_held(app):
+    widget = _make_widget()
+    widget._swallowed_buttons = {Qt.MouseButton.LeftButton}
+    with (
+        patch.object(_BASE, "leaveEvent", create=True) as mock_leave,
+        patch("moleditpy.ui.custom_qt_interactor.QApplication") as mock_qapp,
+    ):
+        mock_qapp.mouseButtons.return_value = Qt.MouseButton.NoButton
+        widget.leaveEvent(MagicMock())
+
+        assert not widget._swallowed_buttons
+        mock_leave.assert_called_once()
+
+
+def test_leave_event_keeps_latches_while_button_held(app):
+    widget = _make_widget()
+    widget._swallowed_buttons = {Qt.MouseButton.LeftButton}
+    with (
+        patch.object(_BASE, "leaveEvent", create=True),
+        patch("moleditpy.ui.custom_qt_interactor.QApplication") as mock_qapp,
+    ):
+        mock_qapp.mouseButtons.return_value = Qt.MouseButton.LeftButton
+        widget.leaveEvent(MagicMock())
+
+        assert Qt.MouseButton.LeftButton in widget._swallowed_buttons

--- a/tests/unit/test_custom_qt_interactor.py
+++ b/tests/unit/test_custom_qt_interactor.py
@@ -1,8 +1,9 @@
-"""Unit tests for CustomQtInteractor fast-click swallow pairing."""
+"""Unit tests for CustomQtInteractor fast-click handling."""
 
 from unittest.mock import MagicMock, patch
 
-from PyQt6.QtCore import Qt
+from PyQt6.QtCore import QEvent, QPointF, Qt
+from PyQt6.QtGui import QMouseEvent
 
 from moleditpy.ui.custom_qt_interactor import CustomQtInteractor
 
@@ -10,102 +11,44 @@ _BASE = CustomQtInteractor.__mro__[1]
 
 
 def _make_widget():
-    widget = CustomQtInteractor(main_window=None)
-    widget._click_count = 0
-    widget._last_click_time = 0.0
-    widget._swallowed_buttons = set()
-    return widget
+    return CustomQtInteractor(main_window=None)
 
 
-def _event(button=Qt.MouseButton.LeftButton):
-    event = MagicMock()
-    event.button.return_value = button
-    return event
+def _double_click_event():
+    return QMouseEvent(
+        QEvent.Type.MouseButtonDblClick,
+        QPointF(10.0, 10.0),
+        QPointF(10.0, 10.0),
+        Qt.MouseButton.LeftButton,
+        Qt.MouseButton.LeftButton,
+        Qt.KeyboardModifier.NoModifier,
+    )
 
 
-def test_third_fast_left_click_and_its_release_are_swallowed(app):
-    widget = _make_widget()
-    with (
-        patch.object(_BASE, "mousePressEvent", create=True) as mock_press,
-        patch.object(_BASE, "mouseReleaseEvent", create=True) as mock_release,
-    ):
-        widget.mousePressEvent(_event())
-        widget.mousePressEvent(_event())
-        third = _event()
-        widget.mousePressEvent(third)
-
-        assert mock_press.call_count == 2
-        third.accept.assert_called_once()
-        assert Qt.MouseButton.LeftButton in widget._swallowed_buttons
-
-        # The paired release is swallowed exactly once
-        widget.mouseReleaseEvent(_event())
-        mock_release.assert_not_called()
-        assert Qt.MouseButton.LeftButton not in widget._swallowed_buttons
-
-        # The next release passes through again
-        widget.mouseReleaseEvent(_event())
-        assert mock_release.call_count == 1
-
-
-def test_double_click_swallows_press_release_pair(app):
-    widget = _make_widget()
-    with patch.object(_BASE, "mouseReleaseEvent", create=True) as mock_release:
-        event = _event()
-        widget.mouseDoubleClickEvent(event)
-
-        event.accept.assert_called_once()
-        assert widget._click_count == 2
-        assert Qt.MouseButton.LeftButton in widget._swallowed_buttons
-
-        widget.mouseReleaseEvent(_event())
-        mock_release.assert_not_called()
-        assert not widget._swallowed_buttons
-
-
-def test_right_click_not_counted_toward_triple_click_filter(app):
+def test_double_click_redispatched_as_plain_press(app):
     widget = _make_widget()
     with patch.object(_BASE, "mousePressEvent", create=True) as mock_press:
-        widget.mousePressEvent(_event())
-        widget.mousePressEvent(_event())
-        widget.mousePressEvent(_event(Qt.MouseButton.RightButton))
+        widget.mouseDoubleClickEvent(_double_click_event())
 
-        assert mock_press.call_count == 3
-        assert not widget._swallowed_buttons
+        assert mock_press.call_count == 1
+        forwarded = mock_press.call_args[0][0]
+        assert forwarded.type() == QEvent.Type.MouseButtonPress
+        assert forwarded.button() == Qt.MouseButton.LeftButton
 
 
-def test_release_of_other_button_passes_while_left_latched(app):
+def test_fast_consecutive_presses_all_pass_through(app):
     widget = _make_widget()
-    widget._swallowed_buttons = {Qt.MouseButton.LeftButton}
+    with patch.object(_BASE, "mousePressEvent", create=True) as mock_press:
+        for _ in range(4):
+            widget.mousePressEvent(MagicMock())
+
+        assert mock_press.call_count == 4
+
+
+def test_release_passes_through_unconditionally(app):
+    widget = _make_widget()
     with patch.object(_BASE, "mouseReleaseEvent", create=True) as mock_release:
-        widget.mouseReleaseEvent(_event(Qt.MouseButton.RightButton))
+        widget.mouseReleaseEvent(MagicMock())
+        widget.mouseReleaseEvent(MagicMock())
 
-        assert mock_release.call_count == 1
-        assert Qt.MouseButton.LeftButton in widget._swallowed_buttons
-
-
-def test_leave_event_clears_stale_latches_when_no_button_held(app):
-    widget = _make_widget()
-    widget._swallowed_buttons = {Qt.MouseButton.LeftButton}
-    with (
-        patch.object(_BASE, "leaveEvent", create=True) as mock_leave,
-        patch("moleditpy.ui.custom_qt_interactor.QApplication") as mock_qapp,
-    ):
-        mock_qapp.mouseButtons.return_value = Qt.MouseButton.NoButton
-        widget.leaveEvent(MagicMock())
-
-        assert not widget._swallowed_buttons
-        mock_leave.assert_called_once()
-
-
-def test_leave_event_keeps_latches_while_button_held(app):
-    widget = _make_widget()
-    widget._swallowed_buttons = {Qt.MouseButton.LeftButton}
-    with (
-        patch.object(_BASE, "leaveEvent", create=True),
-        patch("moleditpy.ui.custom_qt_interactor.QApplication") as mock_qapp,
-    ):
-        mock_qapp.mouseButtons.return_value = Qt.MouseButton.LeftButton
-        widget.leaveEvent(MagicMock())
-
-        assert Qt.MouseButton.LeftButton in widget._swallowed_buttons
+        assert mock_release.call_count == 2

--- a/tests/unit/test_move_selected_atoms_dialog.py
+++ b/tests/unit/test_move_selected_atoms_dialog.py
@@ -840,3 +840,23 @@ def test_box_selection_click_to_reset(qapp):
             dlg.eventFilter(interactor, press_ev)
             dlg.eventFilter(interactor, release_ev)
             mock_clear.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Box selection style restore (fast-click freeze root cause)
+# ---------------------------------------------------------------------------
+
+
+def test_box_selection_off_restores_style_via_pyvista(make_dialog):
+    """Restore must go through iren.style so pyvista bookkeeping tracks it."""
+    dlg, _mol, mw = make_dialog()
+    sentinel = object()
+    dlg.original_style = sentinel
+    dlg.widgets["box_select_btn"] = MagicMock()
+    plotter = mw.view_3d_manager.plotter
+
+    dlg.toggle_box_selection(False)
+
+    plotter.disable_picking.assert_called_once()
+    assert plotter.iren.style is sentinel
+    plotter.interactor.SetInteractorStyle.assert_not_called()

--- a/tests/unit/test_ui_manager_robustness.py
+++ b/tests/unit/test_ui_manager_robustness.py
@@ -77,3 +77,80 @@ def test_set_mode_robustness():
     ui.set_mode("atom_C")
     assert ui.host.init_manager.scene.mode == "atom_C"
     assert ui.host.init_manager.scene.template_preview.hide.called
+
+
+# ---------------------------------------------------------------------------
+# Interactor style installation / watchdog (fast-click freeze root cause)
+# ---------------------------------------------------------------------------
+
+
+class _NoIrenPlotter:
+    """Plotter stand-in without pyvista's iren attribute."""
+
+    def __init__(self):
+        self.interactor = MagicMock()
+
+    @property
+    def iren(self):
+        raise AttributeError("no iren")
+
+
+def test_install_interactor_style_registers_via_pyvista():
+    """Style must go through iren.style so pyvista's update_style() keeps it."""
+    ui = _make_ui_manager()
+    style = object()
+
+    ui._install_interactor_style(style)
+
+    plotter = ui.host.view_3d_manager.plotter
+    assert plotter.iren.style is style
+    plotter.interactor.SetInteractorStyle.assert_not_called()
+
+
+def test_install_interactor_style_falls_back_to_raw_vtk():
+    ui = _make_ui_manager()
+    plotter = _NoIrenPlotter()
+    ui.host.view_3d_manager.plotter = plotter
+    style = object()
+
+    ui._install_interactor_style(style)
+
+    plotter.interactor.SetInteractorStyle.assert_called_once_with(style)
+
+
+def test_style_watchdog_reinstalls_replaced_style():
+    """A style evicted by pyvista (e.g. its double-click chart handler) is reinstalled."""
+    ui = _make_ui_manager()
+    expected = object()
+    ui._expected_style = expected
+    plotter = ui.host.view_3d_manager.plotter
+    plotter.interactor.GetInteractorStyle.return_value = MagicMock()
+
+    ui._check_interactor_style()
+
+    assert plotter.iren.style is expected
+
+
+def test_style_watchdog_keeps_installed_style():
+    ui = _make_ui_manager()
+    expected = object()
+    ui._expected_style = expected
+    plotter = ui.host.view_3d_manager.plotter
+    plotter.interactor.GetInteractorStyle.return_value = expected
+
+    ui._check_interactor_style()
+
+    assert plotter.iren.style is not expected  # no reinstall happened
+
+
+def test_style_watchdog_ignores_rubberband_style():
+    """pyvista's temporary box-selection style must not be fought by the watchdog."""
+    ui = _make_ui_manager()
+    ui._expected_style = object()
+    rubber = type("InteractorStyleRubberBandPick", (), {})()
+    plotter = ui.host.view_3d_manager.plotter
+    plotter.interactor.GetInteractorStyle.return_value = rubber
+
+    ui._check_interactor_style()
+
+    assert plotter.iren.style is not ui._expected_style


### PR DESCRIPTION
# fix(3d): fast clicking permanently froze 3D pick/drag/select — root cause fixed

## Summary

- **Fix the long-standing fast-click freeze** (camera rotation kept working but atom pick/drag/select died until app restart). Root cause: pyvista's `RenderWindowInteractor` registers an unconditional double-left-click chart handler (0.8 s / ~6 px window); fast clicks fire it and its unconditional `update_style()` re-asserted pyvista's own `_style_class` (`InteractorStyleTrackballCamera`), silently evicting `CustomInteractorStyle`, which had been installed behind pyvista's back via raw VTK `SetInteractorStyle()`. Styles are now registered through `plotter.iren.style` so pyvista's bookkeeping points at our style and the re-assert is a no-op (raw VTK call kept as fallback; same treatment for the `MoveSelectedAtomsDialog` box-selection restore).
- **Add a 2 s style watchdog** (`UIManager._check_interactor_style`) that reinstalls `CustomInteractorStyle` if anything ever evicts it again (debug-level log as the traceable signal; pyvista's temporary RubberBand box-selection style is exempted).
- **Add mouse-move self-heal** in `CustomInteractorStyle`: stuck drag/rotate state (own flags, VTK state machine, Move Group dialog latches) is force-reset whenever the real `QApplication.mouseButtons()` shows the button is not actually held.
- **Remove the Qt-level double/triple-click swallow filter** in `CustomQtInteractor` — it only masked the pyvista eviction (its 0.5 s window < pyvista's 0.8 s, hence the original *intermittent* freeze) and made rapid atom selection feel dead. Double-clicks are now re-dispatched as synthetic plain presses, so every fast click registers as a real click. Also elevated three silently-swallowed selection-handler exceptions from debug to warning.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation
- [x] Tests
- [ ] CI / build

## Related issues

Fast-click 3D interactor freeze (reported/diagnosed interactively; reproduced in `--safe` mode, so plugin-independent — no issue number).

## Test plan

- [x] Ran `python tests/run_all_tests.py` — all pass (1388 unit + integration)
- [x] Manually tested in the GUI with the check list — fast clicking in measurement and 3D-edit mode no longer freezes; watchdog log confirmed the eviction live and the fix removes it
- [x] Added new unit tests — 7 new tests: pyvista-aware style install + raw-VTK fallback, watchdog reinstall / keep / RubberBand-exempt (`test_ui_manager_robustness.py`), box-selection restore via pyvista bookkeeping (`test_move_selected_atoms_dialog.py`), plus self-heal coverage in `test_custom_interactor_style.py` and double-click re-dispatch in `test_custom_qt_interactor.py`

## Checklist

- [x] `python -m flake8 moleditpy/src/ --select=F` returns 0 issues
- [x] No bare `except:` clauses added (use `except Exception as e:` and log the error)
- [x] No new unused imports or variables
- [x] Plugin API changes are backwards-compatible (or documented in Summary) — no plugin code touches interactor-style APIs (all plugin repos + installed plugins audited); plugin picking uses Qt event filters, unaffected

## Notes for reviewers

- Rule going forward: **never call raw `SetInteractorStyle()` on a pyvista plotter** — always assign through `iren.style`, or pyvista's chart double-click handler will evict the style.
- `moleditpy-linux/` intentionally untouched (synced separately).
- Diagnosis trail (press tracing, pick-miss bbox logging) was added and fully removed during the investigation; the only remaining trace hook is the watchdog's debug-level message.
