### PR TITLE
4.5.2: fix the first-heteroatom freeze, cache the OS theme query, run CI on dev branches

### DIFF
--- a/.github/workflows/full-gui-tests.yml
+++ b/.github/workflows/full-gui-tests.yml
@@ -6,9 +6,10 @@ name: Full GUI Tests
 
 on:
   push:
-    branches: [ main, master, dev, 'test/**' ]
+    # 'dev-*' covers the dev-N.N.N release branches, which otherwise got no CI.
+    branches: [ main, master, dev, 'dev-*', 'test/**' ]
   pull_request:
-    branches: [ main, master, dev ]
+    branches: [ main, master, dev, 'dev-*' ]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,9 +2,10 @@ name: MoleditPy Tests
 
 on:
   push:
-    branches: [ main, master, dev ]
+    # 'dev-*' covers the dev-N.N.N release branches, which otherwise got no CI.
+    branches: [ main, master, dev, 'dev-*' ]
   pull_request:
-    branches: [ main, master, dev ]
+    branches: [ main, master, dev, 'dev-*' ]
   workflow_dispatch:
 
 permissions:

--- a/moleditpy-linux/pyproject.toml
+++ b/moleditpy-linux/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
     "pyqt6 < 6.10; python_version == '3.9'",
     "pyqt6 < 6.12; python_version != '3.9'",
     "pyvista < 0.49",
-    "pyvistaqt < 0.12",
+    "pyvistaqt < 0.13",
     "rdkit < 2026.4",
 ]
 

--- a/moleditpy/pyproject.toml
+++ b/moleditpy/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
   "pyqt6 < 6.10; python_version == '3.9'",
   "pyqt6 < 6.12; python_version != '3.9'",
   "pyvista < 0.49",
-  "pyvistaqt < 0.12",
+  "pyvistaqt < 0.13",
   "rdkit < 2026.4",
   "openbabel-wheel < 3.2"
 ]

--- a/moleditpy/pyproject.toml
+++ b/moleditpy/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "MoleditPy"
 
-version = "4.5.1"
+version = "4.5.2"
 
 license = {file = "LICENSE"}
 

--- a/moleditpy/src/moleditpy/ui/atom_item.py
+++ b/moleditpy/src/moleditpy/ui/atom_item.py
@@ -43,6 +43,34 @@ from ..utils.sip_isdeleted_safe import sip_isdeleted_safe
 if TYPE_CHECKING:
     from .bond_item import BondItem
 
+SUBSCRIPT_MAP = str.maketrans("0123456789", "₀₁₂₃₄₅₆₇₈₉")
+
+# Every subscript digit, so one warm-up covers any implicit-H count.
+_WARM_UP_TEXT = "CH" + "0123456789".translate(SUBSCRIPT_MAP)
+
+
+def warm_font_cache(font: Optional[QFont] = None) -> None:
+    """Pay Qt's one-off font costs up front instead of on the first heteroatom.
+
+    Two process-wide costs hide in QFontMetricsF: the first text shaping in a
+    family (~10-120 ms, worse on a cold Windows font cache) and the first
+    lookup of a subscript digit, which Arial lacks — Qt answers that by walking
+    the whole system font database (~200-330 ms, measured).
+
+    Drawing a carbon skeleton pays neither: a bonded neutral carbon is
+    invisible, so it renders no glyph at all. The first O or N a user places
+    gets "OH₂" and pays both at once, mid-click, as a visible freeze.
+
+    Call once on the GUI thread after the window is up. QFontMetricsF is not
+    usable off the GUI thread, so this cannot move to a worker.
+    """
+    try:
+        QFontMetricsF(font or QFont(FONT_FAMILY, 20, FONT_WEIGHT_BOLD)).boundingRect(
+            _WARM_UP_TEXT
+        )
+    except (RuntimeError, TypeError, ValueError):
+        logging.debug("Font cache warm-up skipped", exc_info=True)
+
 
 class AtomItem(QGraphicsItem):
     """2D scene item representing a single atom in the molecule editor."""
@@ -138,8 +166,7 @@ class AtomItem(QGraphicsItem):
             if not is_skeletal_carbon:
                 hydrogen_part = "H"
                 if self.implicit_h_count > 1:
-                    subscript_map = str.maketrans("0123456789", "₀₁₂₃₄₅₆₇₈₉")
-                    hydrogen_part += str(self.implicit_h_count).translate(subscript_map)
+                    hydrogen_part += str(self.implicit_h_count).translate(SUBSCRIPT_MAP)
 
         flip_text = False
         if hydrogen_part and self.bonds:
@@ -261,8 +288,7 @@ class AtomItem(QGraphicsItem):
             if not is_skeletal_carbon:
                 hydrogen_part = "H"
                 if self.implicit_h_count > 1:
-                    subscript_map = str.maketrans("0123456789", "₀₁₂₃₄₅₆₇₈₉")
-                    hydrogen_part += str(self.implicit_h_count).translate(subscript_map)
+                    hydrogen_part += str(self.implicit_h_count).translate(SUBSCRIPT_MAP)
 
         flip_text = False
         if hydrogen_part and self.bonds:
@@ -361,9 +387,8 @@ class AtomItem(QGraphicsItem):
                 if not is_skeletal_carbon:
                     hydrogen_part = "H"
                     if self.implicit_h_count > 1:
-                        subscript_map = str.maketrans("0123456789", "₀₁₂₃₄₅₆₇₈₉")
                         hydrogen_part += str(self.implicit_h_count).translate(
-                            subscript_map
+                            SUBSCRIPT_MAP
                         )
 
             # --- Determine if the text should be flipped ---

--- a/moleditpy/src/moleditpy/ui/main_window_init.py
+++ b/moleditpy/src/moleditpy/ui/main_window_init.py
@@ -72,6 +72,10 @@ from .settings_dialog import SettingsDialog
 from .zoomable_view import ZoomableView
 
 
+# Distinct from None, which is a real answer meaning "OS preference unknown".
+_UNQUERIED = object()
+
+
 class MainInitManager:
     """Feature class separated from main_window.py"""
 
@@ -80,6 +84,7 @@ class MainInitManager:
     ) -> None:
         self.host = host
         # Explicit declarations for Mypy
+        self._os_dark_pref: Any = _UNQUERIED
         self.scene: Any = None  # MoleculeScene, created during init
         self.data: Optional[MolecularData] = None
         self.formula_label: Optional[QLabel] = None
@@ -1077,7 +1082,11 @@ class MainInitManager:
                 return QColor(fg)
 
         with suppress_log(Exception):
-            os_pref = detect_system_dark_mode()
+            # Cached: this forks `defaults`/`gsettings` on macOS and Linux, and
+            # icon painting asks once per icon (15+ during startup).
+            if self._os_dark_pref is _UNQUERIED:
+                self._os_dark_pref = detect_system_dark_mode()
+            os_pref = self._os_dark_pref
             if os_pref is not None:
                 return QColor("#FFFFFF") if os_pref else QColor("#000000")
 

--- a/moleditpy/src/moleditpy/ui/main_window_init.py
+++ b/moleditpy/src/moleditpy/ui/main_window_init.py
@@ -20,9 +20,6 @@ import os
 import sys
 from typing import Any, Dict, Optional
 
-# RDKit imports (explicit to satisfy flake8 and used features)
-from rdkit import Chem
-
 # PyQt6 Modules
 from PyQt6.QtCore import QLineF, QPointF, QRectF, Qt, QTimer, QUrl
 from PyQt6.QtGui import (
@@ -65,7 +62,8 @@ except ImportError:
     winreg = None  # type: ignore[assignment]
 
 
-from ..utils.constants import DEFAULT_CPK_COLORS, NUM_DASHES, VERSION
+from ..utils.constants import DEFAULT_CPK_COLORS, FONT_FAMILY, NUM_DASHES, VERSION
+from .atom_item import warm_font_cache
 from .custom_qt_interactor import CustomQtInteractor
 from ..core.molecular_data import MolecularData
 from .molecule_scene import MoleculeScene
@@ -179,18 +177,6 @@ class MainInitManager:
         # Install event filter to capture window close events (handled in UIManager)
         self.host.installEventFilter(self.host.ui_manager)
 
-        # RDKit Warm-up (initial execution cost)
-        try:
-            # Create a molecule with a variety of common atoms to ensure
-            # the valence/H-count machinery is fully initialized.
-            warmup_smiles = "OC(N)C(S)P"
-            warmup_mol = Chem.MolFromSmiles(warmup_smiles)
-            if warmup_mol:
-                for atom in warmup_mol.GetAtoms():
-                    atom.GetNumImplicitHs()
-        except (AttributeError, RuntimeError, ValueError) as e:
-            logging.warning(f"RDKit warm-up failed: {e}")
-
         self.host.state_manager.reset_undo_stack()
         self.scene.selectionChanged.connect(  # type: ignore[attr-defined]
             self.host.edit_actions_manager.update_edit_menu_actions
@@ -206,6 +192,8 @@ class MainInitManager:
             QTimer.singleShot(0, lambda: self.load_command_line_file(initial_file))
 
         QTimer.singleShot(0, self.apply_initial_settings)
+        # After apply_initial_settings, so the user's own font family is warmed.
+        QTimer.singleShot(0, self._warm_font_cache)
         # Camera initialization flag (permits reset only during the first draw)
         self._camera_initialized = False
 
@@ -225,6 +213,19 @@ class MainInitManager:
             logging.debug(
                 f"Suppressed exception: {e}"
             )  # Suppress non-critical UI/menu initialization errors
+
+    def _warm_font_cache(self) -> None:
+        """Resolve the atom-label font now, in the user's configured family."""
+        scene = getattr(self, "scene", None)
+        font = None
+        if scene is not None and hasattr(scene, "get_setting"):
+            family = scene.get_setting("atom_font_family_2d", FONT_FAMILY)
+            size = scene.get_setting("atom_font_size_2d", 20)
+            bold = scene.get_setting("atom_font_bold_2d", True)
+            font = QFont(
+                family, size, QFont.Weight.Bold if bold else QFont.Weight.Normal
+            )
+        warm_font_cache(font)
 
     def init_ui(self) -> None:
         """Set the window icon and initialize main layout, toolbars, and menu bar."""

--- a/moleditpy/src/moleditpy/utils/system_utils.py
+++ b/moleditpy/src/moleditpy/utils/system_utils.py
@@ -21,6 +21,9 @@ try:
 except ImportError:
     winreg = None  # type: ignore[assignment]
 
+# A wedged `defaults`/`gsettings` must not take the app's startup with it.
+_THEME_QUERY_TIMEOUT_S = 5.0
+
 
 def detect_system_dark_mode() -> Optional[bool]:
     """Return True if the OS prefers dark app theme, False if light, or None if unknown."""
@@ -33,8 +36,18 @@ def detect_system_dark_mode() -> Optional[bool]:
 
 
 def detect_system_theme() -> Optional[str]:
-    """Return the OS's preferred theme setting as 'dark', 'light', or None."""
-    with suppress_log(AttributeError, RuntimeError, OSError, FileNotFoundError):
+    """Return the OS's preferred theme setting as 'dark', 'light', or None.
+
+    Forks a helper process on macOS and Linux, so callers that ask repeatedly
+    should hold on to the answer rather than re-querying.
+    """
+    with suppress_log(
+        AttributeError,
+        RuntimeError,
+        OSError,
+        FileNotFoundError,
+        subprocess.SubprocessError,
+    ):
         # Windows
         if platform.system() == "Windows" and winreg is not None:
             with winreg.OpenKey(
@@ -50,6 +63,7 @@ def detect_system_theme() -> Optional[str]:
                 ["defaults", "read", "-g", "AppleInterfaceStyle"],
                 capture_output=True,
                 text=True,
+                timeout=_THEME_QUERY_TIMEOUT_S,
             )
             if p.returncode == 0 and "dark" in p.stdout.strip().lower():
                 return "dark"
@@ -61,6 +75,7 @@ def detect_system_theme() -> Optional[str]:
                 ["gsettings", "get", "org.gnome.desktop.interface", "color-scheme"],
                 capture_output=True,
                 text=True,
+                timeout=_THEME_QUERY_TIMEOUT_S,
             )
             if p.returncode == 0:
                 out = p.stdout.strip().strip("'\n ")
@@ -73,6 +88,7 @@ def detect_system_theme() -> Optional[str]:
                 ["gsettings", "get", "org.gnome.desktop.interface", "gtk-theme"],
                 capture_output=True,
                 text=True,
+                timeout=_THEME_QUERY_TIMEOUT_S,
             )
             if p.returncode == 0 and "-dark" in p.stdout.lower():
                 return "dark"

--- a/tests/assertion_catalog.md
+++ b/tests/assertion_catalog.md
@@ -1515,6 +1515,16 @@ _Without an E/Z label the drawn geometry still decides the stereo._
 - assert parsed is not None
 - assert Chem.MolToSmiles(parsed) == 'C/C=C/C'
 
+### test_ez_block_falls_back_when_molecule_cannot_be_built
+_An unbuildable structure must fall through, not crash the conversion._
+
+- assert compute._ez_consistent_mol_block() is None
+
+### test_ez_block_falls_back_when_layout_fails
+_A failure while rebuilding the 2D layout is logged, not raised._
+
+- assert compute._ez_consistent_mol_block() is None
+
 ## tests/unit/test_constants.py
 
 ### test_constants_version_from_metadata
@@ -3774,6 +3784,54 @@ _No description provided._
 
 - assert any(('error occurred during SVG export' in str(c.args[0]) for c in mock_parser_host.statusBar().showMessage.call_args_list))
 
+## tests/unit/test_font_cache_warmup.py
+
+### TestSubscriptMap.test_maps_every_digit
+_No description provided._
+
+- assert '0123456789'.translate(SUBSCRIPT_MAP) == '₀₁₂₃₄₅₆₇₈₉'
+
+### TestSubscriptMap.test_labels_render_as_subscripts
+_No description provided._
+
+- assert 'H' + '2'.translate(SUBSCRIPT_MAP) == 'H₂'
+
+### TestWarmUpText.test_covers_every_subscript_digit
+_One warm-up must serve any implicit-H count, not just H₂._
+
+- assert digit in _WARM_UP_TEXT
+
+### TestWarmUpText.test_covers_latin_shaping_too
+_No description provided._
+
+- assert 'C' in _WARM_UP_TEXT and 'H' in _WARM_UP_TEXT
+
+### TestWarmFontCache.test_measures_the_warm_up_text
+_No description provided._
+
+- fm.return_value.boundingRect.assert_called_once_with(_WARM_UP_TEXT)
+
+### TestWarmFontCache.test_uses_the_font_it_is_given
+_No description provided._
+
+- assert fm.call_args[0][0] is font
+
+### TestWarmFontCache.test_never_raises
+_A cosmetic optimisation must not be able to break startup._
+
+
+### TestInitManagerHook.test_warms_with_the_configured_font
+_No description provided._
+
+- assert font.family() == 'Times New Roman'
+- assert font.pointSize() == 14
+- assert font.weight() == QFont.Weight.Normal
+
+### TestInitManagerHook.test_falls_back_when_the_scene_has_no_settings
+_No description provided._
+
+- warm.assert_called_once_with(None)
+
 ## tests/unit/test_geometry.py
 
 ### test_3d_bond_lengths
@@ -4403,6 +4461,39 @@ _Add Hydrogens must not skip an aromatic N-H (luminol is C8H7N3O2)._
 
 - assert len(after) - before == 7
 - assert set(nitrogens) == set(added_to)
+
+## tests/unit/test_icon_theme_cache.py
+
+### TestOsThemeIsQueriedOnce.test_repeated_icons_fork_only_one_helper
+_detect_system_dark_mode forks `defaults`/`gsettings`; 15+ per launch hung CI._
+
+- detect.assert_called_once()
+
+### TestOsThemeIsQueriedOnce.test_unknown_preference_is_not_re_queried
+_None is a real answer ("OS could not say"), so it must also be cached._
+
+- detect.assert_called_once()
+
+### TestColourIsStillCorrect.test_dark_os_gives_white_icons
+_No description provided._
+
+- assert MainInitManager._get_icon_foreground_color(manager) == QColor('#FFFFFF')
+
+### TestColourIsStillCorrect.test_light_os_gives_black_icons
+_No description provided._
+
+- assert MainInitManager._get_icon_foreground_color(manager) == QColor('#000000')
+
+### TestColourIsStillCorrect.test_explicit_setting_wins_without_asking_the_os
+_No description provided._
+
+- detect.assert_not_called()
+- assert MainInitManager._get_icon_foreground_color(manager) == QColor('#FF0000')
+
+### TestColourIsStillCorrect.test_falls_back_to_background_luminance
+_With no OS answer, a dark canvas still has to yield light icons._
+
+- assert MainInitManager._get_icon_foreground_color(manager) == QColor('#FFFFFF')
 
 ## tests/unit/test_io.py
 
@@ -5437,6 +5528,14 @@ _Past 999 atoms a V2000 counts line would corrupt; V3000 must be used._
 _Small structures must not churn to V3000._
 
 - assert 'V2000' in block.splitlines()[3]
+
+### test_fallback_v3000_encodes_wedge_and_dash
+_V3000 bond lines must carry stereo as CFG=1 (wedge) / CFG=3 (dash)._
+
+- assert _mdl_radical_code(0) == 0
+- assert 'V3000' in block.splitlines()[3]
+- assert any((ln.endswith('CFG=1') for ln in bond_lines))
+- assert any((ln.endswith('CFG=3') for ln in bond_lines))
 
 ## tests/unit/test_molecule_scene_behavior.py
 

--- a/tests/coverage_report.md
+++ b/tests/coverage_report.md
@@ -1,6 +1,6 @@
 # MoleditPy Coverage Report
 
-- **Overall Project Coverage**: **89.50%**
+- **Overall Project Coverage**: **89.59%**
 
 ### Coverage Breakdown
 
@@ -9,7 +9,7 @@
 | moleditpy\src\moleditpy\__init__.py                     |      6 |      2 |   66.7% |
 | moleditpy\src\moleditpy\main.py                         |    170 |     35 |   79.4% |
 | moleditpy\src\moleditpy\core\mol_geometry.py            |    292 |      4 |   98.6% |
-| moleditpy\src\moleditpy\core\molecular_data.py          |    284 |      3 |   98.9% |
+| moleditpy\src\moleditpy\core\molecular_data.py          |    284 |      0 |  100.0% |
 | moleditpy\src\moleditpy\plugins\plugin_interface.py     |    238 |      6 |   97.5% |
 | moleditpy\src\moleditpy\plugins\plugin_manager.py       |    407 |     11 |   97.3% |
 | moleditpy\src\moleditpy\plugins\plugin_manager_window.py |    187 |      2 |   98.9% |
@@ -20,14 +20,14 @@
 | moleditpy\src\moleditpy\ui\analysis_window.py           |    117 |     25 |   78.6% |
 | moleditpy\src\moleditpy\ui\angle_dialog.py              |    272 |     28 |   89.7% |
 | moleditpy\src\moleditpy\ui\app_state.py                 |    345 |     57 |   83.5% |
-| moleditpy\src\moleditpy\ui\atom_item.py                 |    325 |     39 |   88.0% |
+| moleditpy\src\moleditpy\ui\atom_item.py                 |    329 |     39 |   88.1% |
 | moleditpy\src\moleditpy\ui\atom_picking.py              |    167 |     13 |   92.2% |
 | moleditpy\src\moleditpy\ui\base_picking_dialog.py       |     81 |      4 |   95.1% |
 | moleditpy\src\moleditpy\ui\bond_item.py                 |    366 |     55 |   85.0% |
 | moleditpy\src\moleditpy\ui\bond_length_dialog.py        |    257 |     17 |   93.4% |
 | moleditpy\src\moleditpy\ui\calculation_worker.py        |    583 |     90 |   84.6% |
 | moleditpy\src\moleditpy\ui\color_settings_dialog.py     |    166 |     13 |   92.2% |
-| moleditpy\src\moleditpy\ui\compute_logic.py             |    451 |     11 |   97.6% |
+| moleditpy\src\moleditpy\ui\compute_logic.py             |    451 |      7 |   98.4% |
 | moleditpy\src\moleditpy\ui\constrained_optimization_dialog.py |    480 |     24 |   95.0% |
 | moleditpy\src\moleditpy\ui\custom_interactor_style.py   |    772 |    113 |   85.4% |
 | moleditpy\src\moleditpy\ui\custom_qt_interactor.py      |     24 |      0 |  100.0% |
@@ -40,7 +40,7 @@
 | moleditpy\src\moleditpy\ui\geometry_base_dialog.py      |     52 |      1 |   98.1% |
 | moleditpy\src\moleditpy\ui\io_logic.py                  |    737 |     76 |   89.7% |
 | moleditpy\src\moleditpy\ui\main_window.py               |    195 |     13 |   93.3% |
-| moleditpy\src\moleditpy\ui\main_window_init.py          |   1061 |     94 |   91.1% |
+| moleditpy\src\moleditpy\ui\main_window_init.py          |   1067 |     86 |   91.9% |
 | moleditpy\src\moleditpy\ui\mirror_dialog.py             |     72 |      7 |   90.3% |
 | moleditpy\src\moleditpy\ui\molecular_scene_handler.py   |   1000 |    143 |   85.7% |
 | moleditpy\src\moleditpy\ui\molecule_scene.py            |    614 |     82 |   86.6% |
@@ -66,12 +66,12 @@
 | moleditpy\src\moleditpy\utils\default_settings.py       |      1 |      0 |  100.0% |
 | moleditpy\src\moleditpy\utils\sip_isdeleted_safe.py     |     19 |      0 |  100.0% |
 | moleditpy\src\moleditpy\utils\suppress_log.py           |     10 |      0 |  100.0% |
-| moleditpy\src\moleditpy\utils\system_utils.py           |     39 |      0 |  100.0% |
-| **TOTAL** | **16643** | **1748** | **89.50%** |
+| moleditpy\src\moleditpy\utils\system_utils.py           |     40 |      0 |  100.0% |
+| **TOTAL** | **16654** | **1733** | **89.59%** |
 
 ## Test Suite Status
-- **Total tests passed**: 2125 (1 skipped)
-- **Unit tests**: PASSED (1941 passed)
+- **Total tests passed**: 2143 (1 skipped)
+- **Unit tests**: PASSED (1959 passed)
 - **Integration tests**: PASSED (75 passed)
 - **E2E tests**: PASSED (34 passed, 1 skipped)
 - **GUI tests**: PASSED (75 passed)

--- a/tests/unit/test_font_cache_warmup.py
+++ b/tests/unit/test_font_cache_warmup.py
@@ -1,0 +1,75 @@
+"""The startup font-cache warm-up that keeps the first heteroatom responsive."""
+
+from unittest.mock import MagicMock, patch
+
+from PyQt6.QtGui import QFont
+
+from moleditpy.ui.atom_item import SUBSCRIPT_MAP, _WARM_UP_TEXT, warm_font_cache
+
+
+class TestSubscriptMap:
+    def test_maps_every_digit(self):
+        assert "0123456789".translate(SUBSCRIPT_MAP) == "₀₁₂₃₄₅₆₇₈₉"
+
+    def test_labels_render_as_subscripts(self):
+        assert "H" + "2".translate(SUBSCRIPT_MAP) == "H₂"
+
+
+class TestWarmUpText:
+    def test_covers_every_subscript_digit(self):
+        """One warm-up must serve any implicit-H count, not just H₂."""
+        for digit in "₀₁₂₃₄₅₆₇₈₉":
+            assert digit in _WARM_UP_TEXT, f"{digit} would still cost a cache miss"
+
+    def test_covers_latin_shaping_too(self):
+        assert "C" in _WARM_UP_TEXT and "H" in _WARM_UP_TEXT
+
+
+class TestWarmFontCache:
+    def test_measures_the_warm_up_text(self, app):
+        with patch("moleditpy.ui.atom_item.QFontMetricsF") as fm:
+            warm_font_cache()
+        fm.return_value.boundingRect.assert_called_once_with(_WARM_UP_TEXT)
+
+    def test_uses_the_font_it_is_given(self, app):
+        font = QFont("Times New Roman", 14)
+        with patch("moleditpy.ui.atom_item.QFontMetricsF") as fm:
+            warm_font_cache(font)
+        assert fm.call_args[0][0] is font
+
+    def test_never_raises(self, app):
+        """A cosmetic optimisation must not be able to break startup."""
+        with patch("moleditpy.ui.atom_item.QFontMetricsF", side_effect=RuntimeError):
+            warm_font_cache()
+
+
+class TestInitManagerHook:
+    def test_warms_with_the_configured_font(self, app):
+        from moleditpy.ui.main_window_init import MainInitManager
+
+        manager = MagicMock(spec=MainInitManager)
+        manager.scene = MagicMock()
+        manager.scene.get_setting.side_effect = lambda key, default: {
+            "atom_font_family_2d": "Times New Roman",
+            "atom_font_size_2d": 14,
+            "atom_font_bold_2d": False,
+        }.get(key, default)
+
+        with patch("moleditpy.ui.main_window_init.warm_font_cache") as warm:
+            MainInitManager._warm_font_cache(manager)
+
+        font = warm.call_args[0][0]
+        assert font.family() == "Times New Roman"
+        assert font.pointSize() == 14
+        assert font.weight() == QFont.Weight.Normal
+
+    def test_falls_back_when_the_scene_has_no_settings(self, app):
+        from moleditpy.ui.main_window_init import MainInitManager
+
+        manager = MagicMock(spec=MainInitManager)
+        manager.scene = object()
+
+        with patch("moleditpy.ui.main_window_init.warm_font_cache") as warm:
+            MainInitManager._warm_font_cache(manager)
+
+        warm.assert_called_once_with(None)

--- a/tests/unit/test_icon_theme_cache.py
+++ b/tests/unit/test_icon_theme_cache.py
@@ -1,0 +1,74 @@
+"""The icon painter must ask the OS for its theme once, not once per icon."""
+
+from unittest.mock import MagicMock, patch
+
+from PyQt6.QtGui import QColor
+
+from moleditpy.ui.main_window_init import _UNQUERIED, MainInitManager
+
+
+def _manager(settings=None):
+    manager = MagicMock(spec=MainInitManager)
+    manager.settings = settings if settings is not None else {}
+    manager._os_dark_pref = _UNQUERIED
+    return manager
+
+
+class TestOsThemeIsQueriedOnce:
+    def test_repeated_icons_fork_only_one_helper(self, app):
+        """detect_system_dark_mode forks `defaults`/`gsettings`; 15+ per launch hung CI."""
+        manager = _manager()
+        with patch(
+            "moleditpy.ui.main_window_init.detect_system_dark_mode", return_value=True
+        ) as detect:
+            for _ in range(15):
+                MainInitManager._get_icon_foreground_color(manager)
+        detect.assert_called_once()
+
+    def test_unknown_preference_is_not_re_queried(self, app):
+        """None is a real answer ("OS could not say"), so it must also be cached."""
+        manager = _manager()
+        with patch(
+            "moleditpy.ui.main_window_init.detect_system_dark_mode", return_value=None
+        ) as detect:
+            for _ in range(5):
+                MainInitManager._get_icon_foreground_color(manager)
+        detect.assert_called_once()
+
+
+class TestColourIsStillCorrect:
+    def test_dark_os_gives_white_icons(self, app):
+        manager = _manager()
+        with patch(
+            "moleditpy.ui.main_window_init.detect_system_dark_mode", return_value=True
+        ):
+            assert MainInitManager._get_icon_foreground_color(manager) == QColor(
+                "#FFFFFF"
+            )
+
+    def test_light_os_gives_black_icons(self, app):
+        manager = _manager()
+        with patch(
+            "moleditpy.ui.main_window_init.detect_system_dark_mode", return_value=False
+        ):
+            assert MainInitManager._get_icon_foreground_color(manager) == QColor(
+                "#000000"
+            )
+
+    def test_explicit_setting_wins_without_asking_the_os(self, app):
+        manager = _manager({"icon_foreground": "#FF0000"})
+        with patch("moleditpy.ui.main_window_init.detect_system_dark_mode") as detect:
+            assert MainInitManager._get_icon_foreground_color(manager) == QColor(
+                "#FF0000"
+            )
+        detect.assert_not_called()
+
+    def test_falls_back_to_background_luminance(self, app):
+        """With no OS answer, a dark canvas still has to yield light icons."""
+        manager = _manager({"background_color": "#101010"})
+        with patch(
+            "moleditpy.ui.main_window_init.detect_system_dark_mode", return_value=None
+        ):
+            assert MainInitManager._get_icon_foreground_color(manager) == QColor(
+                "#FFFFFF"
+            )


### PR DESCRIPTION
## Summary

<!-- What does this PR do? List the key changes in 2–4 bullet points. -->

- **Fixes the first-heteroatom freeze.** Placing the first O or N on an empty canvas stalled the editor mid-click. The cost is Qt, not RDKit: Arial has no U+2082, so the first `OH₂` label makes `QFontMetricsF` walk the entire system font database. Measured here at **384 ms for that first label, 0.04 ms for every one after** — the result is cached process-wide. A `QFontMetricsF` warm-up now runs on the first idle after `apply_initial_settings`, in the user's configured font family, moving the same one-time cost into startup where the user already expects to wait.
- **Removes the RDKit warm-up molecule**, which could never have helped. `MainInitManager` built `OC(N)C(S)P` and called `GetNumImplicitHs()` on it, but the molecule is never drawn — and even a drawn carbon skeleton renders no glyph at all, because a bonded neutral carbon is invisible (`AtomItem.update_style`). It never reached the font engine, which is where the time actually goes. `from rdkit import Chem` became unused and went with it.
- **Stops the icon painter forking a helper process per icon.** `_get_icon_foreground_color` called `detect_system_dark_mode()` once per generated icon — 15+ `defaults`/`gsettings` forks per launch — which is what deadlocked the `macos-latest / 3.14` job in the normal test suite. Now queried once per window. Those `subprocess.run` calls also had **no timeout at all**, so a wedged helper could hang startup indefinitely; bounded at 5 s.
- **Runs CI on `dev-N.N.N` branches.** Both workflows listed `dev` exactly, which does not match `dev-4.5.2` — so every release branch has been reaching `main` with only hand-dispatched CI. Verified fixed: the push of `6adf97f` triggered both workflows automatically.
- Merges Dependabot #114 and #115 (`pyvistaqt <0.12` → `<0.13`, for `moleditpy/` and `moleditpy-linux/`), and bumps the version to 4.5.2.

## Type of change

<!-- Check all that apply. -->

- [x] Bug fix
- [ ] New feature
- [x] Refactor / code cleanup
- [ ] Documentation
- [x] Tests
- [x] CI / build

## Related issues

<!-- Link any related issues, e.g. Closes #123 -->

None.

## Test plan

<!-- How did you verify the change works? -->

- [x] Ran `python tests/run_all_tests.py` — all pass (**2143 passed, 1 skipped**; coverage 89.50% → 89.59%)
- [x] Ran the full-GUI tier locally — 36 passed
- [x] Green in CI — `MoleditPy Tests` 11/11 jobs on the theme-cache commit, `Full GUI Tests` 20/20 on the font warm-up
- [ ] Manually tested in the GUI with the check list
- [x] Added new unit tests (15: 9 for the font warm-up, 6 for the icon-theme cache)

### Measurements, not estimates

| | before | after |
|---|---|---|
| first `OH₂` label | 384.84 ms | **0.04 ms** |
| OS theme queries per launch | 15+ forks | **1** |

### Things I checked and deliberately did *not* change

- **`AtomItem.boundingRect()` rebuilding `QFont`/`QFontMetricsF` per call.** I had flagged this as a paint cost. Measured: **1.8 µs per call, 0.54 ms per 300-atom repaint.** Not worth touching the paint path for; reverted the refactor I had started.
- **`QTimer.singleShot(100, fit_to_view)`.** I had described this as able to render into a finalised plotter. That was wrong — `fit_to_view` (`view_3d_logic.py:1791`) operates on the 2D scene (`init_manager.scene`, `view_2d`) and never touches the plotter. The residual risk is a `RuntimeError` only if the window closes within 100 ms of a file drop, and it is already wrapped defensively.
- **`manual.md`.** I had thought `python -m moleditpy_installer` and `Version: 4.5` were stale. Both are correct — `moleditpy_installer.__main__` exists, and the version line is intentionally minor-level. `manual-JP.md` and both wikis were checked and are consistent.

### Note on where the theme cache lives

The obvious fix — `@functools.lru_cache` on `detect_system_theme` itself — **breaks 9 tests** in `test_system_utils.py`, which call it repeatedly under different mocked platforms and would get a stale answer. It is cached on `MainInitManager` instead, so `system_utils`' public behaviour is unchanged. The sentinel (rather than `None`) is required because `None` is a real answer — "the OS could not say" — that must be cached too, not retried 15 times.

## Checklist

- [x] `python -m flake8 moleditpy/src/ --select=F` returns 0 issues
- [x] No bare `except:` clauses added (use `except Exception as e:` and log the error)
- [x] No new unused imports or variables
- [x] Plugin API changes are backwards-compatible (or documented in Summary) — no API changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NnQ68fojVw3hmMx832qQoW
