### PR TITLE
Dev 4.7.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,13 +56,17 @@ Run full suite + pylint in one pass (updates `tests/pylint-score.txt` automatica
 MOLEDITPY_HEADLESS=1 QT_QPA_PLATFORM=offscreen python tests/run_all_tests.py --pylint
 ```
 
-## Linting
+## Linting and Type Checking
 
 ```bash
 pylint moleditpy/src/moleditpy/
+ruff format moleditpy/src tests && ruff check moleditpy/src
+mypy moleditpy/src/moleditpy/          # config in mypy.ini; must stay at zero errors
 ```
 
-Target score: > 9.0/10. PEP 8 compliance required. Type hints required for all functions and methods.
+Target pylint score: > 9.0/10. PEP 8 compliance required. Type hints required for all functions and methods.
+
+Run all three before committing. `mypy` is clean as of 4.7.0 — do not add errors, and do not silence one with `# type: ignore` where a real guard or an explicitly typed local expresses the intent (numpy 2.x returns `Any` under `python_version = 3.9`, so assign to a `np.ndarray` local and return that).
 
 The `--pylint` flag on `run_all_tests.py` runs pylint automatically after all tests pass and writes the score to `tests/pylint-score.txt`.
 

--- a/moleditpy/pyproject.toml
+++ b/moleditpy/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "MoleditPy"
 
-version = "4.6.1"
+version = "4.7.0"
 
 license = {file = "LICENSE"}
 

--- a/moleditpy/src/moleditpy/ui/angle_dialog.py
+++ b/moleditpy/src/moleditpy/ui/angle_dialog.py
@@ -487,7 +487,10 @@ class AngleDialog(GeometryBaseDialog):
         if abs(achieved - requested) < 0.5:
             return
         with suppress_log(AttributeError, RuntimeError, TypeError):
-            self.main_window.statusBar().showMessage(
+            status_bar = self.main_window.statusBar()
+            if status_bar is None:
+                return
+            status_bar.showMessage(
                 f"Angle unchanged ({achieved:.2f} deg): the three atoms rotate "
                 "together, which happens for an angle inside a ring.",
                 5000,

--- a/moleditpy/src/moleditpy/ui/atom_item.py
+++ b/moleditpy/src/moleditpy/ui/atom_item.py
@@ -135,13 +135,7 @@ class AtomItem(QGraphicsItem):
         self.update()
 
     def visual_rect(self) -> QRectF:
-        """Return the rectangle the atom actually draws into.
-
-        Kept separate from boundingRect(), which Qt also requires to cover the
-        (zoom-dependent) hit shape: selection and hover highlights are drawn
-        from this one, so they stay wrapped around the label instead of
-        ballooning with the hit radius when zoomed out.
-        """
+        """Return the rectangle the atom draws into; highlights use this."""
         font_size = 20
         font_family = FONT_FAMILY
         font_bold = True
@@ -259,11 +253,7 @@ class AtomItem(QGraphicsItem):
         return full_visual_rect.adjusted(-3, -3, 3, 3)
 
     def boundingRect(self) -> QRectF:
-        """Return the item geometry: everything drawn, plus the hit shape.
-
-        The hit circle from shape() must stay inside boundingRect(), or Qt's
-        item index prunes hover/click hits that shape() would accept.
-        """
+        """Return the drawn rect plus the hit shape, which Qt requires it to cover."""
         hit_r = self.hit_radius()
         return self.visual_rect().united(
             QRectF(-hit_r, -hit_r, hit_r * 2.0, hit_r * 2.0)
@@ -349,23 +339,11 @@ class AtomItem(QGraphicsItem):
         return path
 
     def hit_radius(self) -> float:
-        """Return the hit/snap radius in scene units for the current zoom.
-
-        The radius is derived from the ``bond_snapping_distance_2d`` setting so
-        that hover highlight matches the snapping / keyboard instant-switch
-        zone exactly.  The setting is in screen pixels, so it is divided by the
-        current view scale.
-        """
+        """Return the hit/snap radius in scene units for the current zoom."""
         return scene_hit_radius(self.scene(), fallback=max(4.0, ATOM_RADIUS - 6.0) * 2)
 
     def shape(self) -> QPainterPath:
-        """Define the shape of the atom item for collision detection.
-
-        Deliberately independent of the drawn label: the hit zone is a fixed
-        number of screen pixels, so zooming in narrows the molecular distance
-        it covers.  That is what makes zooming the way to target atoms
-        precisely in a crowded structure.
-        """
+        """Define the collision area: a fixed pixel radius, never the drawn label."""
         scene_radius = self.hit_radius()
 
         path = QPainterPath()

--- a/moleditpy/src/moleditpy/ui/atom_item.py
+++ b/moleditpy/src/moleditpy/ui/atom_item.py
@@ -112,8 +112,8 @@ class AtomItem(QGraphicsItem):
         font_italic = False
         font_underline = False
 
-        scene = self.scene()
-        if scene is not None and hasattr(scene, "get_setting"):
+        scene: Any = self.scene()
+        if scene is not None:
             font_size = scene.get_setting("atom_font_size_2d", 20)
             font_family = scene.get_setting("atom_font_family_2d", FONT_FAMILY)
             font_bold = scene.get_setting("atom_font_bold_2d", True)
@@ -147,8 +147,8 @@ class AtomItem(QGraphicsItem):
         font_bold = True
         font_italic = False
         font_underline = False
-        scene = self.scene()
-        if scene is not None and hasattr(scene, "get_setting"):
+        scene: Any = self.scene()
+        if scene is not None:
             font_size = scene.get_setting("atom_font_size_2d", 20)
             font_family = scene.get_setting("atom_font_family_2d", FONT_FAMILY)
             font_bold = scene.get_setting("atom_font_bold_2d", True)
@@ -280,8 +280,8 @@ class AtomItem(QGraphicsItem):
         font_bold = True
         font_italic = False
         font_underline = False
-        scene = self.scene()
-        if scene is not None and hasattr(scene, "get_setting"):
+        scene: Any = self.scene()
+        if scene is not None:
             font_size = scene.get_setting("atom_font_size_2d", 20)
             font_family = scene.get_setting("atom_font_family_2d", FONT_FAMILY)
             font_bold = scene.get_setting("atom_font_bold_2d", True)
@@ -384,11 +384,11 @@ class AtomItem(QGraphicsItem):
         # Color logic: check if we should use bond color (uniform) or CPK (element-specific)
         color = CPK_COLORS.get(self.symbol, CPK_COLORS["DEFAULT"])
         # Use bond color if specified in settings
-        scene = self.scene()
-        if hasattr(scene, "get_setting") and (
-            self.symbol == "H" or scene.get_setting("atom_use_bond_color_2d", False)  # type: ignore[union-attr]
+        scene: Any = self.scene()
+        if scene is not None and (
+            self.symbol == "H" or scene.get_setting("atom_use_bond_color_2d", False)
         ):
-            custom_color = scene.get_setting("bond_color_2d", "#222222")  # type: ignore[union-attr]
+            custom_color = scene.get_setting("bond_color_2d", "#222222")
             if isinstance(custom_color, str):
                 color = QColor(custom_color)
 

--- a/moleditpy/src/moleditpy/ui/atom_item.py
+++ b/moleditpy/src/moleditpy/ui/atom_item.py
@@ -37,6 +37,7 @@ from ..utils.constants import (
     FONT_FAMILY,
     FONT_WEIGHT_BOLD,
 )
+from ..utils.hit_radius import scene_hit_radius
 from ..utils.sip_isdeleted_safe import sip_isdeleted_safe
 
 if TYPE_CHECKING:
@@ -249,7 +250,12 @@ class AtomItem(QGraphicsItem):
             full_visual_rect = full_visual_rect.united(radical_area)
 
         # 3. Add final margins for selection highlights, etc.
-        return full_visual_rect.adjusted(-3, -3, 3, 3)
+        full_visual_rect = full_visual_rect.adjusted(-3, -3, 3, 3)
+
+        # 4. The hit circle from shape() must stay inside boundingRect(), or
+        # Qt's item index prunes hover/click hits that shape() would accept.
+        hit_r = self.hit_radius()
+        return full_visual_rect.united(QRectF(-hit_r, -hit_r, hit_r * 2.0, hit_r * 2.0))
 
     def get_bg_ellipse_path(self) -> QPainterPath:
         """Return the elliptical background path used for bond endpoint clipping."""
@@ -330,36 +336,26 @@ class AtomItem(QGraphicsItem):
         path.addEllipse(bg_rect)
         return path
 
-    def shape(self) -> QPainterPath:
-        """Define the shape of the atom item for collision detection.
+    def hit_radius(self) -> float:
+        """Return the hit/snap radius in scene units for the current zoom.
 
-        The hit radius is derived from the ``bond_snapping_distance_2d``
-        setting so that hover highlight matches the snapping / keyboard
-        instant-switch zone exactly.  The radius is expressed in screen
-        pixels and divided by the current view scale.
+        The radius is derived from the ``bond_snapping_distance_2d`` setting so
+        that hover highlight matches the snapping / keyboard instant-switch
+        zone exactly.  The setting is in screen pixels, so it is divided by the
+        current view scale.
         """
-        scene = self.scene()
-        if not scene or not scene.views():
-            path = QPainterPath()
-            hit_r = max(4.0, ATOM_RADIUS - 6.0) * 2
-            path.addEllipse(QRectF(-hit_r, -hit_r, hit_r * 2.0, hit_r * 2.0))
-            return path
+        return scene_hit_radius(self.scene(), fallback=max(4.0, ATOM_RADIUS - 6.0) * 2)
 
-        view = scene.views()[0]
-        scale = view.transform().m11()
-        if scale <= 0.0:
-            scale = 1.0
-
-        # Use the same setting that find_atom_near() uses for snapping,
-        # so hover highlight and snap zones are identical.
-        if hasattr(scene, "get_setting"):
-            hit_px = scene.get_setting("bond_snapping_distance_2d", 14.0)
-        else:
-            hit_px = 14.0
-        scene_radius = hit_px / scale
+    def shape(self) -> QPainterPath:
+        """Define the shape of the atom item for collision detection."""
+        scene_radius = self.hit_radius()
 
         path = QPainterPath()
         path.addEllipse(QPointF(0, 0), scene_radius, scene_radius)
+        # When zoomed in the pixel-sized hit circle can be smaller than the
+        # drawn label; the glyph itself must always stay clickable.
+        if self.is_visible:
+            path = path.united(self.get_bg_ellipse_path())
         return path
 
     def paint(

--- a/moleditpy/src/moleditpy/ui/atom_item.py
+++ b/moleditpy/src/moleditpy/ui/atom_item.py
@@ -134,8 +134,14 @@ class AtomItem(QGraphicsItem):
         )
         self.update()
 
-    def boundingRect(self) -> QRectF:
-        """Calculate the bounding rectangle for the atom item."""
+    def visual_rect(self) -> QRectF:
+        """Return the rectangle the atom actually draws into.
+
+        Kept separate from boundingRect(), which Qt also requires to cover the
+        (zoom-dependent) hit shape: selection and hover highlights are drawn
+        from this one, so they stay wrapped around the label instead of
+        ballooning with the hit radius when zoomed out.
+        """
         font_size = 20
         font_family = FONT_FAMILY
         font_bold = True
@@ -250,12 +256,18 @@ class AtomItem(QGraphicsItem):
             full_visual_rect = full_visual_rect.united(radical_area)
 
         # 3. Add final margins for selection highlights, etc.
-        full_visual_rect = full_visual_rect.adjusted(-3, -3, 3, 3)
+        return full_visual_rect.adjusted(-3, -3, 3, 3)
 
-        # 4. The hit circle from shape() must stay inside boundingRect(), or
-        # Qt's item index prunes hover/click hits that shape() would accept.
+    def boundingRect(self) -> QRectF:
+        """Return the item geometry: everything drawn, plus the hit shape.
+
+        The hit circle from shape() must stay inside boundingRect(), or Qt's
+        item index prunes hover/click hits that shape() would accept.
+        """
         hit_r = self.hit_radius()
-        return full_visual_rect.united(QRectF(-hit_r, -hit_r, hit_r * 2.0, hit_r * 2.0))
+        return self.visual_rect().united(
+            QRectF(-hit_r, -hit_r, hit_r * 2.0, hit_r * 2.0)
+        )
 
     def get_bg_ellipse_path(self) -> QPainterPath:
         """Return the elliptical background path used for bond endpoint clipping."""
@@ -347,15 +359,17 @@ class AtomItem(QGraphicsItem):
         return scene_hit_radius(self.scene(), fallback=max(4.0, ATOM_RADIUS - 6.0) * 2)
 
     def shape(self) -> QPainterPath:
-        """Define the shape of the atom item for collision detection."""
+        """Define the shape of the atom item for collision detection.
+
+        Deliberately independent of the drawn label: the hit zone is a fixed
+        number of screen pixels, so zooming in narrows the molecular distance
+        it covers.  That is what makes zooming the way to target atoms
+        precisely in a crowded structure.
+        """
         scene_radius = self.hit_radius()
 
         path = QPainterPath()
         path.addEllipse(QPointF(0, 0), scene_radius, scene_radius)
-        # When zoomed in the pixel-sized hit circle can be smaller than the
-        # drawn label; the glyph itself must always stay clickable.
-        if self.is_visible:
-            path = path.united(self.get_bg_ellipse_path())
         return path
 
     def paint(
@@ -529,17 +543,17 @@ class AtomItem(QGraphicsItem):
         if self.has_problem:
             painter.setBrush(Qt.BrushStyle.NoBrush)
             painter.setPen(QPen(QColor(255, 0, 0, 200), 4))
-            painter.drawRect(self.boundingRect())
+            painter.drawRect(self.visual_rect())
         elif self.isSelected():
             painter.setBrush(Qt.BrushStyle.NoBrush)
             painter.setPen(QPen(QColor(0, 100, 255), 3))
-            painter.drawRect(self.boundingRect())
+            painter.drawRect(self.visual_rect())
         if (not self.isSelected()) and getattr(self, "hovered", False):
             pen = QPen(QColor(144, 238, 144, 200), 3)
             pen.setJoinStyle(Qt.PenJoinStyle.RoundJoin)
             painter.setBrush(Qt.BrushStyle.NoBrush)
             painter.setPen(pen)
-            painter.drawRect(self.boundingRect())
+            painter.drawRect(self.visual_rect())
 
     def itemChange(self, change: QGraphicsItem.GraphicsItemChange, value: Any) -> Any:
         """Propagate position and scene changes to connected bond items."""

--- a/moleditpy/src/moleditpy/ui/bond_item.py
+++ b/moleditpy/src/moleditpy/ui/bond_item.py
@@ -233,12 +233,7 @@ class BondItem(QGraphicsItem):
             return QLineF(0, 0, 0, 0)
 
     def hit_radius(self) -> float:
-        """Return the click/hover half-width in scene units for the current zoom.
-
-        Uses the same ``bond_snapping_distance_2d`` setting (screen pixels) as
-        atom hover/snapping, divided by the view scale so the clickable band
-        stays a constant width on screen.
-        """
+        """Return the click/hover half-width in scene units for the current zoom."""
         return scene_hit_radius(self.scene())
 
     def boundingRect(self) -> QRectF:
@@ -261,8 +256,7 @@ class BondItem(QGraphicsItem):
             bond_offset = scene.get_setting(key, 3.5)
             wedge_width = scene.get_setting("bond_wedge_width_2d", 6.0)
 
-        # The stroked hit band from shape() must stay inside boundingRect(),
-        # otherwise Qt's item index prunes clicks that shape() would accept.
+        # Qt prunes clicks whose shape() escapes boundingRect().
         extra = (getattr(self, "order", 1) - 1) * bond_offset + 50 + wedge_width
         extra = max(extra, self.hit_radius() + 2.0)
         rect = (

--- a/moleditpy/src/moleditpy/ui/bond_item.py
+++ b/moleditpy/src/moleditpy/ui/bond_item.py
@@ -43,6 +43,7 @@ from ..utils.constants import (
     FONT_WEIGHT_BOLD,
     HOVER_PEN_WIDTH,
 )
+from ..utils.hit_radius import scene_hit_radius
 
 if TYPE_CHECKING:
     from .atom_item import AtomItem
@@ -231,6 +232,15 @@ class BondItem(QGraphicsItem):
             # return zero line to prevent downstream crashes.
             return QLineF(0, 0, 0, 0)
 
+    def hit_radius(self) -> float:
+        """Return the click/hover half-width in scene units for the current zoom.
+
+        Uses the same ``bond_snapping_distance_2d`` setting (screen pixels) as
+        atom hover/snapping, divided by the view scale so the clickable band
+        stays a constant width on screen.
+        """
+        return scene_hit_radius(self.scene())
+
     def boundingRect(self) -> QRectF:
         """Return the bounding rect encompassing all visual bond representations."""
         try:
@@ -251,7 +261,10 @@ class BondItem(QGraphicsItem):
             bond_offset = scene.get_setting(key, 3.5)
             wedge_width = scene.get_setting("bond_wedge_width_2d", 6.0)
 
+        # The stroked hit band from shape() must stay inside boundingRect(),
+        # otherwise Qt's item index prunes clicks that shape() would accept.
         extra = (getattr(self, "order", 1) - 1) * bond_offset + 50 + wedge_width
+        extra = max(extra, self.hit_radius() + 2.0)
         rect = (
             QRectF(line.p1(), line.p2())
             .normalized()
@@ -292,25 +305,9 @@ class BondItem(QGraphicsItem):
             path.moveTo(line.p1())
             path.lineTo(line.p2())
 
-            # Use the exact same setting as atom hover highlight and snapping, zoom-aware.
-            scene = self.scene()
-            if scene and scene.views():
-                view = scene.views()[0]
-                scale = view.transform().m11()
-                if scale <= 0.0:
-                    scale = 1.0
-                if hasattr(scene, "get_setting"):
-                    hit_px = scene.get_setting("bond_snapping_distance_2d", 14.0)
-                else:
-                    hit_px = 14.0
-                # width is diameter, so 2 * radius
-                scene_width = (hit_px * 2) / scale
-            else:
-                scene_width = 28.0
-
-            # Stroke it to give it some width
+            # Stroke it to give it some width (width is a diameter, so 2 * radius)
             stroker = QPainterPathStroker()
-            stroker.setWidth(scene_width)
+            stroker.setWidth(self.hit_radius() * 2.0)
             path = stroker.createStroke(path)
 
             # If there's an E/Z label, add its rect to the selection shape

--- a/moleditpy/src/moleditpy/ui/bond_item.py
+++ b/moleditpy/src/moleditpy/ui/bond_item.py
@@ -13,7 +13,7 @@ DOI: 10.5281/zenodo.17268532
 from __future__ import annotations
 import math
 import logging
-from typing import TYPE_CHECKING, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Optional, Tuple, Union
 
 from PyQt6.QtCore import QLineF, QPointF, QRectF, Qt
 from PyQt6.QtGui import (
@@ -249,10 +249,10 @@ class BondItem(QGraphicsItem):
             line = QLineF(0, 0, 0, 0)
 
         # Get dynamic bond offset (spacing)
-        scene = self.scene()
+        scene: Any = self.scene()
         bond_offset = 3.5
         wedge_width = 6.0
-        if scene is not None and hasattr(scene, "get_setting"):
+        if scene is not None:
             key = (
                 "bond_spacing_triple_2d"
                 if getattr(self, "order", 1) == 3
@@ -275,7 +275,7 @@ class BondItem(QGraphicsItem):
         if self.order == 2 and self.stereo in [3, 4]:
             font_size = 20
             font_family = FONT_FAMILY
-            if scene is not None and hasattr(scene, "get_setting"):
+            if scene is not None:
                 font_size = scene.get_setting("atom_font_size_2d", 20)
                 font_family = scene.get_setting("atom_font_family_2d", FONT_FAMILY)
 
@@ -359,8 +359,8 @@ class BondItem(QGraphicsItem):
         bond_color = QColor("#222222")
 
         try:
-            scene = self.scene()
-            if scene is not None and hasattr(scene, "get_setting"):
+            scene: Any = self.scene()
+            if scene is not None:
                 # Color
                 if self.isSelected():
                     bond_color = QColor("blue")
@@ -535,8 +535,8 @@ class BondItem(QGraphicsItem):
                         # --- Label Settings ---
                         font_size = 20
                         font_family = FONT_FAMILY
-                        _sc = self.scene()
-                        if _sc is not None and hasattr(_sc, "get_setting"):
+                        _sc: Any = self.scene()
+                        if _sc is not None:
                             font_size = _sc.get_setting("atom_font_size_2d", 20)
                             font_family = _sc.get_setting(
                                 "atom_font_family_2d", FONT_FAMILY

--- a/moleditpy/src/moleditpy/ui/bond_length_dialog.py
+++ b/moleditpy/src/moleditpy/ui/bond_length_dialog.py
@@ -441,7 +441,10 @@ class BondLengthDialog(GeometryBaseDialog):
         if abs(worst_delta) < 1e-4:
             return
         with suppress_log(AttributeError, RuntimeError, TypeError):
-            self.main_window.statusBar().showMessage(
+            status_bar = self.main_window.statusBar()
+            if status_bar is None:
+                return
+            status_bar.showMessage(
                 f"Bond {worst_label} also changed by {worst_delta:+.3f} A: a bond "
                 "inside a ring cannot be resized on its own.",
                 5000,

--- a/moleditpy/src/moleditpy/ui/custom_interactor_style.py
+++ b/moleditpy/src/moleditpy/ui/custom_interactor_style.py
@@ -51,8 +51,9 @@ _GROUP_ROTATION_RADIANS_PER_PIXEL = 0.008
 def _rodrigues_matrix(axis: np.ndarray, angle: float) -> np.ndarray:
     """Return the rotation matrix for `angle` radians about `axis` (Rodrigues)."""
     norm = float(np.linalg.norm(axis))
+    identity: np.ndarray = np.eye(3)
     if norm < 1e-6 or abs(angle) < 1e-6:
-        return np.eye(3)
+        return identity
     unit = axis / norm
     k_mat = np.array(
         [
@@ -61,7 +62,10 @@ def _rodrigues_matrix(axis: np.ndarray, angle: float) -> np.ndarray:
             [-unit[1], unit[0], 0.0],
         ]
     )
-    return np.eye(3) + np.sin(angle) * k_mat + (1.0 - np.cos(angle)) * (k_mat @ k_mat)
+    rotation: np.ndarray = (
+        identity + np.sin(angle) * k_mat + (1.0 - np.cos(angle)) * (k_mat @ k_mat)
+    )
+    return rotation
 
 
 class CustomInteractorStyle(vtkInteractorStyleTrackballCamera):
@@ -944,7 +948,8 @@ class CustomInteractorStyle(vtkInteractorStyleTrackballCamera):
             speed = _GROUP_ROTATION_RADIANS_PER_PIXEL * self._rotation_sensitivity()
             rot_y = _rodrigues_matrix(view_up, float(dx) * speed)
             rot_x = _rodrigues_matrix(right, -float(dy) * speed)
-            return rot_x @ rot_y
+            combined: np.ndarray = rot_x @ rot_y
+            return combined
         except (AttributeError, RuntimeError, TypeError, ValueError):
             logging.debug("Suppressed non-critical error", exc_info=True)
             return None

--- a/moleditpy/src/moleditpy/ui/dihedral_dialog.py
+++ b/moleditpy/src/moleditpy/ui/dihedral_dialog.py
@@ -489,7 +489,10 @@ class DihedralDialog(GeometryBaseDialog):
         if min(difference, 360.0 - difference) < 0.5:
             return
         with suppress_log(AttributeError, RuntimeError, TypeError):
-            self.main_window.statusBar().showMessage(
+            status_bar = self.main_window.statusBar()
+            if status_bar is None:
+                return
+            status_bar.showMessage(
                 f"Dihedral unchanged ({achieved:.2f}°): the four atoms rotate "
                 "together, which happens for a bond inside a ring.",
                 5000,

--- a/moleditpy/src/moleditpy/ui/edit_3d_logic.py
+++ b/moleditpy/src/moleditpy/ui/edit_3d_logic.py
@@ -242,7 +242,7 @@ class Edit3DManager:
 
         # Position near top-right of atom
         atom_pos = atom_item.pos()
-        atom_rect = atom_item.boundingRect()
+        atom_rect = atom_item.visual_rect()
         label_pos = QPointF(
             atom_pos.x() + atom_rect.width() / 4 + 2,
             atom_pos.y() - atom_rect.height() / 4 - 8,

--- a/moleditpy/src/moleditpy/ui/edit_actions_logic.py
+++ b/moleditpy/src/moleditpy/ui/edit_actions_logic.py
@@ -1045,7 +1045,7 @@ class EditActionsManager:
                 # Only prepare a geometry change if the implicit H count
                 # changes (this may affect the item's bounding rect).
                 need_geometry = current != new_count
-                if need_geometry and hasattr(item, "prepareGeometryChange"):
+                if need_geometry:
                     item.prepareGeometryChange()
                 item.implicit_h_count = new_count
                 item.has_problem = bool(desired_prob)

--- a/moleditpy/src/moleditpy/ui/io_logic.py
+++ b/moleditpy/src/moleditpy/ui/io_logic.py
@@ -495,22 +495,21 @@ class IOManager:
             self.host.statusBar().showMessage("Error: Nothing to save.")
             return
 
-        native_exts = [".pmeprj", ".pmeraw"]
-        if self.host.init_manager.current_file_path and any(
-            self.host.init_manager.current_file_path.lower().endswith(ext)
-            for ext in native_exts
-        ):
+        current_path = self.host.init_manager.current_file_path
+        if current_path and current_path.lower().endswith(".pmeraw"):
+            # Never write back the legacy pickle format: fall through to
+            # Save As, which always produces a .pmeprj.
+            self.host.update_status_message(
+                "Raw (.pmeraw) files are read-only — saving as .pmeprj instead."
+            )
+            self.save_project_as()
+            return
+
+        if current_path and current_path.lower().endswith(".pmeprj"):
             try:
-                if self.host.init_manager.current_file_path.lower().endswith(".pmeraw"):
-                    save_data = self.host.state_manager.get_current_state()
-                    with open(self.host.init_manager.current_file_path, "wb") as f:
-                        pickle.dump(save_data, f)
-                else:
-                    json_data = self.host.state_manager.create_json_data()
-                    with open(
-                        self.host.init_manager.current_file_path, "w", encoding="utf-8"
-                    ) as f:
-                        json.dump(json_data, f, indent=2, ensure_ascii=False)
+                json_data = self.host.state_manager.create_json_data()
+                with open(current_path, "w", encoding="utf-8") as f:
+                    json.dump(json_data, f, indent=2, ensure_ascii=False)
 
                 self.host.set_has_unsaved_changes(False)
                 self.host.state_manager.update_window_title()
@@ -1109,6 +1108,33 @@ class IOManager:
             except (OSError, IOError, ValueError, RuntimeError, AttributeError) as e:
                 self.host.statusBar().showMessage(f"Error saving XYZ: {e}")
 
+    def _confirm_pickle_load(self, file_path: str) -> bool:
+        """Ask the user before unpickling a .pmeraw file.
+
+        A .pmeraw file is a Python pickle: loading one runs arbitrary code
+        embedded in the file, so a file from an untrusted source can take over
+        the machine. Returns True only if the user explicitly chooses Open.
+        """
+        if os.environ.get("MOLEDITPY_HEADLESS"):
+            return True
+
+        box = QMessageBox(self.host)
+        box.setIcon(QMessageBox.Icon.Warning)
+        box.setWindowTitle("Open Raw Project File?")
+        box.setText("This file is in the legacy raw (pickle) format.")
+        box.setInformativeText(
+            f"{os.path.basename(file_path)}\n\n"
+            "Raw project files can execute arbitrary code when opened. "
+            "Only open .pmeraw files that you created yourself or received "
+            "from a source you trust.\n\n"
+            "The .pmeprj format is safe and is recommended instead."
+        )
+        open_button = box.addButton("Open", QMessageBox.ButtonRole.AcceptRole)
+        cancel_button = box.addButton(QMessageBox.StandardButton.Cancel)
+        box.setDefaultButton(cancel_button)
+        box.exec()
+        return box.clickedButton() is open_button
+
     def load_raw_data(self, file_path: Optional[str] = None) -> None:
         """Open a .pmeraw pickle project file."""
         if not self.host.state_manager.check_unsaved_changes():
@@ -1128,6 +1154,10 @@ class IOManager:
             )
             if not file_path:
                 return
+
+        if not self._confirm_pickle_load(file_path):
+            self.host.update_status_message("Opening raw project file cancelled.")
+            return
 
         if not self.host.edit_actions_manager.clear_all(skip_check=True):
             return

--- a/moleditpy/src/moleditpy/ui/io_logic.py
+++ b/moleditpy/src/moleditpy/ui/io_logic.py
@@ -1115,9 +1115,6 @@ class IOManager:
         embedded in the file, so a file from an untrusted source can take over
         the machine. Returns True only if the user explicitly chooses Open.
         """
-        if os.environ.get("MOLEDITPY_HEADLESS"):
-            return True
-
         box = QMessageBox(self.host)
         box.setIcon(QMessageBox.Icon.Warning)
         box.setWindowTitle("Open Raw Project File?")

--- a/moleditpy/src/moleditpy/ui/io_logic.py
+++ b/moleditpy/src/moleditpy/ui/io_logic.py
@@ -497,8 +497,7 @@ class IOManager:
 
         current_path = self.host.init_manager.current_file_path
         if current_path and current_path.lower().endswith(".pmeraw"):
-            # Never write back the legacy pickle format: fall through to
-            # Save As, which always produces a .pmeprj.
+            # Never write the legacy pickle back; Save As only emits .pmeprj.
             self.host.update_status_message(
                 "Raw (.pmeraw) files are read-only — saving as .pmeprj instead."
             )
@@ -1109,12 +1108,7 @@ class IOManager:
                 self.host.statusBar().showMessage(f"Error saving XYZ: {e}")
 
     def _confirm_pickle_load(self, file_path: str) -> bool:
-        """Ask the user before unpickling a .pmeraw file.
-
-        A .pmeraw file is a Python pickle: loading one runs arbitrary code
-        embedded in the file, so a file from an untrusted source can take over
-        the machine. Returns True only if the user explicitly chooses Open.
-        """
+        """Ask before unpickling a .pmeraw file, which can run arbitrary code."""
         box = QMessageBox(self.host)
         box.setIcon(QMessageBox.Icon.Warning)
         box.setWindowTitle("Open Raw Project File?")

--- a/moleditpy/src/moleditpy/ui/main_window_init.py
+++ b/moleditpy/src/moleditpy/ui/main_window_init.py
@@ -223,7 +223,7 @@ class MainInitManager:
         """Resolve the atom-label font now, in the user's configured family."""
         scene = getattr(self, "scene", None)
         font = None
-        if scene is not None and hasattr(scene, "get_setting"):
+        if scene is not None:
             family = scene.get_setting("atom_font_family_2d", FONT_FAMILY)
             size = scene.get_setting("atom_font_size_2d", 20)
             bold = scene.get_setting("atom_font_bold_2d", True)

--- a/moleditpy/src/moleditpy/ui/molecular_scene_handler.py
+++ b/moleditpy/src/moleditpy/ui/molecular_scene_handler.py
@@ -1593,10 +1593,7 @@ class SceneQueryMixin:
     def find_atom_near(self, pos: Any, tol: float = 14.0) -> Any:
         """Return the AtomItem within tolerance distance of pos, or None.
 
-        ``tol`` is specified in **screen pixels**.  It is divided by the
-        current view scale so that the effective snap radius stays constant
-        on screen regardless of zoom level — matching the behaviour of
-        ``AtomItem.shape()`` (hover highlight).
+        ``tol`` is in screen pixels, divided by the view scale to match shape().
         """
         if pos is None:
             return None

--- a/moleditpy/src/moleditpy/ui/molecular_scene_handler.py
+++ b/moleditpy/src/moleditpy/ui/molecular_scene_handler.py
@@ -1609,21 +1609,11 @@ class SceneQueryMixin:
         search_rect = QRectF(pos.x() - tol, pos.y() - tol, 2 * tol, 2 * tol)
         nearby_items = self.items(search_rect)
 
-        atoms = [it for it in nearby_items if isinstance(it, AtomItem)]
-        for it in atoms:
-            # Check the precise distance only for candidate items
-            if QLineF(it.pos(), pos).length() <= tol:
-                return it
-
-        # When zoomed in, the pixel-sized tolerance shrinks below the drawn
-        # label, so also accept a position that lands on the glyph itself.
-        # This keeps snapping in step with AtomItem.shape() (hover highlight).
-        for it in atoms:
-            try:
-                if it.contains(it.mapFromScene(pos)):
+        for it in nearby_items:
+            if isinstance(it, AtomItem):
+                # Check the precise distance only for candidate items
+                if QLineF(it.pos(), pos).length() <= tol:
                     return it
-            except (AttributeError, RuntimeError, TypeError):
-                continue
         return None
 
     def find_bond_between(self, atom1: Any, atom2: Any) -> Any:

--- a/moleditpy/src/moleditpy/ui/molecular_scene_handler.py
+++ b/moleditpy/src/moleditpy/ui/molecular_scene_handler.py
@@ -1396,6 +1396,7 @@ class SceneQueryMixin:
     items: Any
     update_all_items: Any
     window: Any
+    views: Any
     addItem: Any
     removeItem: Any
 
@@ -1601,20 +1602,28 @@ class SceneQueryMixin:
             return None
         # Convert screen-pixel tolerance to scene units (zoom-aware).
         if self.views():
-            xform = self.views()[0].transform()
-            if xform is not None:
-                scale = xform.m11()
-                if scale > 0:
-                    tol = tol / scale
+            scale = self.views()[0].transform().m11()
+            if scale > 0:
+                tol = tol / scale
         # Create a small search rectangle around the position
         search_rect = QRectF(pos.x() - tol, pos.y() - tol, 2 * tol, 2 * tol)
         nearby_items = self.items(search_rect)
 
-        for it in nearby_items:
-            if isinstance(it, AtomItem):
-                # Check the precise distance only for candidate items
-                if QLineF(it.pos(), pos).length() <= tol:
+        atoms = [it for it in nearby_items if isinstance(it, AtomItem)]
+        for it in atoms:
+            # Check the precise distance only for candidate items
+            if QLineF(it.pos(), pos).length() <= tol:
+                return it
+
+        # When zoomed in, the pixel-sized tolerance shrinks below the drawn
+        # label, so also accept a position that lands on the glyph itself.
+        # This keeps snapping in step with AtomItem.shape() (hover highlight).
+        for it in atoms:
+            try:
+                if it.contains(it.mapFromScene(pos)):
                     return it
+            except (AttributeError, RuntimeError, TypeError):
+                continue
         return None
 
     def find_bond_between(self, atom1: Any, atom2: Any) -> Any:

--- a/moleditpy/src/moleditpy/ui/settings_tabs/settings_2d_tab.py
+++ b/moleditpy/src/moleditpy/ui/settings_tabs/settings_2d_tab.py
@@ -190,10 +190,11 @@ class Settings2DTab(SettingsTabBase):
 
         form_layout.addRow(self._create_separator())
 
-        # --- Bond Snapping Settings ---
-        form_layout.addRow(QLabel("<b>Bond Snapping Settings</b>"))
+        # --- Atom Hit / Snap Settings ---
+        form_layout.addRow(QLabel("<b>Atom Hit / Snap Settings</b>"))
 
-        # Bond Snapping Distance
+        # Atom hit radius (also used for bond snapping) — internal key is
+        # kept as bond_snapping_distance_2d so existing settings files load.
         self.bond_snapping_distance_2d_slider, self.bond_snapping_distance_2d_label = (
             self._create_slider(5, 50, 1.0, is_int=True)
         )
@@ -201,10 +202,10 @@ class Settings2DTab(SettingsTabBase):
             "The distance in screen pixels (zoom-independent) within which:\n"
             "• Drawing a bond snaps to an existing atom\n"
             "• Keyboard shortcuts instantly edit the atom under cursor\n"
-            "• Atoms show hover highlight"
+            "• Atoms and bonds show hover highlight and respond to clicks"
         )
         form_layout.addRow(
-            "Bond Snapping Distance (px):",
+            "Atom Hit / Snap Distance (px):",
             self._wrap_layout(
                 self.bond_snapping_distance_2d_slider,
                 self.bond_snapping_distance_2d_label,

--- a/moleditpy/src/moleditpy/ui/zoomable_view.py
+++ b/moleditpy/src/moleditpy/ui/zoomable_view.py
@@ -124,20 +124,15 @@ class ZoomableView(QGraphicsView):
             super().mouseReleaseEvent(event)
 
     def _invalidate_item_geometry(self) -> None:
-        """Re-index every item after a zoom change.
-
-        AtomItem/BondItem express their hit area in screen pixels, so both
-        boundingRect() and shape() change with the view scale.  Without this
-        notification Qt keeps the BSP index built at the old scale and hover /
-        click detection stops matching the drawn hit zone after zooming.
-        """
+        """Re-index items: their pixel-sized hit geometry changes with zoom."""
         scene = self.scene()
         if scene is None:
             return
         for item in scene.items():
+            # A wrapper deleted mid-iteration (scene teardown) raises.
             try:
                 item.prepareGeometryChange()
-            except (AttributeError, RuntimeError):
+            except RuntimeError:
                 continue
 
     def scale(self, sx: float, sy: float) -> None:

--- a/moleditpy/src/moleditpy/ui/zoomable_view.py
+++ b/moleditpy/src/moleditpy/ui/zoomable_view.py
@@ -123,6 +123,33 @@ class ZoomableView(QGraphicsView):
         else:
             super().mouseReleaseEvent(event)
 
+    def _invalidate_item_geometry(self) -> None:
+        """Re-index every item after a zoom change.
+
+        AtomItem/BondItem express their hit area in screen pixels, so both
+        boundingRect() and shape() change with the view scale.  Without this
+        notification Qt keeps the BSP index built at the old scale and hover /
+        click detection stops matching the drawn hit zone after zooming.
+        """
+        scene = self.scene()
+        if scene is None:
+            return
+        for item in scene.items():
+            try:
+                item.prepareGeometryChange()
+            except (AttributeError, RuntimeError):
+                continue
+
+    def scale(self, sx: float, sy: float) -> None:
+        """Scale the view and re-index items for the new scale."""
+        super().scale(sx, sy)
+        self._invalidate_item_geometry()
+
+    def resetTransform(self) -> None:
+        """Reset the view transform and re-index items for the new scale."""
+        super().resetTransform()
+        self._invalidate_item_geometry()
+
     def viewportEvent(self, event: Optional[QEvent]) -> bool:
         """Handle native gestures (like pinch zoom on trackpads)"""
         if event is None:

--- a/moleditpy/src/moleditpy/ui/zoomable_view.py
+++ b/moleditpy/src/moleditpy/ui/zoomable_view.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 from typing import Optional, cast
 
-from PyQt6.QtCore import QEvent, QPointF, Qt
+from PyQt6.QtCore import QEvent, QPointF, Qt, QTimer
 from PyQt6.QtGui import QMouseEvent, QWheelEvent, QNativeGestureEvent
 from PyQt6.QtWidgets import QGraphicsScene, QGraphicsView, QWidget
 
@@ -37,6 +37,14 @@ class ZoomableView(QGraphicsView):
         self._pan_start_pos = QPointF()
         self._pan_start_scroll_h = 0
         self._pan_start_scroll_v = 0
+
+        # Coalesces re-indexing to once per zoom gesture; doing it per wheel
+        # tick dirties every item and costs ~40x the zoom step on a large
+        # structure.
+        self._geometry_timer = QTimer(self)
+        self._geometry_timer.setSingleShot(True)
+        self._geometry_timer.setInterval(50)
+        self._geometry_timer.timeout.connect(self._invalidate_item_geometry)
 
     def wheelEvent(self, event: Optional[QWheelEvent]) -> None:
         """Event handler for mouse wheel rotation"""
@@ -136,14 +144,14 @@ class ZoomableView(QGraphicsView):
                 continue
 
     def scale(self, sx: float, sy: float) -> None:
-        """Scale the view and re-index items for the new scale."""
+        """Scale the view, then re-index items once the gesture settles."""
         super().scale(sx, sy)
-        self._invalidate_item_geometry()
+        self._geometry_timer.start()
 
     def resetTransform(self) -> None:
         """Reset the view transform and re-index items for the new scale."""
         super().resetTransform()
-        self._invalidate_item_geometry()
+        self._geometry_timer.start()
 
     def viewportEvent(self, event: Optional[QEvent]) -> bool:
         """Handle native gestures (like pinch zoom on trackpads)"""

--- a/moleditpy/src/moleditpy/utils/hit_radius.py
+++ b/moleditpy/src/moleditpy/utils/hit_radius.py
@@ -18,10 +18,8 @@ DEFAULT_HIT_PX = 14.0
 def scene_hit_radius(scene: Any, fallback: float = DEFAULT_HIT_PX) -> float:
     """Return the 2D hit/snap radius in scene units for the current zoom.
 
-    The ``bond_snapping_distance_2d`` setting is in screen pixels, so it is
-    divided by the view scale.  AtomItem.shape(), BondItem.shape() and
-    ``find_atom_near()`` all resolve their hit zone through this, which is what
-    keeps hover highlight, clicking and snapping on the same radius.
+    bond_snapping_distance_2d is in screen pixels, so it is divided by the view
+    scale; shape() and find_atom_near() share this to stay in step.
     """
     if not scene or not scene.views():
         return fallback

--- a/moleditpy/src/moleditpy/utils/hit_radius.py
+++ b/moleditpy/src/moleditpy/utils/hit_radius.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+"""
+MoleditPy — A Python-based molecular editing software
+
+Author: Hiromichi Yokoyama
+License: GPL-3.0 license
+Repo: https://github.com/HiroYokoyama/python_molecular_editor
+DOI: 10.5281/zenodo.17268532
+"""
+
+from typing import Any
+
+DEFAULT_HIT_PX = 14.0
+
+
+def scene_hit_radius(scene: Any, fallback: float = DEFAULT_HIT_PX) -> float:
+    """Return the 2D hit/snap radius in scene units for the current zoom.
+
+    The ``bond_snapping_distance_2d`` setting is in screen pixels, so it is
+    divided by the view scale.  AtomItem.shape(), BondItem.shape() and
+    ``find_atom_near()`` all resolve their hit zone through this, which is what
+    keeps hover highlight, clicking and snapping on the same radius.
+    """
+    if not scene or not scene.views():
+        return fallback
+
+    scale = scene.views()[0].transform().m11()
+    if scale <= 0.0:
+        scale = 1.0
+
+    hit_px = DEFAULT_HIT_PX
+    if hasattr(scene, "get_setting"):
+        hit_px = scene.get_setting("bond_snapping_distance_2d", DEFAULT_HIT_PX)
+    return float(hit_px / scale)

--- a/moleditpy/src/moleditpy/utils/hit_radius.py
+++ b/moleditpy/src/moleditpy/utils/hit_radius.py
@@ -30,7 +30,5 @@ def scene_hit_radius(scene: Any, fallback: float = DEFAULT_HIT_PX) -> float:
     if scale <= 0.0:
         scale = 1.0
 
-    hit_px = DEFAULT_HIT_PX
-    if hasattr(scene, "get_setting"):
-        hit_px = scene.get_setting("bond_snapping_distance_2d", DEFAULT_HIT_PX)
+    hit_px = scene.get_setting("bond_snapping_distance_2d", DEFAULT_HIT_PX)
     return float(hit_px / scale)

--- a/mypy.ini
+++ b/mypy.ini
@@ -21,15 +21,6 @@ ignore_missing_imports = True
 [mypy-sip]
 ignore_missing_imports = True
 
-[mypy-moleditpy.ui.constants]
-ignore_missing_imports = True
-
-[mypy-moleditpy.ui.mol_geometry]
-ignore_missing_imports = True
-
-[mypy-moleditpy.ui.molecular_data]
-ignore_missing_imports = True
-
 [mypy-moleditpy_linux.*]
 ignore_missing_imports = True
 

--- a/tests/assertion_catalog.md
+++ b/tests/assertion_catalog.md
@@ -7807,6 +7807,11 @@ _Choosing 'Open' in the raw-file warning proceeds with the load._
 
 - assert io._confirm_pickle_load('danger.pmeraw') is True
 
+### test_confirm_pickle_load_cancel
+_Choosing Cancel in the raw-file warning refuses the load._
+
+- assert io._confirm_pickle_load('danger.pmeraw') is False
+
 ### test_confirm_pickle_load_cancel_aborts
 _Cancelling the raw-file warning must leave the document untouched._
 

--- a/tests/assertion_catalog.md
+++ b/tests/assertion_catalog.md
@@ -3967,8 +3967,8 @@ _No description provided._
 - assert font.pointSize() == 14
 - assert font.weight() == QFont.Weight.Normal
 
-### TestInitManagerHook.test_falls_back_when_the_scene_has_no_settings
-_No description provided._
+### TestInitManagerHook.test_falls_back_before_the_scene_exists
+_Warm-up can run before the scene is built, so a missing scene must_
 
 - warm.assert_called_once_with(None)
 

--- a/tests/assertion_catalog.md
+++ b/tests/assertion_catalog.md
@@ -4574,6 +4574,7 @@ _No description provided._
 ### test_hover_and_snap_use_same_default_radius
 _At default settings both radii must equal bond_snapping_distance_2d._
 
+- assert atom.hit_radius() == pytest.approx(DEFAULT_SNAP_PX)
 - assert scene.find_atom_near(QPointF(DEFAULT_SNAP_PX - 0.1, 0), tol=DEFAULT_SNAP_PX) is atom
 - assert scene.find_atom_near(QPointF(DEFAULT_SNAP_PX + 0.1, 0), tol=DEFAULT_SNAP_PX) is None
 - assert hover_radius == pytest.approx(DEFAULT_SNAP_PX, abs=0.5)
@@ -4586,11 +4587,28 @@ _When the setting is changed, both hover and snap must change together._
 - assert hover_radius == pytest.approx(custom_dist, abs=0.5)
 
 ### test_hover_and_snap_stay_consistent_at_different_zoom_levels
-_Both radii must stay identical in screen-pixel terms at any zoom._
+_Hover shape and snapping must agree at every point, at any zoom._
 
-- assert scene.find_atom_near(QPointF(boundary_scene - 0.01, 0), tol=DEFAULT_SNAP_PX) is atom
-- assert scene.find_atom_near(QPointF(boundary_scene + 0.5, 0), tol=DEFAULT_SNAP_PX) is None
-- assert hover_screen_px == pytest.approx(DEFAULT_SNAP_PX, abs=0.5)
+- assert atom.hit_radius() * scale == pytest.approx(DEFAULT_SNAP_PX)
+- assert hovered == snapped
+
+### test_visual_rect_ignores_the_hit_radius
+_Selection/hover highlights are drawn from visual_rect(), so it must track_
+
+- assert visual.width() < label.width() + 20.0
+- assert visual.height() < label.height() + 20.0
+
+### test_hit_shape_stays_inside_bounding_rect
+_Qt prunes hits by boundingRect, so shape() must never escape it._
+
+- assert bounding.contains(shape_rect)
+
+### test_hit_zone_does_not_grow_to_the_drawn_label_when_zoomed_in
+_Zooming in must sharpen targeting, not widen it._
+
+- assert glyph_w > atom.hit_radius()
+- assert not atom.contains(atom.mapFromScene(on_glyph_edge))
+- assert scene.find_atom_near(on_glyph_edge, tol=DEFAULT_SNAP_PX) is None
 
 ### test_bond_hover_uses_default_radius
 _At default settings, bond shape must use bond_snapping_distance_2d._
@@ -4601,6 +4619,11 @@ _At default settings, bond shape must use bond_snapping_distance_2d._
 _When the setting is changed, bond hover must change._
 
 - assert hover_radius == pytest.approx(custom_dist, abs=0.5)
+
+### test_bond_hit_shape_stays_inside_bounding_rect
+_Zoomed far out the hit band grows in scene units; boundingRect must follow._
+
+- assert bounding.contains(shape_rect)
 
 ### test_bond_hover_stays_consistent_at_different_zoom_levels
 _Bond radius must stay identical in screen-pixel terms at any zoom._
@@ -7773,11 +7796,29 @@ _Verify overwriting an existing JSON project file._
 - io.statusBar().showMessage.assert_any_call(f'Project saved to {project_file}')
 - assert data['format'] == 'PME Project'
 
-### test_save_project_overwrite_raw
-_Verify overwriting an existing raw (pickle) project file._
+### test_save_project_never_overwrites_raw
+_Ctrl+S on a .pmeraw must redirect to Save As (.pmeprj), not rewrite the pickle._
 
-- assert os.path.exists(raw_file)
-- assert data['atoms'] == 'mock'
+- assert not os.path.exists(raw_file)
+- assert mock_save_as.called
+
+### test_confirm_pickle_load_open
+_Choosing 'Open' in the raw-file warning proceeds with the load._
+
+- assert io._confirm_pickle_load('danger.pmeraw') is True
+
+### test_confirm_pickle_load_cancel_aborts
+_Cancelling the raw-file warning must leave the document untouched._
+
+- mock_confirm.assert_called_once_with(str(raw_file))
+- io.host.edit_actions_manager.clear_all.assert_not_called()
+- io.host.state_manager.set_state_from_data.assert_not_called()
+
+### test_load_raw_data_asks_before_unpickling
+_Every .pmeraw load path must go through the confirmation._
+
+- mock_confirm.assert_called_once_with(raw_file)
+- io.host.state_manager.set_state_from_data.assert_called_once()
 
 ### test_save_project_redirect_to_save_as
 _Verify that 'save' redirects to 'save as' if the current file is not a project file._
@@ -11079,6 +11120,21 @@ _viewportEvent with ZoomNativeGesture scales the view and returns True._
 
 - assert result is True
 - assert view.transform().m11() > before
+
+### test_scale_notifies_items_of_geometry_change
+_AtomItem/BondItem hit areas are pixel-sized, so zooming changes their_
+
+- assert probe.notified >= 1
+
+### test_reset_transform_notifies_items_of_geometry_change
+_Reset-zoom must re-index items for the same reason as scale()._
+
+- assert probe.notified >= 1
+
+### test_wheel_zoom_notifies_items_of_geometry_change
+_Ctrl+wheel goes through scale(), so items must be re-indexed._
+
+- assert probe.notified >= 1
 
 ## tests/integration/test_calculation_worker.py
 

--- a/tests/assertion_catalog.md
+++ b/tests/assertion_catalog.md
@@ -11141,6 +11141,12 @@ _Ctrl+wheel goes through scale(), so items must be re-indexed._
 
 - assert probe.notified >= 1
 
+### test_zoom_burst_re_indexes_once_not_per_step
+_Re-indexing per wheel tick dirties every item and made a zoom step ~40x_
+
+- assert probe.notified == 0
+- assert probe.notified == 1
+
 ## tests/integration/test_calculation_worker.py
 
 ### test_calculation_worker_bond_length_validation

--- a/tests/coverage_report.md
+++ b/tests/coverage_report.md
@@ -1,6 +1,6 @@
 # MoleditPy Coverage Report
 
-- **Overall Project Coverage**: **89.73%**
+- **Overall Project Coverage**: **89.72%**
 
 ### Coverage Breakdown
 
@@ -23,7 +23,7 @@
 | moleditpy\src\moleditpy\ui\atom_item.py                 |    327 |     35 |   89.3% |
 | moleditpy\src\moleditpy\ui\atom_picking.py              |    167 |     13 |   92.2% |
 | moleditpy\src\moleditpy\ui\base_picking_dialog.py       |     81 |      4 |   95.1% |
-| moleditpy\src\moleditpy\ui\bond_item.py                 |    370 |     54 |   85.4% |
+| moleditpy\src\moleditpy\ui\bond_item.py                 |    370 |     55 |   85.1% |
 | moleditpy\src\moleditpy\ui\bond_length_dialog.py        |    260 |     18 |   93.1% |
 | moleditpy\src\moleditpy\ui\calculation_worker.py        |    583 |     90 |   84.6% |
 | moleditpy\src\moleditpy\ui\chain_mixin.py               |     97 |      2 |   97.9% |
@@ -43,7 +43,7 @@
 | moleditpy\src\moleditpy\ui\main_window.py               |    195 |     13 |   93.3% |
 | moleditpy\src\moleditpy\ui\main_window_init.py          |   1103 |     86 |   92.2% |
 | moleditpy\src\moleditpy\ui\mirror_dialog.py             |     72 |      7 |   90.3% |
-| moleditpy\src\moleditpy\ui\molecular_scene_handler.py   |   1005 |    142 |   85.9% |
+| moleditpy\src\moleditpy\ui\molecular_scene_handler.py   |   1005 |    143 |   85.8% |
 | moleditpy\src\moleditpy\ui\molecule_scene.py            |    637 |     82 |   87.1% |
 | moleditpy\src\moleditpy\ui\move_group_dialog.py         |    386 |     41 |   89.4% |
 | moleditpy\src\moleditpy\ui\move_selected_atoms_dialog.py |    464 |     44 |   90.5% |
@@ -69,7 +69,7 @@
 | moleditpy\src\moleditpy\utils\sip_isdeleted_safe.py     |     19 |      0 |  100.0% |
 | moleditpy\src\moleditpy\utils\suppress_log.py           |     10 |      0 |  100.0% |
 | moleditpy\src\moleditpy\utils\system_utils.py           |     40 |      0 |  100.0% |
-| **TOTAL** | **16927** | **1738** | **89.73%** |
+| **TOTAL** | **16927** | **1740** | **89.72%** |
 
 ## Test Suite Status
 - **Total tests passed**: 2217 (1 skipped)

--- a/tests/coverage_report.md
+++ b/tests/coverage_report.md
@@ -1,6 +1,6 @@
 # MoleditPy Coverage Report
 
-- **Overall Project Coverage**: **89.73%**
+- **Overall Project Coverage**: **89.72%**
 
 ### Coverage Breakdown
 
@@ -65,11 +65,11 @@
 | moleditpy\src\moleditpy\ui\settings_tabs\settings_tab_base.py |     57 |      0 |  100.0% |
 | moleditpy\src\moleditpy\utils\constants.py              |     60 |      0 |  100.0% |
 | moleditpy\src\moleditpy\utils\default_settings.py       |      1 |      0 |  100.0% |
-| moleditpy\src\moleditpy\utils\hit_radius.py             |     12 |      1 |   91.7% |
+| moleditpy\src\moleditpy\utils\hit_radius.py             |     10 |      1 |   90.0% |
 | moleditpy\src\moleditpy\utils\sip_isdeleted_safe.py     |     19 |      0 |  100.0% |
 | moleditpy\src\moleditpy\utils\suppress_log.py           |     10 |      0 |  100.0% |
 | moleditpy\src\moleditpy\utils\system_utils.py           |     40 |      0 |  100.0% |
-| **TOTAL** | **16925** | **1739** | **89.73%** |
+| **TOTAL** | **16923** | **1739** | **89.72%** |
 
 ## Test Suite Status
 - **Total tests passed**: 2218 (1 skipped)

--- a/tests/coverage_report.md
+++ b/tests/coverage_report.md
@@ -1,6 +1,6 @@
 # MoleditPy Coverage Report
 
-- **Overall Project Coverage**: **89.72%**
+- **Overall Project Coverage**: **89.73%**
 
 ### Coverage Breakdown
 
@@ -58,7 +58,7 @@
 | moleditpy\src\moleditpy\ui\ui_manager.py                |    403 |     36 |   91.1% |
 | moleditpy\src\moleditpy\ui\user_template_dialog.py      |    360 |     45 |   87.5% |
 | moleditpy\src\moleditpy\ui\view_3d_logic.py             |   1007 |    179 |   82.2% |
-| moleditpy\src\moleditpy\ui\zoomable_view.py             |     97 |      5 |   94.8% |
+| moleditpy\src\moleditpy\ui\zoomable_view.py             |    101 |      5 |   95.0% |
 | moleditpy\src\moleditpy\ui\settings_tabs\settings_2d_tab.py |    144 |      0 |  100.0% |
 | moleditpy\src\moleditpy\ui\settings_tabs\settings_3d_tabs.py |    156 |      0 |  100.0% |
 | moleditpy\src\moleditpy\ui\settings_tabs\settings_other_tab.py |     89 |      0 |  100.0% |
@@ -69,11 +69,11 @@
 | moleditpy\src\moleditpy\utils\sip_isdeleted_safe.py     |     19 |      0 |  100.0% |
 | moleditpy\src\moleditpy\utils\suppress_log.py           |     10 |      0 |  100.0% |
 | moleditpy\src\moleditpy\utils\system_utils.py           |     40 |      0 |  100.0% |
-| **TOTAL** | **16923** | **1739** | **89.72%** |
+| **TOTAL** | **16927** | **1739** | **89.73%** |
 
 ## Test Suite Status
-- **Total tests passed**: 2218 (1 skipped)
-- **Unit tests**: PASSED (2023 passed)
+- **Total tests passed**: 2219 (1 skipped)
+- **Unit tests**: PASSED (2024 passed)
 - **Integration tests**: PASSED (75 passed)
 - **E2E tests**: PASSED (34 passed, 1 skipped)
 - **GUI tests**: PASSED (86 passed)

--- a/tests/coverage_report.md
+++ b/tests/coverage_report.md
@@ -1,6 +1,6 @@
 # MoleditPy Coverage Report
 
-- **Overall Project Coverage**: **89.72%**
+- **Overall Project Coverage**: **89.73%**
 
 ### Coverage Breakdown
 
@@ -39,7 +39,7 @@
 | moleditpy\src\moleditpy\ui\edit_actions_logic.py        |    817 |    127 |   84.5% |
 | moleditpy\src\moleditpy\ui\export_logic.py              |    520 |     85 |   83.7% |
 | moleditpy\src\moleditpy\ui\geometry_base_dialog.py      |     52 |      1 |   98.1% |
-| moleditpy\src\moleditpy\ui\io_logic.py                  |    753 |     77 |   89.8% |
+| moleditpy\src\moleditpy\ui\io_logic.py                  |    751 |     76 |   89.9% |
 | moleditpy\src\moleditpy\ui\main_window.py               |    195 |     13 |   93.3% |
 | moleditpy\src\moleditpy\ui\main_window_init.py          |   1103 |     86 |   92.2% |
 | moleditpy\src\moleditpy\ui\mirror_dialog.py             |     72 |      7 |   90.3% |
@@ -69,11 +69,11 @@
 | moleditpy\src\moleditpy\utils\sip_isdeleted_safe.py     |     19 |      0 |  100.0% |
 | moleditpy\src\moleditpy\utils\suppress_log.py           |     10 |      0 |  100.0% |
 | moleditpy\src\moleditpy\utils\system_utils.py           |     40 |      0 |  100.0% |
-| **TOTAL** | **16927** | **1740** | **89.72%** |
+| **TOTAL** | **16925** | **1739** | **89.73%** |
 
 ## Test Suite Status
-- **Total tests passed**: 2217 (1 skipped)
-- **Unit tests**: PASSED (2022 passed)
+- **Total tests passed**: 2218 (1 skipped)
+- **Unit tests**: PASSED (2023 passed)
 - **Integration tests**: PASSED (75 passed)
 - **E2E tests**: PASSED (34 passed, 1 skipped)
 - **GUI tests**: PASSED (86 passed)

--- a/tests/coverage_report.md
+++ b/tests/coverage_report.md
@@ -1,6 +1,6 @@
 # MoleditPy Coverage Report
 
-- **Overall Project Coverage**: **89.76%**
+- **Overall Project Coverage**: **89.73%**
 
 ### Coverage Breakdown
 
@@ -18,32 +18,32 @@
 | moleditpy\src\moleditpy\ui\align_plane_dialog.py        |    151 |     15 |   90.1% |
 | moleditpy\src\moleditpy\ui\alignment_dialog.py          |    147 |     10 |   93.2% |
 | moleditpy\src\moleditpy\ui\analysis_window.py           |    117 |     25 |   78.6% |
-| moleditpy\src\moleditpy\ui\angle_dialog.py              |    272 |     28 |   89.7% |
+| moleditpy\src\moleditpy\ui\angle_dialog.py              |    275 |     29 |   89.5% |
 | moleditpy\src\moleditpy\ui\app_state.py                 |    345 |     57 |   83.5% |
-| moleditpy\src\moleditpy\ui\atom_item.py                 |    334 |     37 |   88.9% |
+| moleditpy\src\moleditpy\ui\atom_item.py                 |    327 |     35 |   89.3% |
 | moleditpy\src\moleditpy\ui\atom_picking.py              |    167 |     13 |   92.2% |
 | moleditpy\src\moleditpy\ui\base_picking_dialog.py       |     81 |      4 |   95.1% |
-| moleditpy\src\moleditpy\ui\bond_item.py                 |    377 |     57 |   84.9% |
-| moleditpy\src\moleditpy\ui\bond_length_dialog.py        |    257 |     17 |   93.4% |
+| moleditpy\src\moleditpy\ui\bond_item.py                 |    370 |     54 |   85.4% |
+| moleditpy\src\moleditpy\ui\bond_length_dialog.py        |    260 |     18 |   93.1% |
 | moleditpy\src\moleditpy\ui\calculation_worker.py        |    583 |     90 |   84.6% |
 | moleditpy\src\moleditpy\ui\chain_mixin.py               |     97 |      2 |   97.9% |
 | moleditpy\src\moleditpy\ui\color_settings_dialog.py     |    166 |     13 |   92.2% |
 | moleditpy\src\moleditpy\ui\compute_logic.py             |    451 |      7 |   98.4% |
 | moleditpy\src\moleditpy\ui\constrained_optimization_dialog.py |    480 |     24 |   95.0% |
-| moleditpy\src\moleditpy\ui\custom_interactor_style.py   |    772 |    113 |   85.4% |
+| moleditpy\src\moleditpy\ui\custom_interactor_style.py   |    775 |    113 |   85.4% |
 | moleditpy\src\moleditpy\ui\custom_qt_interactor.py      |     24 |      0 |  100.0% |
 | moleditpy\src\moleditpy\ui\dialog_3d_picking_mixin.py   |    137 |     19 |   86.1% |
 | moleditpy\src\moleditpy\ui\dialog_logic.py              |    230 |     25 |   89.1% |
-| moleditpy\src\moleditpy\ui\dihedral_dialog.py           |    277 |     32 |   88.4% |
+| moleditpy\src\moleditpy\ui\dihedral_dialog.py           |    280 |     33 |   88.2% |
 | moleditpy\src\moleditpy\ui\edit_3d_logic.py             |    221 |     32 |   85.5% |
 | moleditpy\src\moleditpy\ui\edit_actions_logic.py        |    817 |    127 |   84.5% |
 | moleditpy\src\moleditpy\ui\export_logic.py              |    520 |     85 |   83.7% |
 | moleditpy\src\moleditpy\ui\geometry_base_dialog.py      |     52 |      1 |   98.1% |
-| moleditpy\src\moleditpy\ui\io_logic.py                  |    737 |     76 |   89.7% |
+| moleditpy\src\moleditpy\ui\io_logic.py                  |    753 |     77 |   89.8% |
 | moleditpy\src\moleditpy\ui\main_window.py               |    195 |     13 |   93.3% |
 | moleditpy\src\moleditpy\ui\main_window_init.py          |   1103 |     86 |   92.2% |
 | moleditpy\src\moleditpy\ui\mirror_dialog.py             |     72 |      7 |   90.3% |
-| moleditpy\src\moleditpy\ui\molecular_scene_handler.py   |   1006 |    141 |   86.0% |
+| moleditpy\src\moleditpy\ui\molecular_scene_handler.py   |   1005 |    142 |   85.9% |
 | moleditpy\src\moleditpy\ui\molecule_scene.py            |    637 |     82 |   87.1% |
 | moleditpy\src\moleditpy\ui\move_group_dialog.py         |    386 |     41 |   89.4% |
 | moleditpy\src\moleditpy\ui\move_selected_atoms_dialog.py |    464 |     44 |   90.5% |
@@ -52,27 +52,28 @@
 | moleditpy\src\moleditpy\ui\plugin_menu_manager.py       |    287 |     30 |   89.5% |
 | moleditpy\src\moleditpy\ui\settings_dialog.py           |    101 |      3 |   97.0% |
 | moleditpy\src\moleditpy\ui\string_importers.py          |    121 |      0 |  100.0% |
-| moleditpy\src\moleditpy\ui\template_preview_item.py     |    149 |      2 |   98.7% |
+| moleditpy\src\moleditpy\ui\template_preview_item.py     |    149 |      4 |   97.3% |
 | moleditpy\src\moleditpy\ui\template_preview_view.py     |     46 |      4 |   91.3% |
 | moleditpy\src\moleditpy\ui\translation_dialog.py        |    276 |     21 |   92.4% |
-| moleditpy\src\moleditpy\ui\ui_manager.py                |    403 |     33 |   91.8% |
+| moleditpy\src\moleditpy\ui\ui_manager.py                |    403 |     36 |   91.1% |
 | moleditpy\src\moleditpy\ui\user_template_dialog.py      |    360 |     45 |   87.5% |
 | moleditpy\src\moleditpy\ui\view_3d_logic.py             |   1007 |    179 |   82.2% |
-| moleditpy\src\moleditpy\ui\zoomable_view.py             |     82 |      2 |   97.6% |
+| moleditpy\src\moleditpy\ui\zoomable_view.py             |     97 |      5 |   94.8% |
 | moleditpy\src\moleditpy\ui\settings_tabs\settings_2d_tab.py |    144 |      0 |  100.0% |
 | moleditpy\src\moleditpy\ui\settings_tabs\settings_3d_tabs.py |    156 |      0 |  100.0% |
 | moleditpy\src\moleditpy\ui\settings_tabs\settings_other_tab.py |     89 |      0 |  100.0% |
 | moleditpy\src\moleditpy\ui\settings_tabs\settings_tab_base.py |     57 |      0 |  100.0% |
 | moleditpy\src\moleditpy\utils\constants.py              |     60 |      0 |  100.0% |
 | moleditpy\src\moleditpy\utils\default_settings.py       |      1 |      0 |  100.0% |
+| moleditpy\src\moleditpy\utils\hit_radius.py             |     12 |      1 |   91.7% |
 | moleditpy\src\moleditpy\utils\sip_isdeleted_safe.py     |     19 |      0 |  100.0% |
 | moleditpy\src\moleditpy\utils\suppress_log.py           |     10 |      0 |  100.0% |
 | moleditpy\src\moleditpy\utils\system_utils.py           |     40 |      0 |  100.0% |
-| **TOTAL** | **16887** | **1729** | **89.76%** |
+| **TOTAL** | **16927** | **1738** | **89.73%** |
 
 ## Test Suite Status
-- **Total tests passed**: 2195 (1 skipped)
-- **Unit tests**: PASSED (2000 passed)
+- **Total tests passed**: 2217 (1 skipped)
+- **Unit tests**: PASSED (2022 passed)
 - **Integration tests**: PASSED (75 passed)
 - **E2E tests**: PASSED (34 passed, 1 skipped)
 - **GUI tests**: PASSED (86 passed)

--- a/tests/e2e/test_corrupt_files.py
+++ b/tests/e2e/test_corrupt_files.py
@@ -81,6 +81,11 @@ def test_corrupted_files_never_crash_loaders(window, qtbot, tmp_path, monkeypatc
     monkeypatch.setattr(
         window.state_manager, "check_unsaved_changes", lambda: True, raising=False
     )
+    # .pmeraw opens behind a modal warning; answer it so the loader is what is
+    # under test here, and so this never depends on MOLEDITPY_HEADLESS.
+    monkeypatch.setattr(
+        window.io_manager, "_confirm_pickle_load", lambda _p: True, raising=False
+    )
     window.init_manager.settings["skip_chemistry_checks"] = True
 
     crashes = []

--- a/tests/e2e/test_project_roundtrip.py
+++ b/tests/e2e/test_project_roundtrip.py
@@ -120,6 +120,10 @@ def test_pmeraw_roundtrip(window, qtbot, tmp_path, monkeypatch):
     assert window.data.atoms == {}
 
     _patch_unsaved_prompt(monkeypatch, QMessageBox.StandardButton.No)
+    # Answer the .pmeraw pickle warning; the roundtrip is what is under test.
+    monkeypatch.setattr(
+        window.io_manager, "_confirm_pickle_load", lambda _p: True, raising=False
+    )
     window.io_manager.load_raw_data(str(saved))
     qtbot.wait(200)
 

--- a/tests/unit/test_atom_bond_items.py
+++ b/tests/unit/test_atom_bond_items.py
@@ -481,12 +481,20 @@ class TestBondItem:
         assert rect_stereo.height() >= rect_no_stereo.height()
 
 
+class _SettingsScene(QGraphicsScene):
+    """Stands in for MoleculeScene, which is the only scene that holds atom and
+    bond items in the app: they read their geometry settings via get_setting()."""
+
+    def get_setting(self, key, default=None):
+        return default
+
+
 class TestAtomDragPropagation:
     """Bonds must track atom positions live, without ever being dragged themselves."""
 
     def _bonded_pair(self):
         # Bonds only refresh once they are in a scene.
-        scene = QGraphicsScene()
+        scene = _SettingsScene()
         atom1 = AtomItem(1, "C", QPointF(0.0, 0.0))
         atom2 = AtomItem(2, "C", QPointF(50.0, 0.0))
         scene.addItem(atom1)

--- a/tests/unit/test_atom_bond_items.py
+++ b/tests/unit/test_atom_bond_items.py
@@ -3,7 +3,7 @@
 import pytest
 from unittest.mock import MagicMock, patch
 from PyQt6.QtCore import QPointF, QRectF, QLineF
-from PyQt6.QtGui import QPainterPath
+from PyQt6.QtGui import QPainterPath, QTransform
 from PyQt6.QtWidgets import QGraphicsItem, QGraphicsScene
 from moleditpy.ui.atom_item import AtomItem
 from moleditpy.ui.bond_item import BondItem
@@ -243,11 +243,25 @@ class TestAtomItem:
             )
 
 
+def _make_mock_scene():
+    """A fake scene that answers get_setting()/views() like the real one.
+
+    Items read zoom (view transform) and settings while computing their
+    geometry, so both must return real numbers, not MagicMocks.
+    """
+    scene = MagicMock()
+    scene.get_setting.side_effect = lambda key, default=None: default
+    view = MagicMock()
+    view.transform.return_value = QTransform()
+    scene.views.return_value = [view]
+    return scene
+
+
 # Helper for mocking scene() on BondItem
 class MockableBondItem(BondItem):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self._mock_scene = MagicMock()
+        self._mock_scene = _make_mock_scene()
 
     def scene(self):
         return self._mock_scene
@@ -328,8 +342,10 @@ class TestBondItem:
         mock_window = MagicMock()
         mock_window.settings = {}  # Empty dict for defaults
         mock_scene.window = mock_window
-        mock_scene.views.return_value = [MagicMock()]
-        mock_scene.views.return_value[0].window.return_value = mock_window
+        mock_view = MagicMock()
+        mock_view.transform.return_value = QTransform()  # identity (m11 = 1.0)
+        mock_scene.views.return_value = [mock_view]
+        mock_view.window.return_value = mock_window
 
         bond_item.paint(mock_painter, option, widget)
 
@@ -446,8 +462,10 @@ class TestBondItem:
         mock_scene = bond_item.scene()
         mock_window = MagicMock()
         mock_window.settings = {"atom_font_size_2d": 20}
-        mock_scene.views.return_value = [MagicMock()]
-        mock_scene.views.return_value[0].window.return_value = mock_window
+        mock_view = MagicMock()
+        mock_view.transform.return_value = QTransform()  # identity (m11 = 1.0)
+        mock_scene.views.return_value = [mock_view]
+        mock_view.window.return_value = mock_window
         mock_scene.window = mock_window
 
         bond_item.boundingRect()

--- a/tests/unit/test_edit_3d_logic.py
+++ b/tests/unit/test_edit_3d_logic.py
@@ -140,7 +140,9 @@ def test_add_2d_measurement_label_adds_item(mock_parser_host):
 
     atom_item = MagicMock()
     atom_item.pos.return_value = QPointF(10.0, 20.0)
-    atom_item.boundingRect.return_value = QRectF(0, 0, 16.0, 16.0)
+    # visual_rect(), not boundingRect(): the latter also covers the zoom-dependent
+    # hit shape, which would drift the label away from the atom as you zoom out.
+    atom_item.visual_rect.return_value = QRectF(0, 0, 16.0, 16.0)
 
     edit3d.add_2d_measurement_label(atom_item, "1.234 Å")
 

--- a/tests/unit/test_font_cache_warmup.py
+++ b/tests/unit/test_font_cache_warmup.py
@@ -63,11 +63,17 @@ class TestInitManagerHook:
         assert font.pointSize() == 14
         assert font.weight() == QFont.Weight.Normal
 
-    def test_falls_back_when_the_scene_has_no_settings(self, app):
+    def test_falls_back_before_the_scene_exists(self, app):
+        """Warm-up can run before the scene is built, so a missing scene must
+        fall back to the default font rather than raise.
+
+        This previously asserted a scene that exists but lacks get_setting();
+        that path was a hasattr() guard for test fakes only — the app's only
+        scene is MoleculeScene, which always has it."""
         from moleditpy.ui.main_window_init import MainInitManager
 
         manager = MagicMock(spec=MainInitManager)
-        manager.scene = object()
+        manager.scene = None
 
         with patch("moleditpy.ui.main_window_init.warm_font_cache") as warm:
             MainInitManager._warm_font_cache(manager)

--- a/tests/unit/test_hover_snap_consistency.py
+++ b/tests/unit/test_hover_snap_consistency.py
@@ -60,29 +60,26 @@ def scene_with_atom(app):
 # ---------------------------------------------------------------------------
 
 
-def _glyph_extent(atom):
-    """Half-width / half-height of the atom's drawn label, in scene units."""
-    rect = atom.get_bg_ellipse_path().boundingRect()
-    return rect.width() / 2, rect.height() / 2
-
-
 def test_hover_and_snap_use_same_default_radius(scene_with_atom):
-    """At default settings the hit radius must be the setting (glyph aside)."""
+    """At default settings both radii must equal bond_snapping_distance_2d."""
     scene, atom, _, _ = scene_with_atom
 
+    # Hover: shape() radius (in scene units; at scale=1 ≡ screen px)
+    hover_radius = atom.shape().boundingRect().width() / 2
     assert atom.hit_radius() == pytest.approx(DEFAULT_SNAP_PX)
 
-    # Snap: find_atom_near at the boundary distance, probed along the axis
-    # where the glyph does not extend past the snap circle.
-    _, glyph_h = _glyph_extent(atom)
-    assert glyph_h > DEFAULT_SNAP_PX  # the label is taller than the snap circle
+    # Snap: find_atom_near at the boundary distance
     assert (
         scene.find_atom_near(QPointF(DEFAULT_SNAP_PX - 0.1, 0), tol=DEFAULT_SNAP_PX)
         is atom
     ), "atom should be found inside snapping distance"
-    far = QPointF(0, glyph_h + DEFAULT_SNAP_PX + 10.0)
-    assert scene.find_atom_near(far, tol=DEFAULT_SNAP_PX) is None, (
-        "atom should NOT be found far outside snapping distance and glyph"
+    assert (
+        scene.find_atom_near(QPointF(DEFAULT_SNAP_PX + 0.1, 0), tol=DEFAULT_SNAP_PX)
+        is None
+    ), "atom should NOT be found outside snapping distance"
+
+    assert hover_radius == pytest.approx(DEFAULT_SNAP_PX, abs=0.5), (
+        f"hover radius ({hover_radius}) must match snap distance ({DEFAULT_SNAP_PX})"
     )
 
 
@@ -92,12 +89,11 @@ def test_hover_and_snap_follow_custom_setting(scene_with_atom):
     custom_dist = 25.0
     settings["bond_snapping_distance_2d"] = custom_dist
 
-    assert atom.hit_radius() == pytest.approx(custom_dist)
+    hover_radius = atom.shape().boundingRect().width() / 2
 
-    _, glyph_h = _glyph_extent(atom)
     assert scene.find_atom_near(QPointF(custom_dist - 0.1, 0), tol=custom_dist) is atom
-    far = QPointF(0, max(custom_dist, glyph_h) + 10.0)
-    assert scene.find_atom_near(far, tol=custom_dist) is None
+    assert scene.find_atom_near(QPointF(custom_dist + 0.1, 0), tol=custom_dist) is None
+    assert hover_radius == pytest.approx(custom_dist, abs=0.5)
 
 
 @pytest.mark.parametrize("scale", [0.5, 1.0, 2.0, 4.0])
@@ -112,11 +108,11 @@ def test_hover_and_snap_stay_consistent_at_different_zoom_levels(
     scene, atom, mock_view, _ = scene_with_atom
     mock_view.transform.return_value = QTransform.fromScale(scale, scale)
 
-    # The pixel-sized radius stays constant on screen.
+    # The pixel-sized radius stays constant on screen, so zooming in narrows
+    # the molecular distance it covers — that is how precise editing works.
     assert atom.hit_radius() * scale == pytest.approx(DEFAULT_SNAP_PX)
 
-    glyph_w, glyph_h = _glyph_extent(atom)
-    reach = max(glyph_w, glyph_h, DEFAULT_SNAP_PX / scale) + 12.0
+    reach = DEFAULT_SNAP_PX / scale + 12.0
     probes = []
     for i in range(1, 13):
         d = reach * i / 12.0
@@ -128,6 +124,24 @@ def test_hover_and_snap_stay_consistent_at_different_zoom_levels(
         assert hovered == snapped, (
             f"scale={scale}: hover ({hovered}) and snap ({snapped}) disagree at {p}"
         )
+
+
+@pytest.mark.parametrize("scale", [0.05, 0.25, 1.0, 4.0])
+def test_visual_rect_ignores_the_hit_radius(scene_with_atom, scale):
+    """Selection/hover highlights are drawn from visual_rect(), so it must track
+    the label only. boundingRect() additionally covers the hit shape — drawing
+    from that would balloon the highlight box as the user zooms out."""
+    scene, atom, mock_view, settings = scene_with_atom
+    settings["bond_snapping_distance_2d"] = 50.0  # slider maximum
+    mock_view.transform.return_value = QTransform.fromScale(scale, scale)
+
+    label = atom.get_bg_ellipse_path().boundingRect()
+    visual = atom.visual_rect()
+
+    assert visual.width() < label.width() + 20.0, (
+        f"scale={scale}: visual_rect {visual} is not tracking the drawn label"
+    )
+    assert visual.height() < label.height() + 20.0
 
 
 @pytest.mark.parametrize("scale", [0.5, 1.0, 2.0, 4.0, 8.0])
@@ -144,19 +158,25 @@ def test_hit_shape_stays_inside_bounding_rect(scene_with_atom, scale):
 
 
 @pytest.mark.parametrize("scale", [4.0, 8.0, 16.0])
-def test_drawn_label_is_always_clickable_when_zoomed_in(scene_with_atom, scale):
-    """Zoomed in, the pixel radius shrinks below the glyph — it must still hit."""
+def test_hit_zone_does_not_grow_to_the_drawn_label_when_zoomed_in(
+    scene_with_atom, scale
+):
+    """Zooming in must sharpen targeting, not widen it.
+
+    The hit zone stays a fixed number of screen pixels, so it covers an ever
+    smaller molecular distance as the user zooms — the reason zooming is how
+    you pick one atom out of a crowded structure. Growing it to the drawn
+    glyph would make targeting worse the further in you zoom.
+    """
     scene, atom, mock_view, _ = scene_with_atom
     mock_view.transform.return_value = QTransform.fromScale(scale, scale)
 
-    glyph_w, _ = _glyph_extent(atom)
-    assert glyph_w > atom.hit_radius()  # the regression precondition
+    glyph_w = atom.get_bg_ellipse_path().boundingRect().width() / 2
+    assert glyph_w > atom.hit_radius()  # zoomed in, the label dwarfs the hit zone
 
-    on_glyph = QPointF(glyph_w * 0.7, 0)
-    assert atom.contains(atom.mapFromScene(on_glyph)), "glyph must be hoverable"
-    assert scene.find_atom_near(on_glyph, tol=DEFAULT_SNAP_PX) is atom, (
-        "glyph must be snappable"
-    )
+    on_glyph_edge = QPointF(glyph_w * 0.9, 0)
+    assert not atom.contains(atom.mapFromScene(on_glyph_edge))
+    assert scene.find_atom_near(on_glyph_edge, tol=DEFAULT_SNAP_PX) is None
 
 
 @pytest.fixture

--- a/tests/unit/test_hover_snap_consistency.py
+++ b/tests/unit/test_hover_snap_consistency.py
@@ -60,25 +60,29 @@ def scene_with_atom(app):
 # ---------------------------------------------------------------------------
 
 
+def _glyph_extent(atom):
+    """Half-width / half-height of the atom's drawn label, in scene units."""
+    rect = atom.get_bg_ellipse_path().boundingRect()
+    return rect.width() / 2, rect.height() / 2
+
+
 def test_hover_and_snap_use_same_default_radius(scene_with_atom):
-    """At default settings both radii must equal bond_snapping_distance_2d."""
+    """At default settings the hit radius must be the setting (glyph aside)."""
     scene, atom, _, _ = scene_with_atom
 
-    # Hover: shape() radius (in scene units; at scale=1 ≡ screen px)
-    hover_radius = atom.shape().boundingRect().width() / 2
+    assert atom.hit_radius() == pytest.approx(DEFAULT_SNAP_PX)
 
-    # Snap: find_atom_near at the boundary distance
+    # Snap: find_atom_near at the boundary distance, probed along the axis
+    # where the glyph does not extend past the snap circle.
+    _, glyph_h = _glyph_extent(atom)
+    assert glyph_h > DEFAULT_SNAP_PX  # the label is taller than the snap circle
     assert (
         scene.find_atom_near(QPointF(DEFAULT_SNAP_PX - 0.1, 0), tol=DEFAULT_SNAP_PX)
         is atom
     ), "atom should be found inside snapping distance"
-    assert (
-        scene.find_atom_near(QPointF(DEFAULT_SNAP_PX + 0.1, 0), tol=DEFAULT_SNAP_PX)
-        is None
-    ), "atom should NOT be found outside snapping distance"
-
-    assert hover_radius == pytest.approx(DEFAULT_SNAP_PX, abs=0.5), (
-        f"hover radius ({hover_radius}) must match snap distance ({DEFAULT_SNAP_PX})"
+    far = QPointF(0, glyph_h + DEFAULT_SNAP_PX + 10.0)
+    assert scene.find_atom_near(far, tol=DEFAULT_SNAP_PX) is None, (
+        "atom should NOT be found far outside snapping distance and glyph"
     )
 
 
@@ -88,40 +92,70 @@ def test_hover_and_snap_follow_custom_setting(scene_with_atom):
     custom_dist = 25.0
     settings["bond_snapping_distance_2d"] = custom_dist
 
-    hover_radius = atom.shape().boundingRect().width() / 2
+    assert atom.hit_radius() == pytest.approx(custom_dist)
 
+    _, glyph_h = _glyph_extent(atom)
     assert scene.find_atom_near(QPointF(custom_dist - 0.1, 0), tol=custom_dist) is atom
-    assert scene.find_atom_near(QPointF(custom_dist + 0.1, 0), tol=custom_dist) is None
-    assert hover_radius == pytest.approx(custom_dist, abs=0.5)
+    far = QPointF(0, max(custom_dist, glyph_h) + 10.0)
+    assert scene.find_atom_near(far, tol=custom_dist) is None
 
 
 @pytest.mark.parametrize("scale", [0.5, 1.0, 2.0, 4.0])
 def test_hover_and_snap_stay_consistent_at_different_zoom_levels(
     scene_with_atom, scale
 ):
-    """Both radii must stay identical in screen-pixel terms at any zoom."""
+    """Hover shape and snapping must agree at every point, at any zoom.
+
+    This is the invariant that matters: an atom is keyboard-editable exactly
+    when the user sees its hover highlight.
+    """
     scene, atom, mock_view, _ = scene_with_atom
     mock_view.transform.return_value = QTransform.fromScale(scale, scale)
 
-    # Hover: shape() returns scene-unit radius; multiply by scale → screen px
-    hover_scene_radius = atom.shape().boundingRect().width() / 2
-    hover_screen_px = hover_scene_radius * scale
+    # The pixel-sized radius stays constant on screen.
+    assert atom.hit_radius() * scale == pytest.approx(DEFAULT_SNAP_PX)
 
-    # Snap: find_atom_near converts tol (screen px) to scene units internally.
-    # The boundary in scene units is DEFAULT_SNAP_PX / scale.
-    boundary_scene = DEFAULT_SNAP_PX / scale
-    assert (
-        scene.find_atom_near(QPointF(boundary_scene - 0.01, 0), tol=DEFAULT_SNAP_PX)
-        is atom
-    ), f"scale={scale}: atom should be found inside snap zone"
-    assert (
-        scene.find_atom_near(QPointF(boundary_scene + 0.5, 0), tol=DEFAULT_SNAP_PX)
-        is None
-    ), f"scale={scale}: atom should NOT be found outside snap zone"
+    glyph_w, glyph_h = _glyph_extent(atom)
+    reach = max(glyph_w, glyph_h, DEFAULT_SNAP_PX / scale) + 12.0
+    probes = []
+    for i in range(1, 13):
+        d = reach * i / 12.0
+        probes += [QPointF(d, 0), QPointF(0, d), QPointF(d * 0.7, d * 0.7)]
 
-    assert hover_screen_px == pytest.approx(DEFAULT_SNAP_PX, abs=0.5), (
-        f"scale={scale}: hover screen radius ({hover_screen_px}) != "
-        f"snap distance ({DEFAULT_SNAP_PX})"
+    for p in probes:
+        hovered = atom.contains(atom.mapFromScene(p))
+        snapped = scene.find_atom_near(p, tol=DEFAULT_SNAP_PX) is atom
+        assert hovered == snapped, (
+            f"scale={scale}: hover ({hovered}) and snap ({snapped}) disagree at {p}"
+        )
+
+
+@pytest.mark.parametrize("scale", [0.5, 1.0, 2.0, 4.0, 8.0])
+def test_hit_shape_stays_inside_bounding_rect(scene_with_atom, scale):
+    """Qt prunes hits by boundingRect, so shape() must never escape it."""
+    scene, atom, mock_view, _ = scene_with_atom
+    mock_view.transform.return_value = QTransform.fromScale(scale, scale)
+
+    bounding = atom.boundingRect()
+    shape_rect = atom.shape().boundingRect()
+    assert bounding.contains(shape_rect), (
+        f"scale={scale}: shape {shape_rect} escapes boundingRect {bounding}"
+    )
+
+
+@pytest.mark.parametrize("scale", [4.0, 8.0, 16.0])
+def test_drawn_label_is_always_clickable_when_zoomed_in(scene_with_atom, scale):
+    """Zoomed in, the pixel radius shrinks below the glyph — it must still hit."""
+    scene, atom, mock_view, _ = scene_with_atom
+    mock_view.transform.return_value = QTransform.fromScale(scale, scale)
+
+    glyph_w, _ = _glyph_extent(atom)
+    assert glyph_w > atom.hit_radius()  # the regression precondition
+
+    on_glyph = QPointF(glyph_w * 0.7, 0)
+    assert atom.contains(atom.mapFromScene(on_glyph)), "glyph must be hoverable"
+    assert scene.find_atom_near(on_glyph, tol=DEFAULT_SNAP_PX) is atom, (
+        "glyph must be snappable"
     )
 
 
@@ -179,6 +213,20 @@ def test_bond_hover_follows_custom_setting(scene_with_bond):
 
     hover_radius = bond.shape().boundingRect().height() / 2
     assert hover_radius == pytest.approx(custom_dist, abs=0.5)
+
+
+@pytest.mark.parametrize("scale", [0.05, 0.25, 1.0, 4.0])
+def test_bond_hit_shape_stays_inside_bounding_rect(scene_with_bond, scale):
+    """Zoomed far out the hit band grows in scene units; boundingRect must follow."""
+    _scene, bond, mock_view, settings = scene_with_bond
+    settings["bond_snapping_distance_2d"] = 50.0  # slider maximum
+    mock_view.transform.return_value = QTransform.fromScale(scale, scale)
+
+    bounding = bond.boundingRect()
+    shape_rect = bond.shape().boundingRect()
+    assert bounding.contains(shape_rect), (
+        f"scale={scale}: shape {shape_rect} escapes boundingRect {bounding}"
+    )
 
 
 @pytest.mark.parametrize("scale", [0.5, 1.0, 2.0, 4.0])

--- a/tests/unit/test_project_io.py
+++ b/tests/unit/test_project_io.py
@@ -115,21 +115,67 @@ def test_save_project_overwrite_json(mock_parser_host, tmp_path):
         io.statusBar().showMessage.assert_any_call(f"Project saved to {project_file}")
 
 
-def test_save_project_overwrite_raw(mock_parser_host, tmp_path):
-    """Verify overwriting an existing raw (pickle) project file."""
+def test_save_project_never_overwrites_raw(mock_parser_host, tmp_path):
+    """Ctrl+S on a .pmeraw must redirect to Save As (.pmeprj), not rewrite the pickle.
+
+    Writing back a pickle keeps the project in a format that executes code on
+    load; the raw format is export-only from 4.6.2 on.
+    """
     io = DummyProjectIo(mock_parser_host)
     raw_file = str(tmp_path / "existing.pmeraw")
     io.host.init_manager.current_file_path = raw_file
     io.host.state_manager.data.atoms = {1: {"symbol": "C"}}
 
-    with patch.object(
-        io.host.state_manager, "get_current_state", return_value={"atoms": "mock"}
-    ):
+    with patch.object(io, "save_project_as") as mock_save_as:
         io.save_project()
-        assert os.path.exists(raw_file)
-        with open(raw_file, "rb") as f:
-            data = pickle.load(f)
-            assert data["atoms"] == "mock"
+        assert mock_save_as.called
+
+    assert not os.path.exists(raw_file), "Ctrl+S must not write the .pmeraw file"
+
+
+def test_confirm_pickle_load_open(mock_parser_host):
+    """Choosing 'Open' in the raw-file warning proceeds with the load."""
+    io = DummyProjectIo(mock_parser_host)
+    with (
+        patch.dict(os.environ, {}, clear=False),
+        patch("moleditpy.ui.io_logic.QMessageBox") as mock_box_cls,
+    ):
+        os.environ.pop("MOLEDITPY_HEADLESS", None)
+        box = mock_box_cls.return_value
+        open_button = MagicMock()
+        box.addButton.side_effect = [open_button, MagicMock()]
+        box.clickedButton.return_value = open_button
+
+        assert io._confirm_pickle_load("danger.pmeraw") is True
+
+
+def test_confirm_pickle_load_cancel_aborts(mock_parser_host, tmp_path):
+    """Cancelling the raw-file warning must leave the document untouched."""
+    io = DummyProjectIo(mock_parser_host)
+    raw_file = tmp_path / "untrusted.pmeraw"
+    with open(raw_file, "wb") as f:
+        pickle.dump({"atoms": {}}, f)
+
+    with patch.object(io, "_confirm_pickle_load", return_value=False) as mock_confirm:
+        io.load_raw_data(str(raw_file))
+
+    mock_confirm.assert_called_once_with(str(raw_file))
+    io.host.edit_actions_manager.clear_all.assert_not_called()
+    io.host.state_manager.set_state_from_data.assert_not_called()
+
+
+def test_load_raw_data_asks_before_unpickling(mock_parser_host, tmp_path):
+    """Every .pmeraw load path must go through the confirmation."""
+    io = DummyProjectIo(mock_parser_host)
+    raw_file = str(tmp_path / "trusted.pmeraw")
+    with open(raw_file, "wb") as f:
+        pickle.dump({"atoms": {}}, f)
+
+    with patch.object(io, "_confirm_pickle_load", return_value=True) as mock_confirm:
+        io.load_raw_data(raw_file)
+
+    mock_confirm.assert_called_once_with(raw_file)
+    io.host.state_manager.set_state_from_data.assert_called_once()
 
 
 def test_save_project_redirect_to_save_as(mock_parser_host):

--- a/tests/unit/test_project_io.py
+++ b/tests/unit/test_project_io.py
@@ -136,17 +136,25 @@ def test_save_project_never_overwrites_raw(mock_parser_host, tmp_path):
 def test_confirm_pickle_load_open(mock_parser_host):
     """Choosing 'Open' in the raw-file warning proceeds with the load."""
     io = DummyProjectIo(mock_parser_host)
-    with (
-        patch.dict(os.environ, {}, clear=False),
-        patch("moleditpy.ui.io_logic.QMessageBox") as mock_box_cls,
-    ):
-        os.environ.pop("MOLEDITPY_HEADLESS", None)
+    with patch("moleditpy.ui.io_logic.QMessageBox") as mock_box_cls:
         box = mock_box_cls.return_value
         open_button = MagicMock()
         box.addButton.side_effect = [open_button, MagicMock()]
         box.clickedButton.return_value = open_button
 
         assert io._confirm_pickle_load("danger.pmeraw") is True
+
+
+def test_confirm_pickle_load_cancel(mock_parser_host):
+    """Choosing Cancel in the raw-file warning refuses the load."""
+    io = DummyProjectIo(mock_parser_host)
+    with patch("moleditpy.ui.io_logic.QMessageBox") as mock_box_cls:
+        box = mock_box_cls.return_value
+        open_button, cancel_button = MagicMock(), MagicMock()
+        box.addButton.side_effect = [open_button, cancel_button]
+        box.clickedButton.return_value = cancel_button
+
+        assert io._confirm_pickle_load("danger.pmeraw") is False
 
 
 def test_confirm_pickle_load_cancel_aborts(mock_parser_host, tmp_path):

--- a/tests/unit/test_project_io.py
+++ b/tests/unit/test_project_io.py
@@ -197,7 +197,10 @@ def test_load_raw_data_success(mock_parser_host, tmp_path):
     with open(raw_file, "wb") as f:
         pickle.dump(sample_data, f)
 
-    with patch.object(io.host.state_manager, "set_state_from_data") as mock_set_state:
+    with (
+        patch.object(io, "_confirm_pickle_load", return_value=True),
+        patch.object(io.host.state_manager, "set_state_from_data") as mock_set_state,
+    ):
         io.load_raw_data(raw_file)
         assert mock_set_state.called
         assert io.host.init_manager.current_file_path == raw_file
@@ -253,15 +256,20 @@ def test_save_as_json_trigger(mock_parser_host, tmp_path):
 def test_load_raw_data_error_paths(mock_parser_host):
     """Verify error handling during raw data loading (file not found, corrupt)."""
     io = DummyProjectIo(mock_parser_host)
-    io.load_raw_data("non_existent.pmeraw")
-    io.statusBar().showMessage.assert_called_with("File not found: non_existent.pmeraw")
+    # The pickle warning is answered explicitly: these assert the load paths, and
+    # must not depend on MOLEDITPY_HEADLESS being set to skip the dialog.
+    with patch.object(io, "_confirm_pickle_load", return_value=True):
+        io.load_raw_data("non_existent.pmeraw")
+        io.statusBar().showMessage.assert_called_with(
+            "File not found: non_existent.pmeraw"
+        )
 
-    with patch("builtins.open", MagicMock()):
-        with patch("pickle.load", side_effect=pickle.UnpicklingError("Corrupt")):
-            io.load_raw_data("dummy_data")
-            io.statusBar().showMessage.assert_called_with(
-                "Invalid project file format: Corrupt"
-            )
+        with patch("builtins.open", MagicMock()):
+            with patch("pickle.load", side_effect=pickle.UnpicklingError("Corrupt")):
+                io.load_raw_data("dummy_data")
+                io.statusBar().showMessage.assert_called_with(
+                    "Invalid project file format: Corrupt"
+                )
 
 
 def test_open_project_file_unsaved_check(mock_parser_host):
@@ -545,9 +553,12 @@ def test_load_raw_data_dialog_success(io, tmp_path):
     with open(load_path, "wb") as f:
         pickle.dump(sample_data, f)
 
-    with patch(
-        "PyQt6.QtWidgets.QFileDialog.getOpenFileName",
-        return_value=(load_path, "Project Files (*.pmeraw)"),
+    with (
+        patch(
+            "PyQt6.QtWidgets.QFileDialog.getOpenFileName",
+            return_value=(load_path, "Project Files (*.pmeraw)"),
+        ),
+        patch.object(io, "_confirm_pickle_load", return_value=True),
     ):
         io.load_raw_data()
 
@@ -572,7 +583,8 @@ def test_load_raw_data_io_error(io, tmp_path):
     with open(bad_path, "w") as f:
         f.write("not a pickle")
 
-    io.load_raw_data(bad_path)
+    with patch.object(io, "_confirm_pickle_load", return_value=True):
+        io.load_raw_data(bad_path)
     io.statusBar().showMessage.assert_called()
     msg = io.statusBar().showMessage.call_args[0][0]
     assert "Invalid project file format" in msg

--- a/tests/unit/test_scene_extended_logic.py
+++ b/tests/unit/test_scene_extended_logic.py
@@ -22,6 +22,9 @@ def scene_setup(app):
     mock_window.settings = MockSettings(
         {"atom_label_font_size": 10, "bond_width": 2.0, "atom_color_C": "#000000"}
     )
+    # scene.get_setting() reads init_manager.settings; it must be a real dict so
+    # items get numeric geometry values instead of MagicMocks.
+    mock_window.init_manager.settings = {}
 
     # Use real dicts for data
     data = MagicMock()
@@ -30,7 +33,7 @@ def scene_setup(app):
 
     scene = MoleculeScene(data, mock_window)
     mock_view = MagicMock()
-    mock_view.transform.return_value = None
+    mock_view.transform.return_value = QTransform()  # identity (m11 = 1.0)
     scene.views = MagicMock(return_value=[mock_view])
 
     # Use real QPointF for all coordinates

--- a/tests/unit/test_zoomable_view.py
+++ b/tests/unit/test_zoomable_view.py
@@ -15,9 +15,9 @@ Covers:
 
 import pytest
 from unittest.mock import MagicMock, patch
-from PyQt6.QtCore import Qt, QPoint, QEvent
+from PyQt6.QtCore import Qt, QPoint, QEvent, QRectF
 from PyQt6.QtGui import QMouseEvent, QWheelEvent
-from PyQt6.QtWidgets import QGraphicsScene
+from PyQt6.QtWidgets import QGraphicsItem, QGraphicsScene
 from moleditpy.ui.zoomable_view import ZoomableView
 
 
@@ -352,3 +352,61 @@ def test_viewport_event_zoom_native_gesture_scales(app):
     result = view.viewportEvent(ev)
     assert result is True
     assert view.transform().m11() > before
+
+
+# ---------------------------------------------------------------------------
+# Zoom re-indexing
+# ---------------------------------------------------------------------------
+
+
+class _GeometryProbe(QGraphicsItem):
+    """Item that records prepareGeometryChange() notifications."""
+
+    def __init__(self):
+        super().__init__()
+        self.notified = 0
+
+    def boundingRect(self):
+        return QRectF(-5, -5, 10, 10)
+
+    def paint(self, painter, option, widget=None):
+        pass
+
+    def prepareGeometryChange(self):
+        self.notified += 1
+        super().prepareGeometryChange()
+
+
+def test_scale_notifies_items_of_geometry_change(app):
+    """AtomItem/BondItem hit areas are pixel-sized, so zooming changes their
+    geometry; without this notification Qt keeps the stale BSP index and
+    hover/click stops matching the drawn hit zone."""
+    view, scene = _make_view(app)
+    probe = _GeometryProbe()
+    scene.addItem(probe)
+    probe.notified = 0
+
+    view.scale(2.0, 2.0)
+    assert probe.notified >= 1
+
+
+def test_reset_transform_notifies_items_of_geometry_change(app):
+    """Reset-zoom must re-index items for the same reason as scale()."""
+    view, scene = _make_view(app)
+    probe = _GeometryProbe()
+    scene.addItem(probe)
+    probe.notified = 0
+
+    view.resetTransform()
+    assert probe.notified >= 1
+
+
+def test_wheel_zoom_notifies_items_of_geometry_change(app):
+    """Ctrl+wheel goes through scale(), so items must be re-indexed."""
+    view, scene = _make_view(app)
+    probe = _GeometryProbe()
+    scene.addItem(probe)
+    probe.notified = 0
+
+    view.wheelEvent(_wheel_event(120, ctrl=True))
+    assert probe.notified >= 1

--- a/tests/unit/test_zoomable_view.py
+++ b/tests/unit/test_zoomable_view.py
@@ -16,6 +16,7 @@ Covers:
 import pytest
 from unittest.mock import MagicMock, patch
 from PyQt6.QtCore import Qt, QPoint, QEvent, QRectF
+from PyQt6.QtTest import QTest
 from PyQt6.QtGui import QMouseEvent, QWheelEvent
 from PyQt6.QtWidgets import QGraphicsItem, QGraphicsScene
 from moleditpy.ui.zoomable_view import ZoomableView
@@ -377,6 +378,11 @@ class _GeometryProbe(QGraphicsItem):
         super().prepareGeometryChange()
 
 
+def _settle(view):
+    """Let the coalescing timer fire."""
+    QTest.qWait(view._geometry_timer.interval() + 80)
+
+
 def test_scale_notifies_items_of_geometry_change(app):
     """AtomItem/BondItem hit areas are pixel-sized, so zooming changes their
     geometry; without this notification Qt keeps the stale BSP index and
@@ -387,6 +393,7 @@ def test_scale_notifies_items_of_geometry_change(app):
     probe.notified = 0
 
     view.scale(2.0, 2.0)
+    _settle(view)
     assert probe.notified >= 1
 
 
@@ -398,6 +405,7 @@ def test_reset_transform_notifies_items_of_geometry_change(app):
     probe.notified = 0
 
     view.resetTransform()
+    _settle(view)
     assert probe.notified >= 1
 
 
@@ -409,4 +417,21 @@ def test_wheel_zoom_notifies_items_of_geometry_change(app):
     probe.notified = 0
 
     view.wheelEvent(_wheel_event(120, ctrl=True))
+    _settle(view)
     assert probe.notified >= 1
+
+
+def test_zoom_burst_re_indexes_once_not_per_step(app):
+    """Re-indexing per wheel tick dirties every item and made a zoom step ~40x
+    slower (125 ms per tick at 3000 atoms). One pass per gesture is enough."""
+    view, scene = _make_view(app)
+    probe = _GeometryProbe()
+    scene.addItem(probe)
+    probe.notified = 0
+
+    for _ in range(20):
+        view.scale(1.1, 1.1)
+    assert probe.notified == 0, "must not re-index mid-gesture"
+
+    _settle(view)
+    assert probe.notified == 1, f"one pass per gesture, got {probe.notified}"


### PR DESCRIPTION
## Summary

- **Fixes two Qt-level defects in the 4.6.1 pixel-sized hit zones.** 4.6.1 sized `AtomItem`/`BondItem.shape()` from `bond_snapping_distance_2d` in screen pixels but left `boundingRect()` alone; Qt prunes hover/click candidates by bounding rect, so part of the hit zone was dead (for a bare `C` the circle already escaped the rect sideways at 100% zoom, and worse when zoomed out, where the radius is `px / scale`). Bounding rects now cover the hit shape, and `ZoomableView.scale()`/`resetTransform()` re-index items, since Qt otherwise keeps the BSP index built at the previous zoom. `AtomItem.visual_rect()` is split out so selection/hover highlights and 2D measurement labels keep tracking the label instead of ballooning with the hit radius. **Hit-testing behaviour itself is unchanged from 4.6.1** — deliberately, since a hit zone fixed in screen pixels is what makes zooming in the way to target atoms precisely.
- **Guards `.pmeraw` against silent code execution.** A `.pmeraw` project is a Python pickle, so opening one runs whatever code the file carries. `load_raw_data()` now asks first (Cancel is the default button), and every entry point — menu, drag-and-drop, command line — funnels through it. Ctrl+S on a file opened from `.pmeraw` no longer writes the pickle back; it redirects to Save As, which only emits `.pmeprj`.
- **Renames the 2D snapping setting's label.** The slider drives atom hover highlight, click hit areas and keyboard instant-edit as well as bond snapping, so "Bond Snapping Distance" named a fraction of it. Display label and tooltip only — the stored key stays `bond_snapping_distance_2d`, so existing settings files load unchanged.
- **Clears the remaining mypy errors** (9 → 0) and records the ruff/mypy commands in `CLAUDE.md`.
- **Zoom re-indexing is coalesced to once per gesture.** Doing it per wheel tick dirties every item and forces Qt to recompute and re-index all of them: a zoom step measured **13.2 / 44.2 / 125.5 ms** at 300 / 1000 / 3000 atoms, against **0.34 / 1.07 / 3.45 ms** before this branch — ~40x, or 8 fps on a large structure. A single-shot timer restarted per `scale()` collapses a wheel burst into one pass, restoring the original cost (**0.31 / 0.96 / 3.20 ms**). The index is stale for 50 ms after the last tick, which no hover or click can outrun.
- **No test-only code left in the touched files.** All 11 `hasattr(scene, "get_setting")` / `hasattr(item, "prepareGeometryChange")` guards in the package are gone: every `AtomItem`/`BondItem` is built by `MoleculeScene`, which always has `get_setting`, and PyQt exposes `prepareGeometryChange` even on non-subclassed items — verified, not assumed. They were also doing mypy's narrowing, so each site declares `scene: Any` instead; no `# type: ignore` was needed and two existing ones became unnecessary. Net of the whole branch, the only defensive line added to product code is `except RuntimeError` in `ZoomableView`, for a wrapper deleted mid-teardown.
- **The `.pmeraw` prompt is unconditional.** It first carried a `MOLEDITPY_HEADLESS` bypass, which was test-only code in a product file — and unlike the two pre-existing uses of that variable, which only suppress an output-only modal, this one answered a security question on the user's behalf, so setting the variable disabled the pickle guard outright. Tests own the dialog by mocking it instead.

## Type of change

- [x] Bug fix
- [x] New feature
- [x] Refactor / code cleanup
- [x] Documentation
- [x] Tests
- [ ] CI / build

## Related issues

<!-- none -->

## Test plan

- [x] Ran `python tests/run_all_tests.py` — all pass
- [ ] Manually tested in the GUI with the check list
- [x] Added new unit tests

**2219 passed, 1 skipped** (2024 unit / 75 integration / 34 e2e / 86 GUI), coverage **89.73%**.

Verified three ways — with `MOLEDITPY_HEADLESS` set, with it unset, and via a bare `python tests/run_all_tests.py` with no environment at all. This mattered: while the confirmation was still skipped under `MOLEDITPY_HEADLESS=1`, a run without it put a live modal in front of six tests that only wanted the loader — four failed constructing `QMessageBox` with a MagicMock parent, and `test_corrupted_files_never_crash_loaders` hung on `box.exec()` until the pytest timeout killed it. Those tests now answer `_confirm_pickle_load` explicitly, and the bypass is gone from the product code entirely.

New/updated tests cover: hover and snapping agreeing at every probe point and zoom level; `shape()` staying inside `boundingRect()` for atoms and bonds; `visual_rect()` ignoring the hit radius; the hit zone **not** growing to the drawn label when zoomed in; zoom re-indexing via `scale()`/`resetTransform()`/wheel, and that a twenty-step zoom burst re-indexes once rather than twenty times; the `.pmeraw` confirm-open and confirm-cancel paths (`QMessageBox` mocked for both outcomes) and cancel leaving the document untouched; and Ctrl+S never writing `.pmeraw`.

Four test doubles were relying on product-side defensiveness rather than behaving like the real thing, and were fixed instead of being accommodated: two handed items MagicMock settings and transforms (one causing a hard `0xC0000409` crash mid-suite), one put real atom items in a bare `QGraphicsScene`, and `test_falls_back_when_the_scene_has_no_settings` asserted a path that existed only because of a `hasattr` guard — it now asserts the real fallback, warm-up running before the scene is built.

**Not done:** no manual GUI pass — every check here is automated, and the `.pmeraw` dialog has only been exercised with `QMessageBox` mocked.

## Checklist

- [x] `python -m flake8 moleditpy/src/ --select=F` returns 0 issues
- [x] No bare `except:` clauses added (use `except Exception as e:` and log the error)
- [x] No new unused imports or variables
- [x] Plugin API changes are backwards-compatible (or documented in Summary)

Also clean: `ruff format --check` (189 files) and `ruff check` on `moleditpy/src`, `mypy` (0 errors), pylint 9.36.

Comments are kept to a line each: the failure scenario behind every change is recorded in the commit messages rather than in the source.

`moleditpy-linux/` is untouched, as it is synced separately — a dry run of `scripts/sync_linux_version.py` confirms the release workflow will propagate all 12 changed files, including the new `utils/hit_radius.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MvsGqruSx5MajM1FoCjTZq
