### PR TITLE
Dev 4.4.0

### DIFF
--- a/moleditpy/pyproject.toml
+++ b/moleditpy/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "MoleditPy"
 
-version = "4.3.2"
+version = "4.4.0"
 
 license = {file = "LICENSE"}
 

--- a/moleditpy/src/moleditpy/ui/app_state.py
+++ b/moleditpy/src/moleditpy/ui/app_state.py
@@ -420,6 +420,19 @@ class StateManager:
                             # Skip property access if atom data is inconsistent
                             original_id = None
 
+                        # Implicit/explicit H counts raise on an unsanitized mol
+                        # (e.g. an XYZ import whose valences never passed
+                        # sanitization). Default to 0 so the structure still saves
+                        # and round-trips via the binary rather than being dropped.
+                        try:
+                            num_explicit_hs = atom.GetNumExplicitHs()
+                        except (RuntimeError, ValueError):
+                            num_explicit_hs = 0
+                        try:
+                            num_implicit_hs = atom.GetNumImplicitHs()
+                        except (RuntimeError, ValueError):
+                            num_implicit_hs = 0
+
                         atom_3d = {
                             "index": i,
                             "symbol": atom.GetSymbol(),
@@ -428,8 +441,8 @@ class StateManager:
                             "y": pos.y,
                             "z": pos.z,
                             "formal_charge": atom.GetFormalCharge(),
-                            "num_explicit_hs": atom.GetNumExplicitHs(),
-                            "num_implicit_hs": atom.GetNumImplicitHs(),
+                            "num_explicit_hs": num_explicit_hs,
+                            "num_implicit_hs": num_implicit_hs,
                             # include original editor atom id when available for round-trip
                             "original_id": original_id,
                         }
@@ -462,17 +475,21 @@ class StateManager:
                     "constraints_3d": json_safe_constraints,
                 }
 
-                # Molecular info
-                json_data["molecular_info"] = {
-                    "num_atoms": self.host.view_3d_manager.current_mol.GetNumAtoms(),
-                    "num_bonds": self.host.view_3d_manager.current_mol.GetNumBonds(),
-                    "molecular_weight": Descriptors.MolWt(
-                        self.host.view_3d_manager.current_mol
-                    ),
-                    "formula": rdMolDescriptors.CalcMolFormula(
-                        self.host.view_3d_manager.current_mol
-                    ),
-                }
+                # Molecular info — MolWt/CalcMolFormula can raise on an
+                # unsanitized mol; keep it optional so it never blocks the save.
+                try:
+                    json_data["molecular_info"] = {
+                        "num_atoms": self.host.view_3d_manager.current_mol.GetNumAtoms(),
+                        "num_bonds": self.host.view_3d_manager.current_mol.GetNumBonds(),
+                        "molecular_weight": Descriptors.MolWt(
+                            self.host.view_3d_manager.current_mol
+                        ),
+                        "formula": rdMolDescriptors.CalcMolFormula(
+                            self.host.view_3d_manager.current_mol
+                        ),
+                    }
+                except (AttributeError, RuntimeError, ValueError, TypeError) as e:
+                    logging.warning("Could not compute molecular info: %s", e)
 
                 # Identifiers (SMILES/InChI)
                 try:

--- a/moleditpy/src/moleditpy/ui/app_state.py
+++ b/moleditpy/src/moleditpy/ui/app_state.py
@@ -654,7 +654,9 @@ class StateManager:
                                                 ValueError,
                                                 TypeError,
                                                 IndexError,
-                                            ):  # [RDKIT GUARD] RDKit atom property assignment may fail on invalid ids; skip silently.
+                                            ):
+                                                # [RDKIT GUARD] property set may
+                                                # fail on invalid ids; skip.
                                                 logging.debug(
                                                     "Suppressed non-critical error",
                                                     exc_info=True,

--- a/moleditpy/src/moleditpy/ui/custom_interactor_style.py
+++ b/moleditpy/src/moleditpy/ui/custom_interactor_style.py
@@ -25,6 +25,16 @@ from .atom_picking import pick_atom_index_from_screen
 
 from rdkit import Geometry
 
+# VTK's trackball state id for camera rotation (VTKIS_ROTATE); the enum is not
+# exposed to Python, so the literal is used with this name for clarity.
+_VTKIS_ROTATE = 1
+
+# Reference 3D-canvas size (px) that camera rotation speed is normalized to.
+# VTK's stock Rotate divides motion by the live render size, so rotation slows
+# as the canvas grows; normalizing to a fixed reference makes the speed
+# window-size independent and matches the feel at the default window size.
+_ROTATION_REFERENCE_SIZE = 640.0
+
 
 class CustomInteractorStyle(vtkInteractorStyleTrackballCamera):
     """VTK interactor style extending trackball-camera with 3D atom drag and measurement."""
@@ -80,6 +90,43 @@ class CustomInteractorStyle(vtkInteractorStyleTrackballCamera):
             except (AttributeError, RuntimeError):
                 # Safe defensive fallback catching AttributeError, RuntimeError
                 logging.debug("Suppressed non-critical error", exc_info=True)
+
+    def _rotate_size_independent(self) -> None:
+        """Rotate the camera at a speed that does not depend on canvas size.
+
+        Mirrors vtkInteractorStyleTrackballCamera::Rotate but normalizes the
+        per-pixel azimuth/elevation to a fixed reference size instead of the
+        live render size, and scales by the user's rotation-sensitivity setting.
+        """
+        renderer = self.GetCurrentRenderer()
+        interactor = self.GetInteractor()
+        if renderer is None or interactor is None:
+            return
+
+        dx = interactor.GetEventPosition()[0] - interactor.GetLastEventPosition()[0]
+        dy = interactor.GetEventPosition()[1] - interactor.GetLastEventPosition()[1]
+
+        sensitivity = 1.0
+        mw = self.main_window
+        if mw is not None:
+            try:
+                sensitivity = float(
+                    mw.get_settings().get("mouse_rotation_sensitivity", 1.0)
+                )
+            except (AttributeError, TypeError, ValueError):
+                sensitivity = 1.0
+
+        delta = -20.0 / _ROTATION_REFERENCE_SIZE * self.GetMotionFactor() * sensitivity
+        camera = renderer.GetActiveCamera()
+        camera.Azimuth(dx * delta)
+        camera.Elevation(dy * delta)
+        camera.OrthogonalizeViewUp()
+
+        if self.GetAutoAdjustCameraClippingRange():
+            renderer.ResetCameraClippingRange()
+        if interactor.GetLightFollowCamera():
+            renderer.UpdateLightsGeometryToFollowCamera()
+        interactor.Render()
 
     def _stop_vtk_left_button_state(self) -> None:
         """Clear VTK's button/drag state after a custom-handled left click."""
@@ -501,8 +548,14 @@ class CustomInteractorStyle(vtkInteractorStyleTrackballCamera):
             # Custom atom drag
             self.is_dragging = True
         else:
-            # Delegate camera rotation to parent
-            super().OnMouseMove()
+            # Camera interaction. VTK's built-in Rotate divides mouse motion by
+            # the live render size, so rotation slows as the canvas grows. Handle
+            # the rotate state ourselves for window-size-independent speed;
+            # delegate pan/dolly/spin to the parent unchanged.
+            if self.GetState() == _VTKIS_ROTATE:
+                self._rotate_size_independent()
+            else:
+                super().OnMouseMove()
 
             # Update cursor display
             is_edit_active = (

--- a/moleditpy/src/moleditpy/ui/io_logic.py
+++ b/moleditpy/src/moleditpy/ui/io_logic.py
@@ -35,7 +35,12 @@ from PyQt6.QtWidgets import (
 from rdkit import Chem
 from rdkit.Chem import AllChem, rdGeometry, rdMolTransforms, Descriptors
 
-from ..utils.constants import COVALENT_RADII, DUMMY_XYZ_SYMBOLS, VERSION
+from ..utils.constants import (
+    COVALENT_RADII,
+    DUMMY_XYZ_SYMBOLS,
+    VALID_ELEMENT_SYMBOLS,
+    VERSION,
+)
 
 
 class IOManager:
@@ -97,6 +102,38 @@ class IOManager:
         lines[3] = self.fix_mol_counts_line(lines[3])
         return "\n".join(lines)
 
+    @staticmethod
+    def _is_numeric_token(token: str) -> bool:
+        """True if *token* parses as a float."""
+        try:
+            float(token)
+            return True
+        except ValueError:
+            return False
+
+    @staticmethod
+    def _extract_xyz_coords(tokens: list[str]) -> Optional[Tuple[float, float, float]]:
+        """Return the first three float-parseable tokens as (x, y, z).
+
+        Skips non-numeric separator/label columns so ghost-atom rows like
+        ``XX : x y z`` (a colon in the second column) parse the same as a
+        standard ``symbol x y z`` row. Returns None if fewer than three numbers
+        are present.
+        """
+        nums: list[float] = []
+        for tok in tokens:
+            try:
+                nums.append(float(tok))
+            except ValueError:
+                if nums:
+                    break  # trailing non-numeric column after the coordinates
+                continue  # leading label/separator column before the coordinates
+            if len(nums) == 3:
+                break
+        if len(nums) == 3:
+            return (nums[0], nums[1], nums[2])
+        return None
+
     def _normalize_xyz_symbol(self, raw_symbol: str) -> Tuple[str, bool]:
         """Return the RDKit symbol for an XYZ atom and whether it is a dummy."""
         stripped = raw_symbol.strip()
@@ -105,11 +142,11 @@ class IOManager:
         if stripped.upper() in DUMMY_XYZ_SYMBOLS:
             return "*", True
         symbol = stripped.capitalize()
-        try:
-            atomic_num = Chem.GetPeriodicTable().GetAtomicNumber(symbol)
-        except (RuntimeError, ValueError, TypeError):
-            return "*", True
-        if atomic_num <= 0:
+        # Membership test rather than GetAtomicNumber(symbol): the latter makes
+        # RDKit's C++ layer print an "Element 'Xx' not found" violation to
+        # stderr for any dummy/pseudo label even though we catch the exception,
+        # which users read as a failed load.
+        if symbol not in VALID_ELEMENT_SYMBOLS:
             return "*", True
         return symbol, False
 
@@ -138,9 +175,18 @@ class IOManager:
 
         atoms_data = []
         has_dummy_atoms = False
+        nonstandard_rows = 0
         atom_lines = lines[atom_start : atom_start + num_atoms]
         if len(atom_lines) < num_atoms:
-            raise ValueError("XYZ file format error: fewer atom rows than expected")
+            # Header count exceeds the rows present (truncated / miscounted file).
+            # Load the atoms that are actually there rather than refusing the
+            # whole file, so any parseable XYZ still opens.
+            logging.warning(
+                "XYZ declares %d atoms but only %d rows present; loading %d.",
+                num_atoms,
+                len(atom_lines),
+                len(atom_lines),
+            )
 
         for i, line in enumerate(atom_lines):
             parts = line.split()
@@ -149,9 +195,15 @@ class IOManager:
             raw_symbol = parts[0]
             symbol, is_dummy = self._normalize_xyz_symbol(raw_symbol)
             has_dummy_atoms = has_dummy_atoms or is_dummy
-            atoms_data.append(
-                (symbol, float(parts[1]), float(parts[2]), float(parts[3]))
-            )
+            coords = self._extract_xyz_coords(parts[1:])
+            if coords is None:
+                raise ValueError(f"Invalid atom data at line {atom_start + i + 1}")
+            # Standard rows put coordinates in the first three columns after the
+            # symbol; a non-numeric first column means an extra separator/label
+            # (e.g. the ':' in "XX : x y z") was skipped — flag it for the user.
+            if not self._is_numeric_token(parts[1]):
+                nonstandard_rows += 1
+            atoms_data.append((symbol, *coords))
 
         if not atoms_data:
             raise ValueError("No valid atoms found in XYZ file")
@@ -162,6 +214,8 @@ class IOManager:
             atom = Chem.Atom(symbol)
             atom.SetIntProp("xyz_unique_id", i)
             if atom.GetAtomicNum() == 0:
+                # Ghost/dummy rows (e.g. "XX : x y z") load as the wildcard "*";
+                # stash the real label token so it is kept for round-tripping.
                 atom.SetProp("xyz_original_symbol", atom_lines[i].split()[0])
             mol.AddAtom(atom)
             conf.SetAtomPosition(i, rdGeometry.Point3D(x, y, z))
@@ -190,7 +244,16 @@ class IOManager:
                 _set_prop(candidate, "_xyz_charge", charge_val)
                 return candidate
             else:
-                self.estimate_bonds_from_distances(mol)
+                # Distance-based bonding is best-effort: a failure here must not
+                # lose the molecule. The skip/dummy path only needs atoms and
+                # coordinates, so fall back to a bond-free structure so that any
+                # parseable XYZ still loads.
+                try:
+                    self.estimate_bonds_from_distances(mol)
+                except (RuntimeError, ValueError, TypeError, AttributeError) as e:
+                    logging.warning(
+                        "Bond estimation failed; loading atoms without bonds: %s", e
+                    )
                 candidate = mol.GetMol()
                 _set_prop(candidate, "_xyz_charge", charge_val)
                 return candidate
@@ -240,6 +303,8 @@ class IOManager:
 
         if final_mol:
             final_mol.xyz_atom_data = atoms_data
+            if nonstandard_rows:
+                _set_prop(final_mol, "_xyz_nonstandard_rows", nonstandard_rows)
         return final_mol
 
     def _report_load_error(self, title: str, message: str) -> None:
@@ -866,9 +931,17 @@ class IOManager:
             self.host.view_3d_manager.update_atom_id_menu_state()
 
             if self.host.statusBar():
-                self.host.statusBar().showMessage(
-                    f"3D Viewer Mode: Loaded {os.path.basename(file_path)}"
-                )
+                message = f"3D Viewer Mode: Loaded {os.path.basename(file_path)}"
+                nonstandard = 0
+                with suppress_log(AttributeError, KeyError, RuntimeError, TypeError):
+                    if mol.HasProp("_xyz_nonstandard_rows"):
+                        nonstandard = mol.GetIntProp("_xyz_nonstandard_rows")
+                if nonstandard:
+                    message += (
+                        f" (non-standard columns in {nonstandard} row(s); "
+                        "coordinates read from the numeric columns)"
+                    )
+                self.host.statusBar().showMessage(message)
             self.host.set_current_file_path(file_path)
             self.host.set_has_unsaved_changes(False)
             self.host.state_manager.update_window_title()

--- a/moleditpy/src/moleditpy/ui/io_logic.py
+++ b/moleditpy/src/moleditpy/ui/io_logic.py
@@ -176,7 +176,8 @@ class IOManager:
         atoms_data = []
         has_dummy_atoms = False
         nonstandard_rows = 0
-        atom_lines = lines[atom_start : atom_start + num_atoms]
+        atom_end = atom_start + num_atoms
+        atom_lines = lines[atom_start:atom_end]
         if len(atom_lines) < num_atoms:
             # Header count exceeds the rows present (truncated / miscounted file).
             # Load the atoms that are actually there rather than refusing the

--- a/moleditpy/src/moleditpy/ui/settings_tabs/settings_3d_tabs.py
+++ b/moleditpy/src/moleditpy/ui/settings_tabs/settings_3d_tabs.py
@@ -78,6 +78,16 @@ class Settings3DSceneTab(SettingsTabBase):
         self.projection_combo.addItems(["Perspective", "Orthographic"])
         form_layout.addRow("Projection Mode:", self.projection_combo)
 
+        # Camera rotation speed (0.10x–3.00x). Speed is normalized to a fixed
+        # reference canvas size, so it stays constant regardless of window size.
+        self.rotation_sens_slider, self.rotation_sens_label = self._create_slider(
+            10, 300, 100.0
+        )
+        form_layout.addRow(
+            "Mouse Rotation Speed:",
+            self._wrap_layout(self.rotation_sens_slider, self.rotation_sens_label),
+        )
+
     def _select_color(self) -> None:
         color = QColorDialog.getColor(QColor(self.current_bg_color), self)
         if color.isValid():
@@ -111,6 +121,9 @@ class Settings3DSceneTab(SettingsTabBase):
         if idx >= 0:
             self.projection_combo.setCurrentIndex(idx)
 
+        sens_val = settings_dict.get("mouse_rotation_sensitivity", 1.0)
+        self.rotation_sens_slider.setValue(int(sens_val * 100))
+
     def get_settings(self) -> dict[str, Any]:
         return {
             "background_color": self.current_bg_color,
@@ -120,6 +133,7 @@ class Settings3DSceneTab(SettingsTabBase):
             "specular": self.specular_slider.value() / 100.0,
             "specular_power": self.spec_power_slider.value(),
             "projection_mode": self.projection_combo.currentText(),
+            "mouse_rotation_sensitivity": self.rotation_sens_slider.value() / 100.0,
         }
 
 

--- a/moleditpy/src/moleditpy/utils/constants.py
+++ b/moleditpy/src/moleditpy/utils/constants.py
@@ -24,7 +24,8 @@ def _get_version() -> str:
 
         try:
             return version("MoleditPy")
-        except PackageNotFoundError:  # [OPTIONAL] Package not installed in editable mode; fall through to pyproject.toml.
+        except PackageNotFoundError:
+            # [OPTIONAL] Not installed in editable mode; fall through to pyproject.toml.
             logging.debug("Suppressed non-critical error", exc_info=True)
     except ImportError:
         logging.debug("Suppressed non-critical error", exc_info=True)

--- a/moleditpy/src/moleditpy/utils/constants.py
+++ b/moleditpy/src/moleditpy/utils/constants.py
@@ -209,6 +209,13 @@ DEFAULT_CPK_COLORS = {
 
 
 pt = Chem.GetPeriodicTable()
+# Real element symbols (H..Og). Membership-test against this instead of calling
+# GetAtomicNumber() on an unknown label: probing the periodic table with a
+# non-element makes RDKit's C++ layer print an alarming "Element 'Xx' not found"
+# violation to stderr even when the Python exception is caught.
+VALID_ELEMENT_SYMBOLS: frozenset[str] = frozenset(
+    pt.GetElementSymbol(i) for i in range(1, 119)
+)
 # 0.3-scaled vdW radii for 3D display only — not physical values
 VDW_DISPLAY_RADII = {pt.GetElementSymbol(i): pt.GetRvdw(i) * 0.3 for i in range(1, 119)}
 # Deprecated alias kept for external plugins

--- a/moleditpy/src/moleditpy/utils/default_settings.py
+++ b/moleditpy/src/moleditpy/utils/default_settings.py
@@ -19,6 +19,8 @@ DEFAULT_SETTINGS = {
     "specular_power": 20,
     "light_intensity": 1.0,
     "show_3d_axes": True,
+    # Camera rotation speed multiplier for the 3D scene (window-size independent).
+    "mouse_rotation_sensitivity": 1.0,
     # --- 3D Model Parameters (Ball and Stick) ---
     "ball_stick_atom_scale": 1.0,
     "ball_stick_bond_radius": 0.1,

--- a/tests/assertion_catalog.md
+++ b/tests/assertion_catalog.md
@@ -292,6 +292,15 @@ _Test full project serialization/deserialization (PMEPRJ)._
 - assert mw.compute_manager.last_successful_optimization_method == 'MMFF94s'
 - assert mw._preserved_plugin_data['TestPlugin']['val'] == 42
 
+### test_pmeprj_saves_unsanitized_3d_mol
+_An unsanitized 3D mol (e.g. bad-valence XYZ import) must still save and_
+
+- assert isinstance(json_data.get('3d_structure'), dict)
+- assert json_data['3d_structure'].get('mol_binary_base64')
+- assert len(json_data['3d_structure']['atoms']) == mol.GetNumAtoms()
+- assert mw.view_3d_manager.current_mol is not None
+- assert mw.view_3d_manager.current_mol.GetNumAtoms() == mol.GetNumAtoms()
+
 ### test_undo_state_binary_roundtrip
 _Test the internal binary state serialization used for Undo/Redo._
 
@@ -2114,6 +2123,22 @@ _No description provided._
 _No description provided._
 
 - assert style._is_dragging_atom is False
+
+### test_rotation_speed_is_window_size_independent
+_The applied azimuth/elevation depend only on mouse delta, motion factor,_
+
+- camera.Azimuth.assert_called_once_with(30 * delta)
+- camera.Elevation.assert_called_once_with(20 * delta)
+- camera.OrthogonalizeViewUp.assert_called_once()
+
+### test_rotation_speed_scales_with_sensitivity
+_Doubling the sensitivity setting doubles the rotation applied._
+
+- assert az2 == pytest.approx(az1 * 2.0)
+
+### test_rotation_handles_missing_renderer
+_No renderer yet (early startup) must not raise._
+
 
 ## tests/unit/test_custom_qt_interactor.py
 
@@ -4236,6 +4261,98 @@ _No description provided._
 - dlg.accept.assert_not_called()
 - assert any(('Invalid charge' in m for m in msgs))
 - dlg.accept.assert_called_once()
+
+### TestXyzDummyAtoms.test_dummy_label_normalizes_to_wildcard
+_No description provided._
+
+- assert symbol == '*'
+- assert is_dummy is True
+
+### TestXyzDummyAtoms.test_real_element_preserved
+_No description provided._
+
+- assert symbol == expected
+- assert is_dummy is False
+
+### TestXyzDummyAtoms.test_dummy_atom_xyz_loads_to_mol
+_No description provided._
+
+- assert mol is not None
+- assert mol.GetNumAtoms() == 3
+- assert mol.GetAtomWithIdx(0).GetSymbol() == '*'
+- assert Chem.Mol(mol.ToBinary()).GetNumAtoms() == 3
+
+### TestXyzDummyAtoms.test_normalize_does_not_emit_rdkit_violation
+_Normalizing a non-element label must not print a C++ periodic-table_
+
+- assert 'not found' not in captured
+- assert 'Violation' not in captured
+
+### TestXyzLoadRobustness.test_bond_estimation_failure_still_loads_atoms
+_No description provided._
+
+- assert mol is not None
+- assert mol.GetNumAtoms() == 3
+- assert mol.GetNumBonds() == 0
+
+### TestXyzLoadRobustness.test_truncated_atom_count_loads_available_rows
+_No description provided._
+
+- assert mol is not None
+- assert mol.GetNumAtoms() == 2
+
+### TestXyzLoadRobustness.test_skip_checks_with_bond_failure_loads
+_No description provided._
+
+- assert mol is not None
+- assert mol.GetNumAtoms() == 2
+
+### TestXyzGhostAtomColumns.test_extract_coords_skips_separator_column
+_No description provided._
+
+- assert io._extract_xyz_coords([':', '1', '2', '3']) == (1.0, 2.0, 3.0)
+- assert io._extract_xyz_coords(['1', '2', '3']) == (1.0, 2.0, 3.0)
+- assert io._extract_xyz_coords(['1', '2', '3', '0.5']) == (1.0, 2.0, 3.0)
+- assert io._extract_xyz_coords(['1', '2']) is None
+
+### TestXyzGhostAtomColumns.test_mixed_standard_and_ghost_columns_load
+_No description provided._
+
+- assert mol is not None
+- assert mol.GetNumAtoms() == 5
+- assert symbols == ['C', 'H', '*', '*', '*']
+- assert round(pos2.x, 1) == -80.5
+- assert round(pos2.z, 1) == -3.0
+
+### TestXyzNonStandardWarning.test_is_numeric_token
+_No description provided._
+
+- assert io._is_numeric_token('1.5') is True
+- assert io._is_numeric_token('-3.0e2') is True
+- assert io._is_numeric_token(':') is False
+- assert io._is_numeric_token('XX') is False
+
+### TestXyzNonStandardWarning.test_parser_records_nonstandard_row_count
+_No description provided._
+
+- assert mol.HasProp('_xyz_nonstandard_rows')
+- assert mol.GetIntProp('_xyz_nonstandard_rows') == 2
+
+### TestXyzNonStandardWarning.test_parser_no_property_for_standard_file
+_No description provided._
+
+- assert not mol.HasProp('_xyz_nonstandard_rows')
+
+### TestXyzNonStandardWarning.test_status_bar_warns_on_nonstandard
+_No description provided._
+
+- assert any(('non-standard columns in 2 row' in m for m in msgs))
+
+### TestXyzNonStandardWarning.test_status_bar_silent_on_standard
+_No description provided._
+
+- assert msgs
+- assert all(('non-standard' not in m for m in msgs))
 
 ## tests/unit/test_items_visual.py
 
@@ -7773,6 +7890,12 @@ _Settings round-trip: update_ui then get_settings recovers the original values._
 - assert abs(result['light_intensity'] - DEFAULT_SETTINGS['light_intensity']) < 0.01
 - assert abs(result['specular'] - DEFAULT_SETTINGS['specular']) < 0.01
 - assert result['specular_power'] == DEFAULT_SETTINGS['specular_power']
+- assert abs(result['mouse_rotation_sensitivity'] - DEFAULT_SETTINGS['mouse_rotation_sensitivity']) < 0.01
+
+### test_scene_tab_rotation_sensitivity_roundtrip
+_A custom rotation-sensitivity value survives update_ui -> get_settings._
+
+- assert abs(tab.get_settings()['mouse_rotation_sensitivity'] - 2.5) < 0.01
 
 ### test_scene_tab_pick_color_valid
 __select_color updates current_bg_color when a valid color is chosen._

--- a/tests/coverage_report.md
+++ b/tests/coverage_report.md
@@ -1,6 +1,6 @@
 # MoleditPy Coverage Report
 
-- **Overall Project Coverage**: **89.25%**
+- **Overall Project Coverage**: **89.29%**
 
 ### Coverage Breakdown
 
@@ -19,7 +19,7 @@
 | moleditpy\src\moleditpy\ui\alignment_dialog.py          |    147 |     10 |   93.2% |
 | moleditpy\src\moleditpy\ui\analysis_window.py           |    117 |     25 |   78.6% |
 | moleditpy\src\moleditpy\ui\angle_dialog.py              |    264 |     28 |   89.4% |
-| moleditpy\src\moleditpy\ui\app_state.py                 |    334 |     55 |   83.5% |
+| moleditpy\src\moleditpy\ui\app_state.py                 |    345 |     57 |   83.5% |
 | moleditpy\src\moleditpy\ui\atom_item.py                 |    325 |     39 |   88.0% |
 | moleditpy\src\moleditpy\ui\atom_picking.py              |    167 |     13 |   92.2% |
 | moleditpy\src\moleditpy\ui\base_picking_dialog.py       |     81 |      4 |   95.1% |
@@ -29,7 +29,7 @@
 | moleditpy\src\moleditpy\ui\color_settings_dialog.py     |    166 |     13 |   92.2% |
 | moleditpy\src\moleditpy\ui\compute_logic.py             |    431 |      7 |   98.4% |
 | moleditpy\src\moleditpy\ui\constrained_optimization_dialog.py |    480 |     24 |   95.0% |
-| moleditpy\src\moleditpy\ui\custom_interactor_style.py   |    499 |    108 |   78.4% |
+| moleditpy\src\moleditpy\ui\custom_interactor_style.py   |    527 |    112 |   78.7% |
 | moleditpy\src\moleditpy\ui\custom_qt_interactor.py      |     24 |      0 |  100.0% |
 | moleditpy\src\moleditpy\ui\dialog_3d_picking_mixin.py   |    137 |     19 |   86.1% |
 | moleditpy\src\moleditpy\ui\dialog_logic.py              |    230 |     25 |   89.1% |
@@ -38,11 +38,11 @@
 | moleditpy\src\moleditpy\ui\edit_actions_logic.py        |    821 |    130 |   84.2% |
 | moleditpy\src\moleditpy\ui\export_logic.py              |    520 |     85 |   83.7% |
 | moleditpy\src\moleditpy\ui\geometry_base_dialog.py      |     52 |      1 |   98.1% |
-| moleditpy\src\moleditpy\ui\io_logic.py                  |    694 |     77 |   88.9% |
+| moleditpy\src\moleditpy\ui\io_logic.py                  |    731 |     77 |   89.5% |
 | moleditpy\src\moleditpy\ui\main_window.py               |    195 |     13 |   93.3% |
 | moleditpy\src\moleditpy\ui\main_window_init.py          |   1061 |     94 |   91.1% |
 | moleditpy\src\moleditpy\ui\mirror_dialog.py             |     72 |      7 |   90.3% |
-| moleditpy\src\moleditpy\ui\molecular_scene_handler.py   |    999 |    146 |   85.4% |
+| moleditpy\src\moleditpy\ui\molecular_scene_handler.py   |    999 |    144 |   85.6% |
 | moleditpy\src\moleditpy\ui\molecule_scene.py            |    614 |     82 |   86.6% |
 | moleditpy\src\moleditpy\ui\move_group_dialog.py         |    386 |     42 |   89.1% |
 | moleditpy\src\moleditpy\ui\move_selected_atoms_dialog.py |    464 |     44 |   90.5% |
@@ -51,7 +51,7 @@
 | moleditpy\src\moleditpy\ui\plugin_menu_manager.py       |    287 |     30 |   89.5% |
 | moleditpy\src\moleditpy\ui\settings_dialog.py           |    101 |      3 |   97.0% |
 | moleditpy\src\moleditpy\ui\string_importers.py          |    121 |      0 |  100.0% |
-| moleditpy\src\moleditpy\ui\template_preview_item.py     |    102 |      3 |   97.1% |
+| moleditpy\src\moleditpy\ui\template_preview_item.py     |    102 |      1 |   99.0% |
 | moleditpy\src\moleditpy\ui\template_preview_view.py     |     46 |      4 |   91.3% |
 | moleditpy\src\moleditpy\ui\translation_dialog.py        |    276 |     21 |   92.4% |
 | moleditpy\src\moleditpy\ui\ui_manager.py                |    395 |     36 |   90.9% |
@@ -59,15 +59,15 @@
 | moleditpy\src\moleditpy\ui\view_3d_logic.py             |   1007 |    179 |   82.2% |
 | moleditpy\src\moleditpy\ui\zoomable_view.py             |     82 |      2 |   97.6% |
 | moleditpy\src\moleditpy\ui\settings_tabs\settings_2d_tab.py |    144 |      0 |  100.0% |
-| moleditpy\src\moleditpy\ui\settings_tabs\settings_3d_tabs.py |    142 |      0 |  100.0% |
+| moleditpy\src\moleditpy\ui\settings_tabs\settings_3d_tabs.py |    146 |      0 |  100.0% |
 | moleditpy\src\moleditpy\ui\settings_tabs\settings_other_tab.py |     89 |      0 |  100.0% |
 | moleditpy\src\moleditpy\ui\settings_tabs\settings_tab_base.py |     57 |      0 |  100.0% |
-| moleditpy\src\moleditpy\utils\constants.py              |     58 |      0 |  100.0% |
+| moleditpy\src\moleditpy\utils\constants.py              |     59 |      0 |  100.0% |
 | moleditpy\src\moleditpy\utils\default_settings.py       |      1 |      0 |  100.0% |
 | moleditpy\src\moleditpy\utils\sip_isdeleted_safe.py     |     19 |      0 |  100.0% |
 | moleditpy\src\moleditpy\utils\suppress_log.py           |     10 |      0 |  100.0% |
 | moleditpy\src\moleditpy\utils\system_utils.py           |     39 |      0 |  100.0% |
-| **TOTAL** | **16187** | **1740** | **89.25%** |
+| **TOTAL** | **16268** | **1742** | **89.29%** |
 
 ## Test Suite Status
 - **Unit tests**: PASSED

--- a/tests/pylint-score.txt
+++ b/tests/pylint-score.txt
@@ -1,1 +1,1 @@
-Your code has been rated at 9.33/10
+Your code has been rated at 9.34/10

--- a/tests/unit/test_app_state.py
+++ b/tests/unit/test_app_state.py
@@ -418,6 +418,50 @@ def test_pmeprj_serialization_roundtrip(dummy_window):
     assert mw._preserved_plugin_data["TestPlugin"]["val"] == 42
 
 
+def _make_unsanitized_mol_with_conformer():
+    """Build a mol that fails sanitization (over-valent C) with 3D coords.
+
+    Mirrors an XYZ import whose valences never passed sanitization: calling
+    GetNumImplicitHs() on such atoms raises a RuntimeError.
+    """
+    rw = Chem.RWMol()
+    c = rw.AddAtom(Chem.Atom(6))
+    for _ in range(5):  # carbon with five bonds -> invalid valence
+        h = rw.AddAtom(Chem.Atom(1))
+        rw.AddBond(c, h, Chem.BondType.SINGLE)
+    mol = rw.GetMol()
+    conf = Chem.Conformer(mol.GetNumAtoms())
+    for i in range(mol.GetNumAtoms()):
+        conf.SetAtomPosition(i, (float(i), 0.0, 0.0))
+    mol.AddConformer(conf)
+    return mol
+
+
+def test_pmeprj_saves_unsanitized_3d_mol(dummy_window):
+    """An unsanitized 3D mol (e.g. bad-valence XYZ import) must still save and
+    restore its 3D structure — previously GetNumImplicitHs() raised mid-loop and
+    the whole 3d_structure block was silently dropped."""
+    mw = dummy_window
+    mol = _make_unsanitized_mol_with_conformer()
+
+    # Sanity: the atom-Hs access that used to break the save really does raise.
+    with pytest.raises(RuntimeError):
+        mol.GetAtomWithIdx(0).GetNumImplicitHs()
+
+    mw.view_3d_manager.current_mol = mol
+    json_data = mw.create_json_data()
+
+    assert isinstance(json_data.get("3d_structure"), dict)
+    assert json_data["3d_structure"].get("mol_binary_base64")
+    assert len(json_data["3d_structure"]["atoms"]) == mol.GetNumAtoms()
+
+    mw.view_3d_manager.current_mol = None
+    mw.load_from_json_data(json_data)
+
+    assert mw.view_3d_manager.current_mol is not None
+    assert mw.view_3d_manager.current_mol.GetNumAtoms() == mol.GetNumAtoms()
+
+
 def test_undo_state_binary_roundtrip(dummy_window):
     """Test the internal binary state serialization used for Undo/Redo."""
     mw = dummy_window

--- a/tests/unit/test_custom_interactor_style.py
+++ b/tests/unit/test_custom_interactor_style.py
@@ -1,6 +1,7 @@
 """Unit tests for CustomInteractorStyle 3D event handling."""
 
 import numpy as np
+import pytest
 
 from unittest.mock import MagicMock, patch
 from moleditpy.ui.custom_interactor_style import CustomInteractorStyle
@@ -850,3 +851,57 @@ def test_reset_interactor_state_without_main_window(app):
     style.reset_interactor_state()  # must not raise
 
     assert style._is_dragging_atom is False
+
+
+def _rotation_style(sensitivity=1.0, motion_factor=10.0):
+    """A style wired for _rotate_size_independent with a fake camera."""
+    host = MagicMock()
+    host.get_settings.return_value = {"mouse_rotation_sensitivity": sensitivity}
+    style = CustomInteractorStyle(host)
+
+    camera = MagicMock()
+    renderer = MagicMock()
+    renderer.GetActiveCamera.return_value = camera
+    interactor = MagicMock()
+    interactor.GetEventPosition.return_value = (130, 120)
+    interactor.GetLastEventPosition.return_value = (100, 100)  # dx=30, dy=20
+    interactor.GetLightFollowCamera.return_value = False
+
+    style.GetCurrentRenderer = MagicMock(return_value=renderer)
+    style.GetInteractor = MagicMock(return_value=interactor)
+    style.GetMotionFactor = MagicMock(return_value=motion_factor)
+    style.GetAutoAdjustCameraClippingRange = MagicMock(return_value=True)
+    return style, camera
+
+
+def test_rotation_speed_is_window_size_independent(app):
+    """The applied azimuth/elevation depend only on mouse delta, motion factor,
+    sensitivity and a fixed reference size — never on the live render size."""
+    from moleditpy.ui.custom_interactor_style import _ROTATION_REFERENCE_SIZE
+
+    style, camera = _rotation_style(sensitivity=1.0, motion_factor=10.0)
+    style._rotate_size_independent()
+
+    delta = -20.0 / _ROTATION_REFERENCE_SIZE * 10.0 * 1.0
+    camera.Azimuth.assert_called_once_with(30 * delta)
+    camera.Elevation.assert_called_once_with(20 * delta)
+    camera.OrthogonalizeViewUp.assert_called_once()
+
+
+def test_rotation_speed_scales_with_sensitivity(app):
+    """Doubling the sensitivity setting doubles the rotation applied."""
+    s1, cam1 = _rotation_style(sensitivity=1.0)
+    s1._rotate_size_independent()
+    s2, cam2 = _rotation_style(sensitivity=2.0)
+    s2._rotate_size_independent()
+
+    az1 = cam1.Azimuth.call_args[0][0]
+    az2 = cam2.Azimuth.call_args[0][0]
+    assert az2 == pytest.approx(az1 * 2.0)
+
+
+def test_rotation_handles_missing_renderer(app):
+    """No renderer yet (early startup) must not raise."""
+    style, _ = _rotation_style()
+    style.GetCurrentRenderer = MagicMock(return_value=None)
+    style._rotate_size_independent()  # must not raise

--- a/tests/unit/test_io_manager.py
+++ b/tests/unit/test_io_manager.py
@@ -552,3 +552,210 @@ class TestPromptForChargeInlineValidation:
             le.text.return_value = "-2"
             validator()
             dlg.accept.assert_called_once()
+
+
+# ===========================================================================
+# Tests for XYZ dummy/pseudo-atom handling (any XYZ must load cleanly)
+# ===========================================================================
+
+
+class TestXyzDummyAtoms:
+    """A dummy/pseudo atom label must map to the RDKit wildcard (*) without
+    the load appearing to fail. Regression: probing the periodic table with a
+    non-element label used to make RDKit print an 'Element 'Xx' not found'
+    violation to stderr, which reads as a load failure."""
+
+    def _io(self):
+        host = DummyHost()
+        host.init_manager.settings = {
+            "skip_chemistry_checks": False,
+            "always_ask_charge": False,
+        }
+        return IOManager(host)
+
+    @pytest.mark.parametrize("label", ["Xx", "XX", "X1", "Bq", "DA", "Q", "LP"])
+    def test_dummy_label_normalizes_to_wildcard(self, qapp, label):
+        io = self._io()
+        symbol, is_dummy = io._normalize_xyz_symbol(label)
+        assert symbol == "*"
+        assert is_dummy is True
+
+    @pytest.mark.parametrize(
+        "label,expected", [("C", "C"), ("fe", "Fe"), ("og", "Og"), ("H", "H")]
+    )
+    def test_real_element_preserved(self, qapp, label, expected):
+        io = self._io()
+        symbol, is_dummy = io._normalize_xyz_symbol(label)
+        assert symbol == expected
+        assert is_dummy is False
+
+    def test_dummy_atom_xyz_loads_to_mol(self, qapp):
+        io = self._io()
+        xyz = "3\n\nXx 0 0 0\nC 0 0 1.0\nO 0 1.2 0\n"
+        mol = io._mol_from_xyz_lines(xyz.splitlines())
+        assert mol is not None
+        assert mol.GetNumAtoms() == 3
+        assert mol.GetAtomWithIdx(0).GetSymbol() == "*"
+        # binary round-trips (used for undo/redo and .pmeprj persistence)
+        assert Chem.Mol(mol.ToBinary()).GetNumAtoms() == 3
+
+    def test_normalize_does_not_emit_rdkit_violation(self, qapp, tmp_path):
+        """Normalizing a non-element label must not print a C++ periodic-table
+        violation to stderr — that stderr noise is the user-visible symptom."""
+        io = self._io()
+        # Capture at the file-descriptor level: RDKit's C++ logger writes to the
+        # underlying stderr fd, not Python's sys.stderr.
+        err_path = tmp_path / "stderr.txt"
+        saved_fd = os.dup(2)
+        with open(err_path, "w") as fh:
+            os.dup2(fh.fileno(), 2)
+            try:
+                for label in ["Xx", "XX", "X1", "Bq", "Zz", "Qq"]:
+                    io._normalize_xyz_symbol(label)
+            finally:
+                os.dup2(saved_fd, 2)
+                os.close(saved_fd)
+        captured = err_path.read_text()
+        assert "not found" not in captured, captured
+        assert "Violation" not in captured, captured
+
+
+class TestXyzLoadRobustness:
+    """Any structurally-parseable XYZ must yield a molecule (never None),
+    even when bond perception fails or the atom-count header is wrong."""
+
+    def _io(self, **settings):
+        host = DummyHost()
+        base = {"skip_chemistry_checks": False, "always_ask_charge": False}
+        base.update(settings)
+        host.init_manager.settings = base
+        return IOManager(host)
+
+    def test_bond_estimation_failure_still_loads_atoms(self, qapp):
+        io = self._io()
+        io.estimate_bonds_from_distances = MagicMock(
+            side_effect=RuntimeError("bond perception blew up")
+        )
+        xyz = "3\n\nXx 0 0 0\nC 0 0 1.0\nO 0 1.2 0\n"
+        mol = io._mol_from_xyz_lines(xyz.splitlines())
+        assert mol is not None
+        assert mol.GetNumAtoms() == 3
+        assert mol.GetNumBonds() == 0
+
+    def test_truncated_atom_count_loads_available_rows(self, qapp):
+        io = self._io()
+        # header claims 5 atoms, only 2 rows present
+        xyz = "5\n\nXx 0 0 0\nC 0 0 1.0\n"
+        mol = io._mol_from_xyz_lines(xyz.splitlines())
+        assert mol is not None
+        assert mol.GetNumAtoms() == 2
+
+    def test_skip_checks_with_bond_failure_loads(self, qapp):
+        io = self._io(skip_chemistry_checks=True)
+        io.estimate_bonds_from_distances = MagicMock(
+            side_effect=ValueError("bad geometry")
+        )
+        xyz = "2\n\nC 0 0 0\nO 0 0 1.2\n"
+        mol = io._mol_from_xyz_lines(xyz.splitlines())
+        assert mol is not None
+        assert mol.GetNumAtoms() == 2
+
+
+class TestXyzGhostAtomColumns:
+    """Ghost-atom rows may carry a separator/label column, e.g. 'XX : x y z'.
+    Coordinates must be read from the numeric columns, not blindly from
+    parts[1..3] (which would hit the ':' and fail the whole file)."""
+
+    def _io(self):
+        host = DummyHost()
+        host.init_manager.settings = {
+            "skip_chemistry_checks": False,
+            "always_ask_charge": False,
+        }
+        return IOManager(host)
+
+    def test_extract_coords_skips_separator_column(self, qapp):
+        io = self._io()
+        assert io._extract_xyz_coords([":", "1", "2", "3"]) == (1.0, 2.0, 3.0)
+        assert io._extract_xyz_coords(["1", "2", "3"]) == (1.0, 2.0, 3.0)
+        # trailing extra column (e.g. a charge) is ignored
+        assert io._extract_xyz_coords(["1", "2", "3", "0.5"]) == (1.0, 2.0, 3.0)
+        # too few numbers -> None (caller raises a clear per-line error)
+        assert io._extract_xyz_coords(["1", "2"]) is None
+
+    def test_mixed_standard_and_ghost_columns_load(self, qapp):
+        io = self._io()
+        xyz = (
+            "5\n\n"
+            "C   -53.9 38.9 -0.9\n"
+            "H   -51.6 42.7  1.1\n"
+            "XX : -80.5 39.9 -3.0\n"
+            "XX : -19.6 38.8 -3.2\n"
+            "XX : -51.7 36.8 -1.6\n"
+        )
+        mol = io._mol_from_xyz_lines(xyz.splitlines())
+        assert mol is not None
+        assert mol.GetNumAtoms() == 5
+        symbols = [mol.GetAtomWithIdx(i).GetSymbol() for i in range(5)]
+        assert symbols == ["C", "H", "*", "*", "*"]
+        # the ghost atoms kept their real coordinates (not shifted by the ':')
+        pos2 = mol.GetConformer().GetAtomPosition(2)
+        assert round(pos2.x, 1) == -80.5
+        assert round(pos2.z, 1) == -3.0
+
+
+class TestXyzNonStandardWarning:
+    """A non-standard column layout loads successfully but must be flagged: the
+    parser records a count property and load_xyz_for_3d_viewing surfaces it on
+    the status bar. Standard files stay silent."""
+
+    def _io(self):
+        host = DummyHost()
+        host.init_manager.settings = {
+            "skip_chemistry_checks": False,
+            "always_ask_charge": False,
+        }
+        return IOManager(host), host
+
+    def test_is_numeric_token(self, qapp):
+        io, _ = self._io()
+        assert io._is_numeric_token("1.5") is True
+        assert io._is_numeric_token("-3.0e2") is True
+        assert io._is_numeric_token(":") is False
+        assert io._is_numeric_token("XX") is False
+
+    def test_parser_records_nonstandard_row_count(self, qapp):
+        io, _ = self._io()
+        xyz = "3\n\nC 0 0 0\nXX : 1 0 0\nXX : 0 1 0\n"
+        mol = io._mol_from_xyz_lines(xyz.splitlines())
+        assert mol.HasProp("_xyz_nonstandard_rows")
+        assert mol.GetIntProp("_xyz_nonstandard_rows") == 2
+
+    def test_parser_no_property_for_standard_file(self, qapp):
+        io, _ = self._io()
+        xyz = "2\n\nC 0 0 0\nO 0 0 1.2\n"
+        mol = io._mol_from_xyz_lines(xyz.splitlines())
+        assert not mol.HasProp("_xyz_nonstandard_rows")
+
+    def test_status_bar_warns_on_nonstandard(self, qapp, tmp_path):
+        io, host = self._io()
+        xyz = tmp_path / "ghost.xyz"
+        xyz.write_text("3\n\nC 0 0 0\nXX : 1 0 0\nXX : 0 1 0\n")
+        with patch("moleditpy.ui.io_logic.QTimer"), patch(
+            "moleditpy.ui.io_logic.QMessageBox"
+        ):
+            io.load_xyz_for_3d_viewing(file_path=str(xyz))
+        msgs = [c[0][0] for c in host.statusBar_mock.showMessage.call_args_list if c[0]]
+        assert any("non-standard columns in 2 row" in m for m in msgs), msgs
+
+    def test_status_bar_silent_on_standard(self, qapp, tmp_path):
+        io, host = self._io()
+        xyz = tmp_path / "std.xyz"
+        xyz.write_text("2\n\nC 0 0 0\nO 0 0 1.2\n")
+        with patch("moleditpy.ui.io_logic.QTimer"), patch(
+            "moleditpy.ui.io_logic.QMessageBox"
+        ):
+            io.load_xyz_for_3d_viewing(file_path=str(xyz))
+        msgs = [c[0][0] for c in host.statusBar_mock.showMessage.call_args_list if c[0]]
+        assert msgs
+        assert all("non-standard" not in m for m in msgs), msgs

--- a/tests/unit/test_settings_3d_tabs.py
+++ b/tests/unit/test_settings_3d_tabs.py
@@ -50,6 +50,7 @@ def test_scene_tab_get_settings_keys(app):
         "specular",
         "specular_power",
         "projection_mode",
+        "mouse_rotation_sensitivity",
     }
     assert expected_keys == set(result.keys())
 
@@ -65,6 +66,20 @@ def test_scene_tab_roundtrip(app):
     assert abs(result["light_intensity"] - DEFAULT_SETTINGS["light_intensity"]) < 0.01
     assert abs(result["specular"] - DEFAULT_SETTINGS["specular"]) < 0.01
     assert result["specular_power"] == DEFAULT_SETTINGS["specular_power"]
+    assert (
+        abs(
+            result["mouse_rotation_sensitivity"]
+            - DEFAULT_SETTINGS["mouse_rotation_sensitivity"]
+        )
+        < 0.01
+    )
+
+
+def test_scene_tab_rotation_sensitivity_roundtrip(app):
+    """A custom rotation-sensitivity value survives update_ui -> get_settings."""
+    tab = Settings3DSceneTab(DEFAULT_SETTINGS)
+    tab.update_ui({**DEFAULT_SETTINGS, "mouse_rotation_sensitivity": 2.5})
+    assert abs(tab.get_settings()["mouse_rotation_sensitivity"] - 2.5) < 0.01
 
 
 @patch("moleditpy.ui.settings_tabs.settings_3d_tabs.QColorDialog.getColor")


### PR DESCRIPTION
# MoleditPy v4.4.0 — `dev-4.4.0`

## Summary

- **XYZ loading is robust for dummy/ghost atoms.** Non-element labels are detected by
  membership in a precomputed element set instead of probing `GetAtomicNumber()` (which
  printed an alarming `Element 'Xx' not found` C++ violation to stderr). Ghost-atom rows
  like `XX : x y z` now parse coordinates from the numeric columns via `_extract_xyz_coords`
  instead of failing on `float(':')`. Bond estimation is non-fatal and a truncated
  atom-count header is tolerated, so any parseable XYZ opens; non-standard column layouts
  load but are flagged on the status bar.
- **`.pmeprj` save works in 3D viewer mode for unsanitized molecules.** `GetNumImplicitHs()`
  / `MolWt()` / `CalcMolFormula()` raise on an unsanitized mol and were called mid-loop
  before `3d_structure` was assigned, silently dropping the whole structure. H counts now
  default to 0 and `molecular_info` is optional, so the structure always saves and
  round-trips via its binary.
- **Window-size-independent 3D rotation + new sensitivity setting.** Camera rotation is now
  handled in the ROTATE state normalized to a fixed reference size (VTK's stock `Rotate`
  divides by the live render size, so it slowed as the canvas grew). New
  **Mouse Rotation Speed** setting (`mouse_rotation_sensitivity`, default 1.0) scales it.
- Regression tests added for every change; version bumped to `4.4.0`.

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation
- [x] Tests
- [ ] CI / build

## Related issues

<!-- Link any related issues, e.g. Closes #123 -->

- Reported: dummy/ghost-atom XYZ failed to load and could not be saved to `.pmeprj`.
- Reported: 3D rotation slowed as the viewer canvas was enlarged.

## Test plan

- [x] Ran `python tests/run_all_tests.py` — all pass (1805 unit tests)
- [x] Manually tested in the GUI with the check list (loaded the reported ghost-atom
      `XX : x y z` file, verified 3D rotation speed is constant across window sizes)
- [x] Added new unit tests

New/updated tests:
- `test_io_manager.py` — dummy-label normalization (no RDKit stderr violation),
  ghost-atom column parsing, bond-estimation-failure/truncated-count robustness,
  non-standard-column status-bar warning.
- `test_app_state.py` — unsanitized 3D mol saves and round-trips in `.pmeprj`.
- `test_custom_interactor_style.py` — rotation speed is window-size independent and
  scales with the sensitivity setting; missing-renderer path is safe.
- `test_settings_3d_tabs.py` — `mouse_rotation_sensitivity` key + round-trip.

## Checklist

- [x] `python -m flake8 moleditpy/src/ --select=F` returns 0 issues
- [x] No bare `except:` clauses added (use `except Exception as e:` and log the error)
- [x] No new unused imports or variables
- [x] Plugin API changes are backwards-compatible (or documented in Summary) — no plugin
      API change in this PR
