### PR TITLE
version 4.5.1

### DIFF
--- a/moleditpy/src/moleditpy/core/molecular_data.py
+++ b/moleditpy/src/moleditpy/core/molecular_data.py
@@ -30,6 +30,93 @@ class PointTuple(tuple):
         return float(self[1])
 
 
+def _mdl_radical_code(radical_electrons: int) -> int:
+    """Map a count of unpaired electrons to an MDL radical code."""
+    # MDL encodes 1 = singlet, 2 = doublet, 3 = triplet.
+    if radical_electrons <= 0:
+        return 0
+    return 2 if radical_electrons == 1 else 3
+
+
+def _mdl_property_lines(atom_records: List[Dict[str, Any]]) -> List[str]:
+    """Build the M CHG / M RAD property lines for a V2000 block."""
+    lines = []
+    for tag, key, encode in (
+        ("CHG", "charge", int),
+        ("RAD", "radical", _mdl_radical_code),
+    ):
+        entries = [
+            (idx, encode(rec[key]))
+            for idx, rec in enumerate(atom_records, start=1)
+            if rec[key]
+        ]
+        # The MDL property block allows at most 8 entries per line.
+        for start in range(0, len(entries), 8):
+            chunk = entries[start : start + 8]
+            lines.append(
+                f"M  {tag}{len(chunk):3d}"
+                + "".join(f"{idx:4d}{val:4d}" for idx, val in chunk)
+            )
+    return lines
+
+
+def _to_v2000_block(
+    atom_records: List[Dict[str, Any]], bond_records: List[Dict[str, Any]]
+) -> str:
+    """Render collected atom/bond records as an MDL V2000 MOL block."""
+    lines = ["", "  MoleditPy", ""]
+    lines.append(
+        f"{len(atom_records):3d}{len(bond_records):3d}  0  0  0  0  0  0  0  0999 V2000"
+    )
+    for rec in atom_records:
+        # Charge and radical travel in the M CHG / M RAD blocks below, so every
+        # per-atom field here stays zero.
+        lines.append(
+            f"{rec['x']:10.4f}{rec['y']:10.4f}{0.0:10.4f} {rec['symbol']:<3}"
+            " 0  0  0  0  0  0  0  0  0  0  0  0"
+        )
+    for rec in bond_records:
+        lines.append(
+            f"{rec['a1']:3d}{rec['a2']:3d}{rec['order']:3d}{rec['stereo']:3d}  0  0  0"
+        )
+    lines.extend(_mdl_property_lines(atom_records))
+    lines.append("M  END")
+    return "\n".join(lines) + "\n"
+
+
+def _to_v3000_block(
+    atom_records: List[Dict[str, Any]], bond_records: List[Dict[str, Any]]
+) -> str:
+    """Render collected atom/bond records as an MDL V3000 MOL block."""
+    lines = ["", "  MoleditPy", "", "  0  0  0  0  0  0  0  0  0  0999 V3000"]
+    lines.append("M  V30 BEGIN CTAB")
+    lines.append(f"M  V30 COUNTS {len(atom_records)} {len(bond_records)} 0 0 0")
+    lines.append("M  V30 BEGIN ATOM")
+    for idx, rec in enumerate(atom_records, start=1):
+        extra = ""
+        if rec["charge"]:
+            extra += f" CHG={int(rec['charge'])}"
+        if rec["radical"]:
+            extra += f" RAD={_mdl_radical_code(rec['radical'])}"
+        lines.append(
+            f"M  V30 {idx} {rec['symbol']} "
+            f"{rec['x']:.4f} {rec['y']:.4f} 0.0000 0{extra}"
+        )
+    lines.append("M  V30 END ATOM")
+    lines.append("M  V30 BEGIN BOND")
+    for idx, rec in enumerate(bond_records, start=1):
+        cfg = ""
+        if rec["stereo"] == 1:
+            cfg = " CFG=1"
+        elif rec["stereo"] == 6:
+            cfg = " CFG=3"
+        lines.append(f"M  V30 {idx} {rec['order']} {rec['a1']} {rec['a2']}{cfg}")
+    lines.append("M  V30 END BOND")
+    lines.append("M  V30 END CTAB")
+    lines.append("M  END")
+    return "\n".join(lines) + "\n"
+
+
 class MolecularData:
     """In-memory graph of atoms and bonds, independent of any UI framework."""
 
@@ -348,7 +435,7 @@ class MolecularData:
 
         # Counts line and bond indices must only reflect atoms actually written
         atom_map: Dict[int, int] = {}
-        atom_lines: List[str] = []
+        atom_records: List[Dict[str, Any]] = []
         for old_id, atom in self.atoms.items():
             # Convert scene pixel coordinates to angstroms when emitting MOL block
             pos = atom.get("pos")
@@ -362,37 +449,23 @@ class MolecularData:
             else:
                 continue
 
-            x, y = x_px * ANGSTROM_PER_PIXEL, y_px * ANGSTROM_PER_PIXEL
-            z, symbol = 0.0, atom["symbol"]
-            charge = atom.get("charge", 0)
-
-            chg_code = 0
-            if charge == 3:
-                chg_code = 1
-            elif charge == 2:
-                chg_code = 2
-            elif charge == 1:
-                chg_code = 3
-            elif charge == -1:
-                chg_code = 5
-            elif charge == -2:
-                chg_code = 6
-            elif charge == -3:
-                chg_code = 7
-
-            atom_map[old_id] = len(atom_lines)
-            atom_lines.append(
-                f"{x:10.4f}{y:10.4f}{z:10.4f} {symbol:<3} 0  0  0{chg_code:3d}  0  0  0  0  0  0  0\n"
+            atom_map[old_id] = len(atom_records)
+            atom_records.append(
+                {
+                    "x": x_px * ANGSTROM_PER_PIXEL,
+                    "y": y_px * ANGSTROM_PER_PIXEL,
+                    "symbol": atom["symbol"],
+                    "charge": int(atom.get("charge", 0) or 0),
+                    "radical": int(atom.get("radical", 0) or 0),
+                }
             )
 
-        bond_lines = []
+        bond_records: List[Dict[str, Any]] = []
         for (id1, id2), bond in self.bonds.items():
             if id1 not in atom_map or id2 not in atom_map:
                 continue
-            idx1, idx2 = atom_map[id1] + 1, atom_map[id2] + 1
-            # Bond order may be a float (1.5 = aromatic); V2000 uses code 4.
+            # Bond order may be a float (1.5 = aromatic); MDL uses code 4.
             order_val = float(bond["order"])
-            order = 4 if order_val == 1.5 else int(order_val)
             stereo_code = 0
             bond_stereo = bond.get("stereo", 0)
             if bond_stereo == 1:
@@ -400,16 +473,20 @@ class MolecularData:
             elif bond_stereo == 2:
                 stereo_code = 6
 
-            bond_lines.append(
-                f"{idx1:3d}{idx2:3d}{order:3d}{stereo_code:3d}  0  0  0\n"
+            bond_records.append(
+                {
+                    "a1": atom_map[id1] + 1,
+                    "a2": atom_map[id2] + 1,
+                    "order": 4 if order_val == 1.5 else int(order_val),
+                    "stereo": stereo_code,
+                }
             )
 
-        mol_block = "\n  MoleditPy\n\n"
-        mol_block += f"{len(atom_lines):3d}{len(bond_lines):3d}  0  0  0  0  0  0  0  0999 V2000\n"
-        mol_block += "".join(atom_lines)
-        mol_block += "".join(bond_lines)
-        mol_block += "M  END\n"
-        return mol_block
+        # V2000 packs the counts into three-character fields, so anything past
+        # 999 would run the atom count into the bond count and corrupt the file.
+        if len(atom_records) > 999 or len(bond_records) > 999:
+            return _to_v3000_block(atom_records, bond_records)
+        return _to_v2000_block(atom_records, bond_records)
 
     def to_template_dict(
         self, name: str, version: str = "1.0", application_version: str = ""

--- a/moleditpy/src/moleditpy/ui/angle_dialog.py
+++ b/moleditpy/src/moleditpy/ui/angle_dialog.py
@@ -35,6 +35,7 @@ from ..core.mol_geometry import (
     calc_angle_deg,
     get_connected_group,
 )
+from ..utils.suppress_log import suppress_log
 
 if TYPE_CHECKING:
     from .main_window import MainWindow
@@ -468,5 +469,26 @@ class AngleDialog(GeometryBaseDialog):
                 atoms_to_move,
             )
 
+        achieved = calc_angle_deg(positions[idx_a], positions[idx_b], positions[idx_c])
+
         # Write updated positions back using inherited helper
         self._update_molecule_geometry(positions)
+
+        self._warn_if_angle_not_applied(new_angle_deg, achieved)
+
+    def _warn_if_angle_not_applied(self, requested: float, achieved: float) -> None:
+        """Tell the user when the requested angle could not be reached.
+
+        For an angle inside a ring the connected group reached from one arm
+        comes back around and contains all three atoms, so they rotate
+        together and the angle is unchanged. Leaving the old value silently
+        looks like the edit was applied.
+        """
+        if abs(achieved - requested) < 0.5:
+            return
+        with suppress_log(AttributeError, RuntimeError, TypeError):
+            self.main_window.statusBar().showMessage(
+                f"Angle unchanged ({achieved:.2f} deg): the three atoms rotate "
+                "together, which happens for an angle inside a ring.",
+                5000,
+            )

--- a/moleditpy/src/moleditpy/ui/bond_length_dialog.py
+++ b/moleditpy/src/moleditpy/ui/bond_length_dialog.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 import logging
 
 import numpy as np
-from typing import Any, TYPE_CHECKING, Optional, Sequence
+from typing import Any, Dict, TYPE_CHECKING, Optional, Sequence
 
 from PyQt6.QtCore import Qt
 from PyQt6.QtWidgets import (
@@ -32,6 +32,7 @@ from rdkit import Chem
 
 from .geometry_base_dialog import GeometryBaseDialog
 from ..core.mol_geometry import calc_distance, get_connected_group
+from ..utils.suppress_log import suppress_log
 
 if TYPE_CHECKING:
     from .main_window import MainWindow
@@ -359,6 +360,8 @@ class BondLengthDialog(GeometryBaseDialog):
         if current_distance == 0:
             return
 
+        original = {i: np.array(p, dtype=float) for i, p in positions.items()}
+
         direction = direction / current_distance
 
         if self.both_groups_radio.isChecked():
@@ -400,3 +403,46 @@ class BondLengthDialog(GeometryBaseDialog):
 
         # Write updated positions back using inherited helper
         self._update_molecule_geometry(positions)
+
+        self._warn_if_other_bonds_moved(original, positions, idx1, idx2)
+
+    def _warn_if_other_bonds_moved(
+        self,
+        before: Dict[int, Any],
+        after: Dict[int, Any],
+        idx1: int,
+        idx2: int,
+    ) -> None:
+        """Report a neighbouring bond that this edit resized as a side effect.
+
+        A bond inside a ring cannot be resized alone: the group translated
+        along the bond axis wraps back around the ring, so the ring closes at
+        a different length. Stretching a benzene bond to 1.80 A pulls its
+        neighbour to 1.24 A, shorter than a double bond, with nothing on
+        screen to say so.
+        """
+        edited = {idx1, idx2}
+        worst_delta = 0.0
+        worst_label = ""
+        for bond in self.mol.GetBonds():
+            i, j = bond.GetBeginAtomIdx(), bond.GetEndAtomIdx()
+            if {i, j} == edited or i not in before or j not in before:
+                continue
+            delta = calc_distance(after[i], after[j]) - calc_distance(
+                before[i], before[j]
+            )
+            if abs(delta) > abs(worst_delta):
+                worst_delta = delta
+                worst_label = (
+                    f"{self.mol.GetAtomWithIdx(i).GetSymbol()}{i}-"
+                    f"{self.mol.GetAtomWithIdx(j).GetSymbol()}{j}"
+                )
+
+        if abs(worst_delta) < 1e-4:
+            return
+        with suppress_log(AttributeError, RuntimeError, TypeError):
+            self.main_window.statusBar().showMessage(
+                f"Bond {worst_label} also changed by {worst_delta:+.3f} A: a bond "
+                "inside a ring cannot be resized on its own.",
+                5000,
+            )

--- a/moleditpy/src/moleditpy/ui/compute_logic.py
+++ b/moleditpy/src/moleditpy/ui/compute_logic.py
@@ -19,6 +19,7 @@ from PyQt6.QtCore import QThread, QTimer, QPoint
 from PyQt6.QtGui import QAction, QColor
 from PyQt6.QtWidgets import QMenu, QMessageBox, QWidget
 from rdkit import Chem
+from rdkit.Chem import AllChem
 
 from . import OBABEL_AVAILABLE
 
@@ -458,7 +459,31 @@ class ComputeManager:
         # Defer so Qt finishes routing the modal result before restoring focus.
         QTimer.singleShot(0, self.host.init_manager.view_2d.setFocus)
 
+    def _ez_consistent_mol_block(self) -> Optional[str]:
+        """MOL block whose 2D geometry encodes the editor's E/Z labels."""
+        data = self.host.state_manager.data
+        if not any(b.get("stereo", 0) in (3, 4) for b in data.bonds.values()):
+            return None
+        stereo_mol = data.to_rdkit_mol(use_2d_stereo=False)
+        if stereo_mol is None:
+            return None
+        try:
+            # MDL carries double-bond cis/trans only in the 2D coordinates, so a
+            # label that contradicts how the user drew the bond is lost unless
+            # the layout is rebuilt from the stereo. These coordinates only seed
+            # 3D generation; the 2D canvas keeps the user's own layout.
+            planar = Chem.Mol(stereo_mol)
+            planar.RemoveAllConformers()
+            AllChem.Compute2DCoords(planar)
+            return str(Chem.MolToMolBlock(planar, includeStereo=True))
+        except (RuntimeError, ValueError) as e:
+            logging.warning("E/Z-consistent 2D layout failed: %s", e)
+            return None
+
     def _setup_mol_block_for_worker(self, mol: Chem.Mol) -> str:
+        ez_block = self._ez_consistent_mol_block()
+        if ez_block:
+            return ez_block
         mol_block = self.host.state_manager.data.to_mol_block()
         if not mol_block:
             mol_block = Chem.MolToMolBlock(mol, includeStereo=True)

--- a/moleditpy/src/moleditpy/ui/dihedral_dialog.py
+++ b/moleditpy/src/moleditpy/ui/dihedral_dialog.py
@@ -35,6 +35,7 @@ from ..core.mol_geometry import (
     calculate_dihedral,
     get_connected_group,
 )
+from ..utils.suppress_log import suppress_log
 
 if TYPE_CHECKING:
     from .main_window import MainWindow
@@ -469,5 +470,27 @@ class DihedralDialog(GeometryBaseDialog):
                 positions, idx1, idx2, idx3, idx4, new_dihedral_deg, atoms_to_move
             )
 
+        achieved = calculate_dihedral(positions, idx1, idx2, idx3, idx4)
+
         # Write updated positions back using inherited helper
         self._update_molecule_geometry(positions)
+
+        self._warn_if_torsion_not_applied(new_dihedral_deg, achieved)
+
+    def _warn_if_torsion_not_applied(self, requested: float, achieved: float) -> None:
+        """Tell the user when the requested torsion could not be reached.
+
+        A torsion inside a ring cannot rotate: the connected group reached from
+        one side comes back around and contains all four atoms, so they turn
+        together and the angle is unchanged. Silently leaving the old value
+        looks like the edit was applied.
+        """
+        difference = abs(achieved - requested) % 360.0
+        if min(difference, 360.0 - difference) < 0.5:
+            return
+        with suppress_log(AttributeError, RuntimeError, TypeError):
+            self.main_window.statusBar().showMessage(
+                f"Dihedral unchanged ({achieved:.2f}°): the four atoms rotate "
+                "together, which happens for a bond inside a ring.",
+                5000,
+            )

--- a/moleditpy/src/moleditpy/ui/edit_actions_logic.py
+++ b/moleditpy/src/moleditpy/ui/edit_actions_logic.py
@@ -583,26 +583,17 @@ class EditActionsManager:
                 if orig_id not in self.host.state_manager.data.atoms:
                     continue
 
-                # Get implicit hydrogens; fallback to total - explicit
-                implicit_h = (
-                    int(rd_atom.GetNumImplicitHs())
-                    if hasattr(rd_atom, "GetNumImplicitHs")
-                    else 0
-                )
-                if implicit_h is None or implicit_h < 0:
+                # Hydrogens still needing an atom of their own. GetTotalNumHs()
+                # excludes H already drawn as atoms but includes the
+                # property-explicit H that sanitization assigns to an aromatic
+                # N-H; subtracting GetNumExplicitHs() here would cancel exactly
+                # that term and leave luminol's two N-H without hydrogens.
+                try:
+                    implicit_h = int(rd_atom.GetTotalNumHs())
+                except (AttributeError, RuntimeError, ValueError, TypeError):
                     implicit_h = 0
-                if implicit_h == 0:
-                    # Fallback
-                    try:
-                        total_h = int(rd_atom.GetTotalNumHs())
-                        explicit_h = (
-                            int(rd_atom.GetNumExplicitHs())
-                            if hasattr(rd_atom, "GetNumExplicitHs")
-                            else 0
-                        )
-                        implicit_h = max(0, total_h - explicit_h)
-                    except (AttributeError, RuntimeError, ValueError, TypeError):
-                        implicit_h = 0
+                if implicit_h < 0:
+                    implicit_h = 0
 
                 if implicit_h <= 0:
                     continue
@@ -954,12 +945,16 @@ class EditActionsManager:
                     continue
                 original_id = atom.GetIntProp("_original_atom_id")
 
-                # Robust retrieval of H counts: prefer implicit, fallback to total or 0
+                # GetTotalNumHs() counts implicit plus property-explicit H but
+                # not H drawn as its own atom, which is exactly what the label
+                # should show. Sanitization files an aromatic N-H (luminol,
+                # pyrrole) under the property, where GetNumImplicitHs() alone
+                # reports 0 and the H silently vanishes from the label.
                 try:
-                    h_count = int(atom.GetNumImplicitHs())
+                    h_count = int(atom.GetTotalNumHs())
                 except (AttributeError, RuntimeError, ValueError, TypeError):
                     try:
-                        h_count = int(atom.GetTotalNumHs())
+                        h_count = int(atom.GetNumImplicitHs())
                     except (AttributeError, RuntimeError, ValueError, TypeError):
                         h_count = 0
 

--- a/moleditpy/src/moleditpy/ui/io_logic.py
+++ b/moleditpy/src/moleditpy/ui/io_logic.py
@@ -816,6 +816,7 @@ class IOManager:
                     atom.GetSymbol(),
                     QPointF(scene_x, scene_y),
                     charge=atom.GetFormalCharge(),
+                    radical=atom.GetNumRadicalElectrons(),
                 )
                 rdkit_idx_to_my_id[i] = atom_id
 

--- a/moleditpy/src/moleditpy/ui/io_logic.py
+++ b/moleditpy/src/moleditpy/ui/io_logic.py
@@ -152,8 +152,11 @@ class IOManager:
 
     def _mol_from_xyz_lines(self, raw_lines: list[str]) -> Any:
         """Create an RDKit molecule from XYZ text lines."""
-        lines = [ln.strip() for ln in raw_lines if not ln.strip().startswith("#")]
-        while lines and not lines[0]:
+        lines = [ln.strip() for ln in raw_lines]
+        # Only leading comments are metadata. In a headed XYZ the second line is
+        # the title and may itself begin with '#', so discarding every '#' line
+        # would shift the atom rows up one and silently drop the first atom.
+        while lines and (not lines[0] or lines[0].startswith("#")):
             lines.pop(0)
 
         if not lines:
@@ -167,9 +170,11 @@ class IOManager:
             if num_atoms == 0:
                 raise ValueError("XYZ file has zero atoms")
         except ValueError as exc:
-            # Not a standard headed XYZ — treat all lines as atom rows
+            # Not a standard headed XYZ — treat all lines as atom rows. There is
+            # no title line here, so interleaved comments are safe to drop.
             if "zero atoms" in str(exc) or "too few" in str(exc):
                 raise
+            lines = [ln for ln in lines if ln and not ln.startswith("#")]
             num_atoms = len(lines)
             atom_start = 0
 

--- a/moleditpy/src/moleditpy/ui/io_logic.py
+++ b/moleditpy/src/moleditpy/ui/io_logic.py
@@ -447,6 +447,7 @@ class IOManager:
         num_atoms = mol.GetNumAtoms()
         bonds_added = []
 
+        candidates = []
         for i in range(num_atoms):
             for j in range(i + 1, num_atoms):
                 atom_i = mol.GetAtomWithIdx(i)
@@ -461,21 +462,27 @@ class IOManager:
                 expected = radius_i + radius_j
                 tolerance = 1.2 if (symbol_i == "H" or symbol_j == "H") else 1.3
                 if expected * 0.5 <= distance <= expected * tolerance:
-                    if mol.GetBondBetweenAtoms(i, j) is None:
-                        if (
-                            symbol_i == "H" and mol.GetAtomWithIdx(i).GetDegree() >= 1
-                        ) or (
-                            symbol_j == "H" and mol.GetAtomWithIdx(j).GetDegree() >= 1
-                        ):
-                            continue
-                        try:
-                            mol.AddBond(i, j, Chem.BondType.SINGLE)
-                            bonds_added.append((i, j, distance))
-                        except (RuntimeError, ValueError, TypeError):
-                            # Safe defensive fallback catching RuntimeError, ValueError, TypeError
-                            logging.debug(
-                                "Suppressed non-critical error", exc_info=True
-                            )
+                    candidates.append((distance, i, j, symbol_i, symbol_j))
+
+        # Nearest pairs first. The monovalent-H rule below accepts whichever
+        # partner it sees first, so index order would otherwise decide the
+        # connectivity and the same geometry could bond an H differently
+        # depending only on how the file happened to list its atoms.
+        candidates.sort(key=lambda c: c[0])
+
+        for distance, i, j, symbol_i, symbol_j in candidates:
+            if mol.GetBondBetweenAtoms(i, j) is not None:
+                continue
+            if (symbol_i == "H" and mol.GetAtomWithIdx(i).GetDegree() >= 1) or (
+                symbol_j == "H" and mol.GetAtomWithIdx(j).GetDegree() >= 1
+            ):
+                continue
+            try:
+                mol.AddBond(i, j, Chem.BondType.SINGLE)
+                bonds_added.append((i, j, distance))
+            except (RuntimeError, ValueError, TypeError):
+                # Safe defensive fallback catching RuntimeError, ValueError, TypeError
+                logging.debug("Suppressed non-critical error", exc_info=True)
 
         return len(bonds_added)
 

--- a/moleditpy/src/moleditpy/ui/string_importers.py
+++ b/moleditpy/src/moleditpy/ui/string_importers.py
@@ -119,6 +119,7 @@ class StringImporterManager:
                 atom.GetSymbol(),
                 QPointF(scene_x, scene_y),
                 charge=atom.GetFormalCharge(),
+                radical=atom.GetNumRadicalElectrons(),
             )
             rdkit_idx_to_my_id[i] = atom_id
         return rdkit_idx_to_my_id

--- a/tests/assertion_catalog.md
+++ b/tests/assertion_catalog.md
@@ -1300,11 +1300,11 @@ _Preinitialized temp conversion mode should not suppress the saved setting._
 
 - assert options['conversion_mode'] == 'fallback'
 
-### test_trigger_conversion_ez_stereo_injection
-_Test that M CFG lines are injected for E/Z stereo bonds._
+### test_trigger_conversion_sends_ez_stereo_to_worker
+_The block trigger_conversion sends must carry the bond's E/Z stereo._
 
-- assert 'M  CFG' in sent_block
-- assert 'M  CFG  1   2   2' in sent_block
+- assert parsed is not None
+- assert Chem.MolToSmiles(parsed) == 'C/C=C/C'
 
 ### test_on_calculation_error_uff_fallback_temporary
 _Verify that UFF fallback uses _temp_optimization_method and doesn't change persistent setting._
@@ -1502,6 +1502,18 @@ _A 'Halt' error still schedules a deferred setFocus so the 2D editor_
 __handle_chemistry_problems must NOT call view_2d.setFocus() directly_
 
 - compute.host.init_manager.view_2d.setFocus.assert_not_called()
+
+### test_worker_mol_block_carries_ez_label
+_The block sent for 3D generation must encode the label, not the drawing._
+
+- assert parsed is not None
+- assert Chem.MolToSmiles(parsed) == expected
+
+### test_worker_mol_block_unlabelled_bond_keeps_drawn_geometry
+_Without an E/Z label the drawn geometry still decides the stereo._
+
+- assert parsed is not None
+- assert Chem.MolToSmiles(parsed) == 'C/C=C/C'
 
 ## tests/unit/test_constants.py
 
@@ -4318,6 +4330,47 @@ _In group mode apply_geometry_update rotates the whole side to the target dihedr
 
 - assert result == pytest.approx(60.0, abs=1.0)
 
+### TestDihedralRingFeedback.test_unreachable_torsion_reports_to_status_bar
+_No description provided._
+
+- mw.statusBar().showMessage.assert_called_once()
+- assert 'unchanged' in message
+- assert 'ring' in message
+
+### TestDihedralRingFeedback.test_applied_torsion_stays_silent
+_No description provided._
+
+- mw.statusBar().showMessage.assert_not_called()
+
+### TestDihedralRingFeedback.test_wraparound_is_not_reported
+_-180 and +180 name the same torsion._
+
+- mw.statusBar().showMessage.assert_not_called()
+
+### TestRingEditFeedback.test_ring_bond_resize_reports_the_neighbour_it_moved
+_No description provided._
+
+- mw.statusBar().showMessage.assert_called_once()
+- assert 'also changed' in message
+- assert 'ring' in message
+
+### TestRingEditFeedback.test_acyclic_bond_resize_stays_silent
+_No description provided._
+
+- mw.statusBar().showMessage.assert_not_called()
+
+### TestRingEditFeedback.test_unreachable_ring_angle_is_reported
+_No description provided._
+
+- mw.statusBar().showMessage.assert_called_once()
+- assert 'unchanged' in message
+- assert 'ring' in message
+
+### TestRingEditFeedback.test_applied_angle_stays_silent
+_No description provided._
+
+- mw.statusBar().showMessage.assert_not_called()
+
 ## tests/unit/test_hydrogen.py
 
 ### test_add_hydrogen_atoms_app_logic
@@ -4332,6 +4385,24 @@ _Verify remove_hydrogen_atoms finds and deletes H items using app logic._
 - actions.scene.delete_items.assert_called()
 - assert h_item in deleted_set
 - assert actions.scene.atom_items[c_id] not in deleted_set
+
+### test_h_label_counts_match_molecule
+_The 2D H label must equal the hydrogens the molecule actually carries._
+
+- assert mol is not None
+- assert counts == expected
+
+### test_h_label_ignores_hydrogens_drawn_as_atoms
+_H drawn as its own atom must not also be counted in the label._
+
+- assert mol is not None
+- assert actions._compute_h_counts(mol)[c_id] == 0
+
+### test_add_hydrogen_atoms_covers_aromatic_nh
+_Add Hydrogens must not skip an aromatic N-H (luminol is C8H7N3O2)._
+
+- assert len(after) - before == 7
+- assert set(nitrogens) == set(added_to)
 
 ## tests/unit/test_io.py
 
@@ -4515,6 +4586,33 @@ _No description provided._
 - assert mol is not None
 - assert mol.GetNumAtoms() == 2
 
+### TestXyzLoadRobustness.test_ambiguous_hydrogen_bonds_to_its_nearest_neighbour
+_H is monovalent, so only one partner wins; it must be the closest._
+
+- assert partners == {'O'}
+
+### TestXyzLoadRobustness.test_bond_perception_is_independent_of_atom_order
+_Shuffling the rows of a real molecule must not change its bonds._
+
+- assert len(reference) == 8
+- assert topology(list(reversed(rows))) == reference
+- assert topology(rows[3:] + rows[:3]) == reference
+
+### TestXyzLoadRobustness.test_hash_title_line_keeps_the_first_atom
+_A '#' title must not be filtered out._
+
+- assert [a.GetSymbol() for a in mol.GetAtoms()] == ['O', 'H', 'H']
+
+### TestXyzLoadRobustness.test_leading_hash_comment_before_count_is_skipped
+_Comments ahead of the count line are metadata and still skipped._
+
+- assert [a.GetSymbol() for a in mol.GetAtoms()] == ['C', 'O']
+
+### TestXyzLoadRobustness.test_headerless_xyz_still_drops_interleaved_comments
+_With no count line there is no title, so comments stay droppable._
+
+- assert [a.GetSymbol() for a in mol.GetAtoms()] == ['O', 'H', 'H']
+
 ### TestXyzLoadRobustness.test_skip_checks_with_bond_failure_loads
 _No description provided._
 
@@ -4567,6 +4665,21 @@ _No description provided._
 
 - assert msgs
 - assert all(('non-standard' not in m for m in msgs))
+
+### TestLoadMolFileProperties.test_radical_survives_mol_import
+_An M RAD block must reach the editor; the count used to be dropped._
+
+- assert 'M  RAD' in mol_text
+- assert len(radicals) == 1
+- assert radicals[0]['symbol'] == 'C'
+- assert radicals[0]['radical'] == 1
+
+### TestLoadMolFileProperties.test_charge_survives_mol_import
+_The companion property must keep working._
+
+- assert len(charged) == 1
+- assert charged[0]['symbol'] == 'N'
+- assert charged[0]['charge'] == 1
 
 ## tests/unit/test_items_visual.py
 
@@ -5288,6 +5401,42 @@ _No description provided._
 _No description provided._
 
 - assert mol is not None
+
+### test_fallback_preserves_formal_charge
+_Charges must survive the manual writer, including beyond the +-3 field._
+
+- assert parsed.GetAtomWithIdx(1).GetFormalCharge() == charge
+
+### test_fallback_preserves_radical_electrons
+_Radicals need an M RAD block; the atom line has no field for them._
+
+- assert parsed.GetAtomWithIdx(1).GetNumRadicalElectrons() == radical
+
+### test_fallback_preserves_charge_and_radical_together
+_A charged radical must not lose either property._
+
+- assert atom.GetFormalCharge() == 1
+- assert atom.GetNumRadicalElectrons() == 1
+
+### test_fallback_charge_column_is_not_the_hydrogen_count_field
+_The per-atom fields stay zero: charge belongs in M CHG, not column hhh._
+
+- assert atom_line[34:].split() == ['0'] * 12
+- assert 'M  CHG' in block
+
+### test_fallback_switches_to_v3000_past_the_v2000_counts_limit
+_Past 999 atoms a V2000 counts line would corrupt; V3000 must be used._
+
+- assert 'V3000' in block.splitlines()[3]
+- assert parsed.GetNumAtoms() == 1200
+- assert parsed.GetNumBonds() == 600
+- assert sum((1 for a in parsed.GetAtoms() if a.GetFormalCharge())) == 1
+- assert sum((1 for a in parsed.GetAtoms() if a.GetNumRadicalElectrons())) == 1
+
+### test_fallback_keeps_v2000_for_small_molecules
+_Small structures must not churn to V3000._
+
+- assert 'V2000' in block.splitlines()[3]
 
 ## tests/unit/test_molecule_scene_behavior.py
 
@@ -8762,6 +8911,191 @@ _No description provided._
 _No description provided._
 
 - assert 'Error loading from InChI: view gone' in _last_status(mock_parser_host)
+
+### test_smiles_preserves_radical_electrons
+_Radicals must survive SMILES import; the count was previously dropped._
+
+- assert len(radicals) == 1
+- assert radicals[0]['symbol'] == symbol
+- assert radicals[0]['radical'] == electrons
+
+### test_smiles_without_radical_stays_unpaired_free
+_A closed-shell molecule must not gain phantom radicals._
+
+- assert all((a.get('radical', 0) == 0 for a in data.atoms.values()))
+
+## tests/unit/test_sync_linux_version.py
+
+### test_dotted_module_references_are_renamed
+_No description provided._
+
+- assert sync.transform('from moleditpy.ui import x', False) == 'from moleditpy_linux.ui import x'
+- assert sync.transform('import moleditpy.core.mol', False) == 'import moleditpy_linux.core.mol'
+
+### test_bare_import_forms_are_renamed
+_No description provided._
+
+- assert sync.transform('import moleditpy', False) == 'import moleditpy_linux'
+- assert sync.transform('from moleditpy import x', False) == 'from moleditpy_linux import x'
+
+### test_module_path_inside_a_string_is_renamed
+_main_window_init compares against a module name at runtime; it must track._
+
+- assert sync.transform(src, False) == 'if "moleditpy_linux.utils.constants" in name:'
+
+### test_config_directory_is_not_renamed
+_~/.moleditpy is shared between both builds._
+
+- assert sync.transform(src, False) == src
+
+### test_log_filename_is_preserved
+_No description provided._
+
+- assert sync.transform(src, False) == src
+
+### test_log_path_inside_ui_text_is_preserved
+_No description provided._
+
+- assert sync.transform(src, False) == src
+
+### test_windows_app_id_is_preserved
+_No description provided._
+
+- assert sync.transform(src, False) == src
+
+### test_no_double_linux_suffix_is_produced
+_The old three-rule chain produced moleditpy_linux_linux and patched it after._
+
+- assert 'moleditpy_linux_linux' not in out
+- assert out == 'import moleditpy_linux.ui\nfrom moleditpy_linux import y\n'
+
+### test_already_renamed_text_is_left_alone
+_No description provided._
+
+- assert sync.transform(src, False) == src
+
+### test_version_lookup_package_is_renamed
+_No description provided._
+
+- assert sync.transform('version("MoleditPy")', False) == 'version("MoleditPy-linux")'
+
+### test_obabel_probe_is_disabled
+_No description provided._
+
+- assert 'find_spec' not in out
+- assert out.count('OBABEL_AVAILABLE = False') == 2
+
+### test_obabel_disablement_preserves_indentation
+_No description provided._
+
+- assert '    OBABEL_AVAILABLE = False\n' in out
+
+### test_obabel_rewrite_does_not_swallow_later_lines
+_A greedy DOTALL `.*None` used to delete everything up to the last None._
+
+- assert 'except ImportError:' in out
+- assert 'DEFAULT_THING = None' in out
+- assert 'TRAILER = 1' in out
+- assert len(out.splitlines()) == len(src.splitlines())
+
+### test_obabel_rewrite_only_applies_to_the_root_init
+_No description provided._
+
+- assert sync.transform(src, False) == src
+- assert sync.transform(src, True) == 'OBABEL_AVAILABLE = False\n'
+
+### test_read_dependencies_maps_name_to_requirement
+_No description provided._
+
+- assert deps == {'numpy': 'numpy', 'pyvista': 'pyvista < 0.49'}
+
+### test_read_dependencies_on_missing_file_is_empty
+_No description provided._
+
+- assert sync.read_dependencies('G:\\nope\\pyproject.toml') == {}
+
+### test_shared_pins_matching_reports_nothing
+_No description provided._
+
+- assert sync.check_shared_pins() == []
+
+### test_shared_pin_drift_is_reported
+_No description provided._
+
+- assert 'rdkit' in message and '2027.1' in message and ('2026.4' in message)
+
+### test_real_pyprojects_share_identical_pins
+_The shipped pair must not drift; only openbabel is main-only._
+
+- assert sync.check_shared_pins() == []
+
+### test_sync_version_fails_when_a_pyproject_is_missing
+_No description provided._
+
+- assert sync.sync_version(dry_run=True, prefix='') is False
+
+### test_sync_version_fails_when_version_is_absent
+_No description provided._
+
+- assert sync.sync_version(dry_run=True, prefix='') is False
+
+### test_sync_version_writes_the_main_version
+_No description provided._
+
+- assert sync.sync_version(dry_run=False, prefix='') is True
+- assert 'version = "4.5.0"' in linux.read_text(encoding='utf-8')
+- assert 'name = "MoleditPy-linux"' in linux.read_text(encoding='utf-8')
+
+### test_sync_version_dry_run_does_not_write
+_No description provided._
+
+- assert 'version = "4.4.1"' in linux.read_text(encoding='utf-8')
+
+### test_missing_main_source_returns_none
+_No description provided._
+
+- assert sync.sync_linux() is None
+
+### test_sync_creates_the_transformed_tree
+_No description provided._
+
+- assert sync.sync_linux() == 3
+- assert (src_linux / 'main.py').read_text(encoding='utf-8') == 'import moleditpy_linux.ui\n'
+- assert 'find_spec' not in (src_linux / '__init__.py').read_text(encoding='utf-8')
+- assert (src_linux / 'assets' / 'icon.png').read_bytes() == b'\x89PNG\r\n'
+
+### test_second_sync_reports_no_changes
+_No description provided._
+
+- assert sync.sync_linux() == 0
+
+### test_dry_run_leaves_the_tree_untouched
+_No description provided._
+
+- assert sync.sync_linux(dry_run=True) == 3
+- assert not src_linux.exists()
+
+### test_orphan_files_are_removed_and_counted
+_No description provided._
+
+- assert sync.sync_linux() == 1
+- assert not stale.exists()
+
+### test_pycache_is_not_counted_as_a_change
+_No description provided._
+
+- assert sync.sync_linux() == 0
+- assert not cache.exists()
+
+### test_source_pycache_is_not_copied
+_No description provided._
+
+- assert not (src_linux / '__pycache__').exists()
+
+### test_sync_fails_when_the_version_cannot_be_read
+_No description provided._
+
+- assert sync.sync_linux() is None
 
 ## tests/unit/test_system_utils.py
 

--- a/tests/coverage_report.md
+++ b/tests/coverage_report.md
@@ -1,6 +1,6 @@
 # MoleditPy Coverage Report
 
-- **Overall Project Coverage**: **89.46%**
+- **Overall Project Coverage**: **89.50%**
 
 ### Coverage Breakdown
 
@@ -9,7 +9,7 @@
 | moleditpy\src\moleditpy\__init__.py                     |      6 |      2 |   66.7% |
 | moleditpy\src\moleditpy\main.py                         |    170 |     35 |   79.4% |
 | moleditpy\src\moleditpy\core\mol_geometry.py            |    292 |      4 |   98.6% |
-| moleditpy\src\moleditpy\core\molecular_data.py          |    258 |      0 |  100.0% |
+| moleditpy\src\moleditpy\core\molecular_data.py          |    284 |      3 |   98.9% |
 | moleditpy\src\moleditpy\plugins\plugin_interface.py     |    238 |      6 |   97.5% |
 | moleditpy\src\moleditpy\plugins\plugin_manager.py       |    407 |     11 |   97.3% |
 | moleditpy\src\moleditpy\plugins\plugin_manager_window.py |    187 |      2 |   98.9% |
@@ -18,27 +18,27 @@
 | moleditpy\src\moleditpy\ui\align_plane_dialog.py        |    151 |     15 |   90.1% |
 | moleditpy\src\moleditpy\ui\alignment_dialog.py          |    147 |     10 |   93.2% |
 | moleditpy\src\moleditpy\ui\analysis_window.py           |    117 |     25 |   78.6% |
-| moleditpy\src\moleditpy\ui\angle_dialog.py              |    264 |     28 |   89.4% |
+| moleditpy\src\moleditpy\ui\angle_dialog.py              |    272 |     28 |   89.7% |
 | moleditpy\src\moleditpy\ui\app_state.py                 |    345 |     57 |   83.5% |
 | moleditpy\src\moleditpy\ui\atom_item.py                 |    325 |     39 |   88.0% |
 | moleditpy\src\moleditpy\ui\atom_picking.py              |    167 |     13 |   92.2% |
 | moleditpy\src\moleditpy\ui\base_picking_dialog.py       |     81 |      4 |   95.1% |
 | moleditpy\src\moleditpy\ui\bond_item.py                 |    366 |     55 |   85.0% |
-| moleditpy\src\moleditpy\ui\bond_length_dialog.py        |    238 |     17 |   92.9% |
+| moleditpy\src\moleditpy\ui\bond_length_dialog.py        |    257 |     17 |   93.4% |
 | moleditpy\src\moleditpy\ui\calculation_worker.py        |    583 |     90 |   84.6% |
 | moleditpy\src\moleditpy\ui\color_settings_dialog.py     |    166 |     13 |   92.2% |
-| moleditpy\src\moleditpy\ui\compute_logic.py             |    432 |      7 |   98.4% |
+| moleditpy\src\moleditpy\ui\compute_logic.py             |    451 |     11 |   97.6% |
 | moleditpy\src\moleditpy\ui\constrained_optimization_dialog.py |    480 |     24 |   95.0% |
 | moleditpy\src\moleditpy\ui\custom_interactor_style.py   |    772 |    113 |   85.4% |
 | moleditpy\src\moleditpy\ui\custom_qt_interactor.py      |     24 |      0 |  100.0% |
 | moleditpy\src\moleditpy\ui\dialog_3d_picking_mixin.py   |    137 |     19 |   86.1% |
 | moleditpy\src\moleditpy\ui\dialog_logic.py              |    230 |     25 |   89.1% |
-| moleditpy\src\moleditpy\ui\dihedral_dialog.py           |    268 |     32 |   88.1% |
+| moleditpy\src\moleditpy\ui\dihedral_dialog.py           |    277 |     32 |   88.4% |
 | moleditpy\src\moleditpy\ui\edit_3d_logic.py             |    221 |     32 |   85.5% |
-| moleditpy\src\moleditpy\ui\edit_actions_logic.py        |    821 |    130 |   84.2% |
+| moleditpy\src\moleditpy\ui\edit_actions_logic.py        |    817 |    127 |   84.5% |
 | moleditpy\src\moleditpy\ui\export_logic.py              |    520 |     85 |   83.7% |
 | moleditpy\src\moleditpy\ui\geometry_base_dialog.py      |     52 |      1 |   98.1% |
-| moleditpy\src\moleditpy\ui\io_logic.py                  |    731 |     77 |   89.5% |
+| moleditpy\src\moleditpy\ui\io_logic.py                  |    737 |     76 |   89.7% |
 | moleditpy\src\moleditpy\ui\main_window.py               |    195 |     13 |   93.3% |
 | moleditpy\src\moleditpy\ui\main_window_init.py          |   1061 |     94 |   91.1% |
 | moleditpy\src\moleditpy\ui\mirror_dialog.py             |     72 |      7 |   90.3% |
@@ -67,11 +67,11 @@
 | moleditpy\src\moleditpy\utils\sip_isdeleted_safe.py     |     19 |      0 |  100.0% |
 | moleditpy\src\moleditpy\utils\suppress_log.py           |     10 |      0 |  100.0% |
 | moleditpy\src\moleditpy\utils\system_utils.py           |     39 |      0 |  100.0% |
-| **TOTAL** | **16560** | **1745** | **89.46%** |
+| **TOTAL** | **16643** | **1748** | **89.50%** |
 
 ## Test Suite Status
-- **Total tests passed**: 2047 (1 skipped)
-- **Unit tests**: PASSED (1863 passed)
+- **Total tests passed**: 2125 (1 skipped)
+- **Unit tests**: PASSED (1941 passed)
 - **Integration tests**: PASSED (75 passed)
 - **E2E tests**: PASSED (34 passed, 1 skipped)
 - **GUI tests**: PASSED (75 passed)

--- a/tests/pylint-score.txt
+++ b/tests/pylint-score.txt
@@ -1,1 +1,1 @@
-Your code has been rated at 9.35/10
+Your code has been rated at 9.36/10

--- a/tests/unit/test_compute_logic.py
+++ b/tests/unit/test_compute_logic.py
@@ -1743,3 +1743,24 @@ def test_worker_mol_block_unlabelled_bond_keeps_drawn_geometry(mock_parser_host)
     parsed = Chem.MolFromMolBlock(block)
     assert parsed is not None
     assert Chem.MolToSmiles(parsed) == "C/C=C/C"
+
+
+def test_ez_block_falls_back_when_molecule_cannot_be_built(mock_parser_host):
+    """An unbuildable structure must fall through, not crash the conversion."""
+    compute = DummyCompute(mock_parser_host)
+    _but2ene_drawn_trans(compute.data, 3)
+
+    with patch.object(compute.data, "to_rdkit_mol", return_value=None):
+        assert compute._ez_consistent_mol_block() is None
+
+
+def test_ez_block_falls_back_when_layout_fails(mock_parser_host):
+    """A failure while rebuilding the 2D layout is logged, not raised."""
+    compute = DummyCompute(mock_parser_host)
+    _but2ene_drawn_trans(compute.data, 3)
+
+    with patch(
+        "moleditpy.ui.compute_logic.AllChem.Compute2DCoords",
+        side_effect=RuntimeError("depiction failed"),
+    ):
+        assert compute._ez_consistent_mol_block() is None

--- a/tests/unit/test_compute_logic.py
+++ b/tests/unit/test_compute_logic.py
@@ -1,5 +1,6 @@
 """Unit tests for ComputeManager optimization trigger logic."""
 
+import pytest
 from rdkit import Chem
 from rdkit.Chem import AllChem
 from moleditpy.ui.compute_logic import ComputeManager
@@ -1073,8 +1074,8 @@ def test_trigger_conversion_uses_default_when_temp_mode_is_none(mock_parser_host
     assert options["conversion_mode"] == "fallback"
 
 
-def test_trigger_conversion_ez_stereo_injection(mock_parser_host):
-    """Test that M CFG lines are injected for E/Z stereo bonds."""
+def test_trigger_conversion_sends_ez_stereo_to_worker(mock_parser_host):
+    """The block trigger_conversion sends must carry the bond's E/Z stereo."""
     compute = DummyCompute(mock_parser_host)
 
     # Create valid E-isomer (trans-2-butene)
@@ -1128,11 +1129,12 @@ def test_trigger_conversion_ez_stereo_injection(mock_parser_host):
             call_args = mock_start_work.emit.call_args
             sent_block = call_args[0][0]
 
-            print(f"DEBUG: Sent Block:\\n{sent_block}")
-            assert "M  CFG" in sent_block
-            # Check for E isomer (val 2) on bond index 2 (RDKit idx 1 + 1)
-            # 1-2 is usually index 1
-            assert "M  CFG  1   2   2" in sent_block
+            # The block must actually encode the E label. An "M  CFG" line
+            # would not: RDKit ignores it, so stereo has to reach the worker
+            # through the 2D geometry it does read.
+            parsed = Chem.MolFromMolBlock(sent_block)
+            assert parsed is not None
+            assert Chem.MolToSmiles(parsed) == "C/C=C/C"
 
 
 def test_on_calculation_error_uff_fallback_temporary(mock_parser_host):
@@ -1696,3 +1698,48 @@ def test_chemistry_problems_focus_not_called_directly(mock_parser_host):
 
     # If setFocus was called synchronously it would appear here; it must not.
     compute.host.init_manager.view_2d.setFocus.assert_not_called()
+
+
+def _but2ene_drawn_trans(data, stereo_label):
+    """but-2-ene laid out zig-zag (trans) with an explicit E/Z label."""
+    ids = [
+        data.add_atom("C", QPointF(i * 50.0, -50.0 if i % 2 else 0.0)) for i in range(4)
+    ]
+    data.add_bond(ids[0], ids[1], order=1)
+    data.add_bond(ids[1], ids[2], order=2, stereo=stereo_label)
+    data.add_bond(ids[2], ids[3], order=1)
+    return ids
+
+
+@pytest.mark.parametrize(
+    "stereo_label,expected",
+    [(3, r"C/C=C\C"), (4, "C/C=C/C")],
+)
+def test_worker_mol_block_carries_ez_label(mock_parser_host, stereo_label, expected):
+    """The block sent for 3D generation must encode the label, not the drawing.
+
+    MDL stores double-bond cis/trans only as 2D geometry, so a Z label on a
+    bond drawn trans was silently dropped and the worker built the wrong isomer.
+    """
+    compute = DummyCompute(mock_parser_host)
+    _but2ene_drawn_trans(compute.data, stereo_label)
+
+    mol = compute.data.to_rdkit_mol()
+    block = ComputeManager._setup_mol_block_for_worker(compute, mol)
+
+    parsed = Chem.MolFromMolBlock(block)
+    assert parsed is not None
+    assert Chem.MolToSmiles(parsed) == expected
+
+
+def test_worker_mol_block_unlabelled_bond_keeps_drawn_geometry(mock_parser_host):
+    """Without an E/Z label the drawn geometry still decides the stereo."""
+    compute = DummyCompute(mock_parser_host)
+    _but2ene_drawn_trans(compute.data, 0)
+
+    mol = compute.data.to_rdkit_mol()
+    block = ComputeManager._setup_mol_block_for_worker(compute, mol)
+
+    parsed = Chem.MolFromMolBlock(block)
+    assert parsed is not None
+    assert Chem.MolToSmiles(parsed) == "C/C=C/C"

--- a/tests/unit/test_geometry_dialogs.py
+++ b/tests/unit/test_geometry_dialogs.py
@@ -640,3 +640,31 @@ class TestDihedralDialogGeometry:
         positions = mol.GetConformer().GetPositions()
         result = calculate_dihedral(positions, 2, 0, 1, 5)
         assert result == pytest.approx(60.0, abs=1.0)
+
+
+class TestDihedralRingFeedback:
+    """A torsion inside a ring cannot rotate; the user must be told."""
+
+    def test_unreachable_torsion_reports_to_status_bar(self, dihedral_dlg):
+        dlg, _, mw = dihedral_dlg
+        dlg._warn_if_torsion_not_applied(60.0, -29.17)
+
+        mw.statusBar().showMessage.assert_called_once()
+        message = mw.statusBar().showMessage.call_args[0][0]
+        assert "unchanged" in message
+        assert "ring" in message
+
+    def test_applied_torsion_stays_silent(self, dihedral_dlg):
+        dlg, _, mw = dihedral_dlg
+        mw.statusBar().showMessage.reset_mock()
+        dlg._warn_if_torsion_not_applied(60.0, 60.0)
+
+        mw.statusBar().showMessage.assert_not_called()
+
+    def test_wraparound_is_not_reported(self, dihedral_dlg):
+        """-180 and +180 name the same torsion."""
+        dlg, _, mw = dihedral_dlg
+        mw.statusBar().showMessage.reset_mock()
+        dlg._warn_if_torsion_not_applied(180.0, -180.0)
+
+        mw.statusBar().showMessage.assert_not_called()

--- a/tests/unit/test_geometry_dialogs.py
+++ b/tests/unit/test_geometry_dialogs.py
@@ -668,3 +668,72 @@ class TestDihedralRingFeedback:
         dlg._warn_if_torsion_not_applied(180.0, -180.0)
 
         mw.statusBar().showMessage.assert_not_called()
+
+
+def _cyclohexane():
+    """Cyclohexane with 3D coords, for ring-constrained edits."""
+    from rdkit import Chem
+    from rdkit.Chem import AllChem
+
+    mol = Chem.AddHs(Chem.MolFromSmiles("C1CCCCC1"))
+    AllChem.EmbedMolecule(mol, randomSeed=42)
+    AllChem.MMFFOptimizeMolecule(mol)
+    return mol
+
+
+class TestRingEditFeedback:
+    """Ring bonds cannot be resized or re-angled in isolation; say so."""
+
+    def test_ring_bond_resize_reports_the_neighbour_it_moved(self, qapp):
+        mol = _cyclohexane()
+        mw = _make_mw(mol)
+        dlg = BondLengthDialog(mol, mw)
+        _patch_labels(dlg)
+        try:
+            dlg.atom1_idx, dlg.atom2_idx = 1, 2
+            dlg._update_molecule_geometry = MagicMock()
+            dlg.both_groups_radio.setChecked(False)
+            dlg.atom1_fix_radio.setChecked(False)
+            dlg.apply_geometry_update(1.80)
+
+            mw.statusBar().showMessage.assert_called_once()
+            message = mw.statusBar().showMessage.call_args[0][0]
+            assert "also changed" in message
+            assert "ring" in message
+        finally:
+            dlg.picking_enabled = False
+            dlg.close()
+
+    def test_acyclic_bond_resize_stays_silent(self, qapp):
+        mol = _ethane()
+        mw = _make_mw(mol)
+        dlg = BondLengthDialog(mol, mw)
+        _patch_labels(dlg)
+        try:
+            dlg.atom1_idx, dlg.atom2_idx = 0, 1
+            dlg._update_molecule_geometry = MagicMock()
+            dlg.both_groups_radio.setChecked(False)
+            dlg.atom1_fix_radio.setChecked(False)
+            mw.statusBar().showMessage.reset_mock()
+            dlg.apply_geometry_update(1.70)
+
+            mw.statusBar().showMessage.assert_not_called()
+        finally:
+            dlg.picking_enabled = False
+            dlg.close()
+
+    def test_unreachable_ring_angle_is_reported(self, angle_dlg):
+        dlg, _, mw = angle_dlg
+        dlg._warn_if_angle_not_applied(95.0, 113.60)
+
+        mw.statusBar().showMessage.assert_called_once()
+        message = mw.statusBar().showMessage.call_args[0][0]
+        assert "unchanged" in message
+        assert "ring" in message
+
+    def test_applied_angle_stays_silent(self, angle_dlg):
+        dlg, _, mw = angle_dlg
+        mw.statusBar().showMessage.reset_mock()
+        dlg._warn_if_angle_not_applied(95.0, 95.0)
+
+        mw.statusBar().showMessage.assert_not_called()

--- a/tests/unit/test_hydrogen.py
+++ b/tests/unit/test_hydrogen.py
@@ -1,8 +1,14 @@
 """Unit tests for implicit hydrogen management."""
 
+import pytest
+
+from moleditpy.core.molecular_data import MolecularData
 from moleditpy.ui.edit_actions_logic import EditActionsManager
 from PyQt6.QtCore import QPointF
 from unittest.mock import patch
+
+Chem = pytest.importorskip("rdkit.Chem")
+AllChem = pytest.importorskip("rdkit.Chem.AllChem")
 
 
 class DummyEditActions(EditActionsManager):
@@ -74,3 +80,116 @@ def test_remove_hydrogen_atoms_app_logic(mock_parser_host):
     h_item = actions.scene.atom_items[h_id]
     assert h_item in deleted_set
     assert actions.scene.atom_items[c_id] not in deleted_set
+
+
+def _build_2d_data(smiles):
+    """Load *smiles* into a MolecularData the way string_importers does."""
+    ref = Chem.MolFromSmiles(smiles)
+    AllChem.Compute2DCoords(ref)
+    Chem.Kekulize(ref)
+    data = MolecularData()
+    idx_to_id = {}
+    conf = ref.GetConformer()
+    for i in range(ref.GetNumAtoms()):
+        atom = ref.GetAtomWithIdx(i)
+        pos = conf.GetAtomPosition(i)
+        idx_to_id[i] = data.add_atom(
+            atom.GetSymbol(),
+            (pos.x * 50.0, -pos.y * 50.0),
+            charge=atom.GetFormalCharge(),
+        )
+    for bond in ref.GetBonds():
+        data.add_bond(
+            idx_to_id[bond.GetBeginAtomIdx()],
+            idx_to_id[bond.GetEndAtomIdx()],
+            order=int(bond.GetBondTypeAsDouble()),
+        )
+    return ref, data
+
+
+# Sanitization assigns an aromatic N-H to NumExplicitHs, where reading only
+# GetNumImplicitHs() reported 0 and dropped the H from the 2D label.
+@pytest.mark.parametrize(
+    "smiles",
+    [
+        "NC1=CC=CC2=C1C(=O)NNC2=O",  # luminol
+        "c1cc[nH]c1",  # pyrrole
+        "c1cnc[nH]1",  # imidazole
+        "c1ccc2[nH]ccc2c1",  # indole
+        "O=c1cc[nH]c(=O)[nH]1",  # uracil
+        "Nc1ncnc2[nH]cnc12",  # adenine
+        "Cc1ccccc1",  # toluene, no aromatic N-H
+        "CC(=O)O",  # acetic acid
+        "[O-]C(=O)c1ccccc1",  # charged
+    ],
+)
+def test_h_label_counts_match_molecule(mock_parser_host, smiles):
+    """The 2D H label must equal the hydrogens the molecule actually carries."""
+    ref, data = _build_2d_data(smiles)
+    mol = data.to_rdkit_mol()
+    assert mol is not None
+
+    actions = DummyEditActions(mock_parser_host)
+    counts = actions._compute_h_counts(mol)
+
+    expected = {
+        atom.GetIntProp("_original_atom_id"): ref.GetAtomWithIdx(
+            atom.GetIntProp("_original_atom_id")
+        ).GetTotalNumHs()
+        for atom in mol.GetAtoms()
+    }
+    assert counts == expected
+
+
+def test_h_label_ignores_hydrogens_drawn_as_atoms(mock_parser_host):
+    """H drawn as its own atom must not also be counted in the label."""
+    data = MolecularData()
+    c_id = data.add_atom("C", (0.0, 0.0))
+    for i in range(4):
+        h_id = data.add_atom("H", (50.0 * (i + 1), 0.0))
+        data.add_bond(c_id, h_id, order=1)
+
+    mol = data.to_rdkit_mol()
+    assert mol is not None
+    actions = DummyEditActions(mock_parser_host)
+    assert actions._compute_h_counts(mol)[c_id] == 0
+
+
+def test_add_hydrogen_atoms_covers_aromatic_nh(mock_parser_host):
+    """Add Hydrogens must not skip an aromatic N-H (luminol is C8H7N3O2)."""
+    actions = DummyEditActions(mock_parser_host)
+    ref, _ = _build_2d_data("NC1=CC=CC2=C1C(=O)NNC2=O")
+
+    conf = ref.GetConformer()
+    idx_to_id = {}
+    for i in range(ref.GetNumAtoms()):
+        atom = ref.GetAtomWithIdx(i)
+        pos = conf.GetAtomPosition(i)
+        idx_to_id[i] = actions.scene.create_atom(
+            atom.GetSymbol(), QPointF(pos.x * 50.0, -pos.y * 50.0)
+        )
+    for bond in ref.GetBonds():
+        actions.scene.create_bond(
+            actions.scene.atom_items[idx_to_id[bond.GetBeginAtomIdx()]],
+            actions.scene.atom_items[idx_to_id[bond.GetEndAtomIdx()]],
+            bond_order=int(bond.GetBondTypeAsDouble()),
+        )
+
+    before = len(
+        [c for c in actions.scene.create_atom.call_args_list if c.args[0] == "H"]
+    )
+    with patch(
+        "moleditpy.ui.edit_actions_logic.sip_isdeleted_safe", return_value=False
+    ):
+        actions.add_hydrogen_atoms()
+    after = [c for c in actions.scene.create_atom.call_args_list if c.args[0] == "H"]
+
+    nitrogens = [idx_to_id[a.GetIdx()] for a in ref.GetAtoms() if a.GetSymbol() == "N"]
+    added_to = [
+        bond_call.args[0].atom_id
+        for bond_call in actions.scene.create_bond.call_args_list
+        if bond_call.args[0].atom_id in nitrogens
+    ]
+    assert len(after) - before == 7
+    # The two ring N-H plus the two amine H: every N must receive hydrogen.
+    assert set(nitrogens) == set(added_to)

--- a/tests/unit/test_io_manager.py
+++ b/tests/unit/test_io_manager.py
@@ -651,6 +651,31 @@ class TestXyzLoadRobustness:
         assert mol is not None
         assert mol.GetNumAtoms() == 2
 
+    def test_hash_title_line_keeps_the_first_atom(self, qapp):
+        """A '#' title must not be filtered out.
+
+        Dropping it shifted every atom row up one against the fixed
+        atom_start of 2, so water silently loaded as H2.
+        """
+        io_mgr = self._io()
+        xyz = "3\n# water, generated\nO 0.0 0.0 0.0\nH 0.96 0.0 0.0\nH -0.24 0.93 0.0\n"
+        mol = io_mgr._mol_from_xyz_lines(xyz.splitlines())
+        assert [a.GetSymbol() for a in mol.GetAtoms()] == ["O", "H", "H"]
+
+    def test_leading_hash_comment_before_count_is_skipped(self, qapp):
+        """Comments ahead of the count line are metadata and still skipped."""
+        io_mgr = self._io()
+        xyz = "# generated\n2\ntitle\nC 0.0 0.0 0.0\nO 0.0 0.0 1.2\n"
+        mol = io_mgr._mol_from_xyz_lines(xyz.splitlines())
+        assert [a.GetSymbol() for a in mol.GetAtoms()] == ["C", "O"]
+
+    def test_headerless_xyz_still_drops_interleaved_comments(self, qapp):
+        """With no count line there is no title, so comments stay droppable."""
+        io_mgr = self._io()
+        xyz = "# gen\nO 0.0 0.0 0.0\n# mid\nH 0.96 0.0 0.0\nH -0.24 0.93 0.0\n"
+        mol = io_mgr._mol_from_xyz_lines(xyz.splitlines())
+        assert [a.GetSymbol() for a in mol.GetAtoms()] == ["O", "H", "H"]
+
     def test_skip_checks_with_bond_failure_loads(self, qapp):
         io = self._io(skip_chemistry_checks=True)
         io.estimate_bonds_from_distances = MagicMock(

--- a/tests/unit/test_io_manager.py
+++ b/tests/unit/test_io_manager.py
@@ -651,6 +651,74 @@ class TestXyzLoadRobustness:
         assert mol is not None
         assert mol.GetNumAtoms() == 2
 
+    def test_ambiguous_hydrogen_bonds_to_its_nearest_neighbour(self, qapp):
+        """H is monovalent, so only one partner wins; it must be the closest.
+
+        The rule used to accept whichever partner came first by atom index, so
+        the same geometry produced different connectivity depending only on the
+        order the file listed its atoms.
+        """
+        # skip_chemistry_checks routes to the distance-based perceiver rather
+        # than RDKit's DetermineBonds, which is the code under test here.
+        io_mgr = self._io(skip_chemistry_checks=True)
+        # H lies 1.05 A from the carbon and 0.95 A from the oxygen.
+        c_first = "3\nt\nC 0.0 0.0 0.0\nO 2.0 0.0 0.0\nH 1.05 0.0 0.0\n"
+        o_first = "3\nt\nO 0.0 0.0 0.0\nC 2.0 0.0 0.0\nH 0.95 0.0 0.0\n"
+
+        for xyz in (c_first, o_first):
+            mol = io_mgr._mol_from_xyz_lines(xyz.splitlines())
+            partners = set()
+            for bond in mol.GetBonds():
+                symbols = {
+                    mol.GetAtomWithIdx(bond.GetBeginAtomIdx()).GetSymbol(),
+                    mol.GetAtomWithIdx(bond.GetEndAtomIdx()).GetSymbol(),
+                }
+                if "H" in symbols:
+                    partners |= symbols - {"H"}
+            assert partners == {"O"}, f"H bonded to {partners} for:\n{xyz}"
+
+    def test_bond_perception_is_independent_of_atom_order(self, qapp):
+        """Shuffling the rows of a real molecule must not change its bonds."""
+        io_mgr = self._io(skip_chemistry_checks=True)
+        rows = [
+            ("O", 1.1, 0.2, 0.0),
+            ("C", 0.0, -0.6, 0.0),
+            ("C", -1.2, 0.2, 0.0),
+            ("H", 1.9, -0.3, 0.0),
+            ("H", 0.0, -1.2, 0.9),
+            ("H", 0.0, -1.2, -0.9),
+            ("H", -1.2, 1.3, 0.0),
+            ("H", -2.1, -0.2, 0.0),
+            ("H", -1.2, 0.2, 1.05),
+        ]
+
+        def topology(ordered):
+            xyz = "%d\nt\n%s\n" % (
+                len(ordered),
+                "\n".join("%s %.4f %.4f %.4f" % r for r in ordered),
+            )
+            mol = io_mgr._mol_from_xyz_lines(xyz.splitlines())
+            conf = mol.GetConformer()
+            bonds = []
+            for bond in mol.GetBonds():
+                i, j = bond.GetBeginAtomIdx(), bond.GetEndAtomIdx()
+                pair = tuple(
+                    sorted(
+                        (
+                            mol.GetAtomWithIdx(i).GetSymbol(),
+                            mol.GetAtomWithIdx(j).GetSymbol(),
+                        )
+                    )
+                )
+                length = conf.GetAtomPosition(i).Distance(conf.GetAtomPosition(j))
+                bonds.append((pair, round(length, 3)))
+            return sorted(bonds)
+
+        reference = topology(rows)
+        assert len(reference) == 8  # ethanol: 2 C-C/C-O plus 6 C-H/O-H
+        assert topology(list(reversed(rows))) == reference
+        assert topology(rows[3:] + rows[:3]) == reference
+
     def test_hash_title_line_keeps_the_first_atom(self, qapp):
         """A '#' title must not be filtered out.
 

--- a/tests/unit/test_io_manager.py
+++ b/tests/unit/test_io_manager.py
@@ -16,6 +16,7 @@ import sys
 import pytest
 from unittest.mock import MagicMock, patch
 
+from PyQt6.QtCore import QPointF
 from PyQt6.QtWidgets import QApplication
 
 # Make the local moleditpy package discoverable
@@ -761,3 +762,54 @@ class TestXyzNonStandardWarning:
         msgs = [c[0][0] for c in host.statusBar_mock.showMessage.call_args_list if c[0]]
         assert msgs
         assert all("non-standard" not in m for m in msgs), msgs
+
+
+class TestLoadMolFileProperties:
+    """load_mol_file must carry per-atom properties into the 2D editor."""
+
+    @staticmethod
+    def _run(mock_parser_host, tmp_path, mol_text):
+        from moleditpy.ui.io_logic import IOManager
+
+        path = tmp_path / "in.mol"
+        path.write_text(mol_text, encoding="utf-8")
+
+        io = IOManager(mock_parser_host)
+        mock_parser_host.init_manager.view_2d.mapToScene.return_value = QPointF(0, 0)
+        with patch("moleditpy.ui.io_logic.QTimer"):
+            io.load_mol_file(file_path=str(path))
+        return mock_parser_host.state_manager.data
+
+    def test_radical_survives_mol_import(self, mock_parser_host, tmp_path):
+        """An M RAD block must reach the editor; the count used to be dropped."""
+        from moleditpy.core.molecular_data import MolecularData
+
+        source = MolecularData()
+        c = source.add_atom("C", (0.0, 0.0), radical=1)
+        o = source.add_atom("O", (50.0, 0.0))
+        source.add_bond(c, o, order=1)
+        mol_text = source.to_mol_block()
+        assert "M  RAD" in mol_text
+
+        data = self._run(mock_parser_host, tmp_path, mol_text)
+
+        radicals = [a for a in data.atoms.values() if a.get("radical", 0)]
+        assert len(radicals) == 1
+        assert radicals[0]["symbol"] == "C"
+        assert radicals[0]["radical"] == 1
+
+    def test_charge_survives_mol_import(self, mock_parser_host, tmp_path):
+        """The companion property must keep working."""
+        from moleditpy.core.molecular_data import MolecularData
+
+        source = MolecularData()
+        n = source.add_atom("N", (0.0, 0.0), charge=1)
+        c = source.add_atom("C", (50.0, 0.0))
+        source.add_bond(n, c, order=1)
+
+        data = self._run(mock_parser_host, tmp_path, source.to_mol_block())
+
+        charged = [a for a in data.atoms.values() if a.get("charge", 0)]
+        assert len(charged) == 1
+        assert charged[0]["symbol"] == "N"
+        assert charged[0]["charge"] == 1

--- a/tests/unit/test_molecular_data.py
+++ b/tests/unit/test_molecular_data.py
@@ -820,3 +820,25 @@ def test_fallback_keeps_v2000_for_small_molecules():
 
     block, _ = _parse_fallback_block(data)
     assert "V2000" in block.splitlines()[3]
+
+
+def test_fallback_v3000_encodes_wedge_and_dash():
+    """V3000 bond lines must carry stereo as CFG=1 (wedge) / CFG=3 (dash)."""
+    from moleditpy.core.molecular_data import _mdl_radical_code
+
+    assert _mdl_radical_code(0) == 0  # guard branch: no unpaired electrons
+
+    data = MolecularData()
+    ids = [
+        data.add_atom("C", QPointF(i % 40 * 40.0, i // 40 * 40.0)) for i in range(1002)
+    ]
+    data.add_bond(ids[0], ids[1], order=1, stereo=1)  # wedge
+    data.add_bond(ids[2], ids[3], order=1, stereo=2)  # dash
+
+    block, _ = _parse_fallback_block(data)
+    assert "V3000" in block.splitlines()[3]
+    bond_lines = [
+        ln for ln in block.splitlines() if ln.startswith("M  V30 ") and "CFG=" in ln
+    ]
+    assert any(ln.endswith("CFG=1") for ln in bond_lines)
+    assert any(ln.endswith("CFG=3") for ln in bond_lines)

--- a/tests/unit/test_molecular_data.py
+++ b/tests/unit/test_molecular_data.py
@@ -726,3 +726,97 @@ def test_to_rdkit_mol_ez_invalid_stereo_atoms_suppressed():
     data.bonds[(c2, c3)]["stereo_atoms"] = 5  # not unpackable -> exception branch
     mol = data.to_rdkit_mol(use_2d_stereo=False)
     assert mol is not None
+
+
+# =============================================================================
+# Manual MOL block fallback: charge / radical / large-molecule fidelity
+# =============================================================================
+
+
+def _parse_fallback_block(data):
+    """Render via the manual fallback and read the result back with RDKit."""
+    with patch.object(data, "to_rdkit_mol", return_value=None):
+        block = data.to_mol_block()
+    assert block is not None
+    parsed = Chem.MolFromMolBlock(block, sanitize=False)
+    assert parsed is not None, f"RDKit could not parse the fallback block:\n{block}"
+    return block, parsed
+
+
+@pytest.mark.parametrize("charge", [1, -1, 2, -2, 3, -3, 4, -4])
+def test_fallback_preserves_formal_charge(charge):
+    """Charges must survive the manual writer, including beyond the +-3 field."""
+    data = MolecularData()
+    data.add_atom("C", QPointF(0, 0))
+    n = data.add_atom("N", QPointF(75, 0), charge=charge)
+    data.add_bond(0, n, order=1)
+
+    _, parsed = _parse_fallback_block(data)
+    assert parsed.GetAtomWithIdx(1).GetFormalCharge() == charge
+
+
+@pytest.mark.parametrize("radical", [1, 2])
+def test_fallback_preserves_radical_electrons(radical):
+    """Radicals need an M RAD block; the atom line has no field for them."""
+    data = MolecularData()
+    data.add_atom("C", QPointF(0, 0))
+    c = data.add_atom("C", QPointF(75, 0), radical=radical)
+    data.add_bond(0, c, order=1)
+
+    _, parsed = _parse_fallback_block(data)
+    assert parsed.GetAtomWithIdx(1).GetNumRadicalElectrons() == radical
+
+
+def test_fallback_preserves_charge_and_radical_together():
+    """A charged radical must not lose either property."""
+    data = MolecularData()
+    data.add_atom("C", QPointF(0, 0))
+    n = data.add_atom("N", QPointF(75, 0), charge=1, radical=1)
+    data.add_bond(0, n, order=1)
+
+    _, parsed = _parse_fallback_block(data)
+    atom = parsed.GetAtomWithIdx(1)
+    assert atom.GetFormalCharge() == 1
+    assert atom.GetNumRadicalElectrons() == 1
+
+
+def test_fallback_charge_column_is_not_the_hydrogen_count_field():
+    """The per-atom fields stay zero: charge belongs in M CHG, not column hhh."""
+    data = MolecularData()
+    data.add_atom("N", QPointF(0, 0), charge=1)
+
+    block, _ = _parse_fallback_block(data)
+    atom_line = block.splitlines()[4]
+    # 3 coordinates of width 10, a space, then the 3-char symbol.
+    assert atom_line[34:].split() == ["0"] * 12
+    assert "M  CHG" in block
+
+
+def test_fallback_switches_to_v3000_past_the_v2000_counts_limit():
+    """Past 999 atoms a V2000 counts line would corrupt; V3000 must be used."""
+    data = MolecularData()
+    ids = [
+        data.add_atom("C", QPointF(i % 40 * 40.0, i // 40 * 40.0)) for i in range(1200)
+    ]
+    for i in range(0, len(ids) - 1, 2):
+        data.add_bond(ids[i], ids[i + 1], order=1)
+    data.atoms[ids[5]]["charge"] = -1
+    data.atoms[ids[7]]["radical"] = 1
+
+    block, parsed = _parse_fallback_block(data)
+    assert "V3000" in block.splitlines()[3]
+    assert parsed.GetNumAtoms() == 1200
+    assert parsed.GetNumBonds() == 600
+    assert sum(1 for a in parsed.GetAtoms() if a.GetFormalCharge()) == 1
+    assert sum(1 for a in parsed.GetAtoms() if a.GetNumRadicalElectrons()) == 1
+
+
+def test_fallback_keeps_v2000_for_small_molecules():
+    """Small structures must not churn to V3000."""
+    data = MolecularData()
+    data.add_atom("C", QPointF(0, 0))
+    data.add_atom("C", QPointF(75, 0))
+    data.add_bond(0, 1, order=1)
+
+    block, _ = _parse_fallback_block(data)
+    assert "V2000" in block.splitlines()[3]

--- a/tests/unit/test_string_importers.py
+++ b/tests/unit/test_string_importers.py
@@ -1,5 +1,6 @@
 """Tests for SMILES/InChI import — verifying atom counts, bonds, and properties against RDKit reference."""
 
+import pytest
 from rdkit import Chem
 from rdkit.Chem import rdMolDescriptors
 from moleditpy.ui.string_importers import StringImporterManager
@@ -328,3 +329,36 @@ def test_inchi_placement_error_reported(mock_parser_host):
     with patch.object(QTimer, "singleShot"):
         importer.load_from_inchi("InChI=1S/CH4/h1H4")
     assert "Error loading from InChI: view gone" in _last_status(mock_parser_host)
+
+
+# =============================================================================
+# Radical preservation on import
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    "smiles,symbol,electrons",
+    [
+        ("[CH3]", "C", 1),
+        ("C[CH2]", "C", 1),
+        ("[CH2]", "C", 2),
+        ("[O]O", "O", 1),
+    ],
+)
+def test_smiles_preserves_radical_electrons(
+    mock_parser_host, smiles, symbol, electrons
+):
+    """Radicals must survive SMILES import; the count was previously dropped."""
+    data = _load_and_get_data(mock_parser_host, "load_from_smiles", smiles)
+
+    radicals = [a for a in data.atoms.values() if a.get("radical", 0)]
+    assert len(radicals) == 1
+    assert radicals[0]["symbol"] == symbol
+    assert radicals[0]["radical"] == electrons
+
+
+def test_smiles_without_radical_stays_unpaired_free(mock_parser_host):
+    """A closed-shell molecule must not gain phantom radicals."""
+    data = _load_and_get_data(mock_parser_host, "load_from_smiles", "CCO")
+
+    assert all(a.get("radical", 0) == 0 for a in data.atoms.values())


### PR DESCRIPTION
## Bugs fixed

**1. Aromatic N-H hydrogens were invisible and un-addable** (`edit_actions_logic.py`)

Sanitization files an aromatic N-H under `NumExplicitHs`, because kekulizing the
ring depends on that H being pinned down, so `GetNumImplicitHs()` returns 0. Two
call sites read it anyway:

- the 2D label dropped the H, so luminol's two ring N-H looked like bare N
- **Add Hydrogens** took `total - explicit`, which for these atoms is `1 - 1 = 0`,
  so luminol received **5 of its 7 hydrogens** — a wrong structure headed for DFT
  with nothing on screen to say so

Both now use `GetTotalNumHs()`. Verified it excludes H drawn as their own atoms
(fully-explicit methane gives 0), so nothing is double-counted. Affected every
aromatic N-H: pyrrole, imidazole, indole, uracil, adenine, guanine, tryptophan.

**2. Formal charges and radicals were lost when saving** (`core/molecular_data.py`)

The fallback MOL writer (used when `to_rdkit_mol()` returns `None` — unsupported
element, or a structure that fails sanitization) wrote the MDL charge code into
the **fourth** per-atom field. That field is `hhh`, the implicit-hydrogen
override; the charge column is `ccc`, the second. Every charge round-tripped as
**0**, and was silently reinterpreted as a hydrogen-count constraint.

Radicals were never emitted at all — the V2000 atom line has no field for them
and the `M RAD` block was absent. Past 999 atoms the three-character counts
fields ran together and produced a file RDKit rejects outright
(`CTAB version string invalid`).

Charge and radical now travel in `M CHG` / `M RAD` blocks, which also lifts the
±3 limit of the `ccc` field, and oversized structures are emitted as V3000.

**3. E/Z labels never reached 3D generation** (`compute_logic.py`)

Draw but-2-ene trans, label the bond Z, convert to 3D — you got the trans isomer.
MDL carries double-bond cis/trans *only* as 2D geometry. The label was correct in
memory (`STEREOZ`), but `MolToMolBlock` writes the drawn coordinates and a reader
re-derives the stereo from them.

`inject_ez_stereo_to_mol_block()` existed to plug exactly this gap by appending
`M CFG` lines, but **RDKit ignores `M CFG`** — parsing with and without the
injected line gives identical stereo, so the mechanism never worked. The block now
gets a 2D layout recomputed from the stereo-bearing mol. Those coordinates only
seed 3D generation; the canvas keeps the user's own layout.

**4. Radicals were discarded on every import** (`io_logic.py`, `string_importers.py`)

Every import path called `create_atom(symbol, pos, charge=...)` and never passed
`radical=`. Combined with fix 2 this was a one-way street: a radical could be
saved but never reloaded, so a save/open round trip silently quenched it.

**5. XYZ files with a `#` title line lost their first atom** (`io_logic.py`)

The parser filtered every line starting with `#`, but atom rows are read from a
fixed offset of 2 — and in a headed XYZ, line 2 is the *title*, which commonly
starts with `#` in generated files. Losing it shifted every row up one, pushing
the last past the count:

```
3
# water, generated      ->  2 atoms: ['H', 'H']
O 0.0 0.0 0.0               the oxygen silently gone
H 0.96 0.0 0.0
H -0.24 0.93 0.0
```

Only leading comments ahead of the count line are skipped now. The headerless
branch has no title, so interleaved comments are still dropped there.

**6. XYZ hydrogens bonded by index order, not distance** (`io_logic.py`)

`estimate_bonds_from_distances` walked pairs in index order and, since H is
monovalent, the first partner won. With an H 1.05 A from a carbon and 0.95 A from
an oxygen, listing the carbon first bonded H to the **carbon**. Same geometry,
different molecule depending on row order. Candidates are now sorted by distance.

Real hydrogen bonds were already excluded by the distance window (an O-H...O
contact at 1.80 A falls outside it), so ordinary structures are unaffected; this
bit distorted geometries and bridging hydrides. Verified unchanged for real
molecules: water 2 bonds, methane 4, ethanol 8, benzene 12, identical across 24
shuffled orderings.

## Silent failures now reported (no geometry changed)

All three geometry dialogs move `get_connected_group()`, which for a bond inside
a ring wraps back around and includes atoms on the far side.

**7. Ring dihedral was a silent no-op** (`dihedral_dialog.py`) — all four atoms
rotate together, so cyclohexane asked for 60 deg stayed at -29.17 deg. Nothing was
corrupted (bond lengths held to 1e-15) but the dialog looked like it applied.

**8. Ring bond-length edits silently distort a neighbour** (`bond_length_dialog.py`),
and ring angles are a no-op like the dihedral (`angle_dialog.py`):

| edit | side effect |
|---|---|
| cyclohexane C1-C2 -> 1.80 A | also pulls C0-C1 1.5302 -> 1.4435 |
| benzene C1-C2 -> 1.80 A | also pulls C0-C1 1.3948 -> **1.2428** |
| cyclopropane C0-C1 -> 1.80 A | also pushes C2-C0 1.5022 -> 1.6711 |

A benzene C-C at 1.24 A is shorter than a double bond.

**These three commits are purely additive — no geometry math was touched.** One
bond length in a ring cannot change without something else changing, so there is
no correct substitute value; the fix reports rather than refuses, keeping the
capability while removing the silence. Acyclic edits stay silent.

## Verified clean — no changes made

Measured and found correct, recorded so they are not re-audited:

- `calculate_dihedral` / `calc_angle_deg` match `rdMolTransforms` exactly
- `adjust_dihedral` / `adjust_bond_angle` hit their targets to ~1e-14 and leave
  every bond length within 1e-15
- best-fit plane projection: residual 1e-16, provably least-squares
- project-file JSON round trip preserves symbol, position, charge, radical, bond
  order (including aromatic 1.5) and all stereo codes
- undo snapshots correctly restore `_original_atom_id`, which `ToBinary` does drop,
  from the separately stored id list
- `_adjust_collision_avoidance` uses `.astype(int)` (truncation, not floor). This
  is **safe and should not be "fixed"**: truncation is monotone non-decreasing, so
  two overlapping padded boxes always share cell `trunc(p)` at any overlap point.
  It only mislabels cells near zero, making the grid slightly over-inclusive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CTMUL9Hjp2kSVGWKGiVngq
