### PR TITLE
Dev 4.7.1

### DIFF
--- a/docs/PLUGIN_DEVELOPMENT_MANUAL_V4.md
+++ b/docs/PLUGIN_DEVELOPMENT_MANUAL_V4.md
@@ -128,6 +128,8 @@ The `context` object passed to `initialize(context)` is your safe proxy to the a
 | **UI** | `set_analysis_enabled(bool)` | Enable / disable the Analysis menu action |
 | **Files** | `register_file_opener(ext, cb, priority)` | Handle a file extension (Import + CLI) |
 | **Files** | `register_drop_handler(cb, priority)` | Handle drag-and-drop onto the window |
+| **Files** | `set_current_file(path)` | Name *path* in the window title as the open file |
+| **Files** | `get_current_file()` | Path the application currently has open, or `None` |
 | **Molecule** | `current_molecule` | Get / set the active RDKit mol |
 | **Molecule** | `load_from_smiles(smiles)` | Add molecule from SMILES string |
 | **Molecule** | `show_xyz_data(xyz_text, source_name="XYZ data")` | Display XYZ text in the 3D viewer |
@@ -276,6 +278,41 @@ context.register_file_opener(".xyz", fallback, priority=-1)     # last resort
 Register a handler for files dropped onto the main 2D/3D editor window. **This is distinct from `register_file_opener`** — drop handlers are only triggered by drag-and-drop, not by the Import menu or command-line file arguments. Register both if you need both paths.
 - **callback** (`Callable[[str], bool]`): Function that receives the dropped file path. Must return `True` if it successfully handled the file, `False` to pass to the next handler.
 - **priority** (`int`): Handlers with higher priority are checked first. Use negative values (e.g., `-1`) for fallback handlers that run only when nothing else claims the file.
+
+#### `set_current_file(path)` / `get_current_file()`
+
+Tell the application which file it now has open, and read it back. The window
+title is built from this path — `job.out - MoleditPy Ver. 4.x` — exactly as it
+is for a project file, so call `set_current_file()` at the end of a file opener
+or drop handler.
+
+> [!NOTE]
+> Both were added in MoleditPy **4.7.1**. A plugin that also supports earlier
+> 4.x hosts should guard the call:
+> `if hasattr(context, "set_current_file"): context.set_current_file(path)`.
+
+- **path** (`str | None`): Path to show. `None` retitles the window "Untitled".
+- **returns** (`get_current_file`): The path, or `None` when nothing is open.
+
+```python
+def open_my_format(path):
+    load(path)
+    context.set_current_file(path)   # window now reads "sample.myext - MoleditPy ..."
+```
+
+> [!IMPORTANT]
+> Assigning `mw.init_manager.current_file_path` yourself sets the value but does
+> **not** repaint the title — it is rebuilt only on demand, so the window keeps
+> naming the previous file. There is no `mw.current_file_path` attribute either;
+> reading one always came back empty. Use these two methods.
+
+Only the **File > Import** menu sets the path for you (the host does it around
+the callback). A file opened from the command line, dropped onto the window, or
+picked inside your own dialog does not, so a plugin that wants the file named
+must call `set_current_file()` on those paths.
+
+Saving is unaffected: **Ctrl+S** only writes back to a `.pmeprj`, so any other
+extension recorded here falls through to *Save As* rather than being overwritten.
 
 #### `register_atom_drag_handler(callback)`
 Register a callback to receive real-time notifications during 3D atom or group dragging (single atom drag, group translate, group rotate).
@@ -625,6 +662,8 @@ def highlight_selection(context):
 | `context.register_menu_action(path, text, cb)` | `context.add_menu_action(path, cb, text)` |
 | `mw.settings.get(key)` | `context.get_setting(key)` |
 | `mw.state_manager.has_unsaved_changes = True` + `mw.state_manager.update_window_title()` | `context.mark_project_modified()` |
+| `mw.init_manager.current_file_path = p` (title never repaints) | `context.set_current_file(p)` |
+| `mw.current_file_path` (not an attribute — always empty) | `context.get_current_file()` |
 | `mw.state_manager.update_realtime_info()` + `mw.edit_actions_manager.update_undo_redo_actions()` + `mw.state_manager.update_window_title()` | `context.refresh_ui()` |
 | `mw.view_3d_manager.fit_to_view()` | `context.fit_2d_view()` |
 | `mw.edit_actions_manager.clear_2d_editor(push_to_undo=False)` | `context.clear_canvas(push_to_undo=False)` |
@@ -1145,3 +1184,7 @@ class TestMyPlugin(unittest.TestCase):
 Thank you for contributing to the MoleditPy ecosystem! If you encounter any bugs or need new API features, please reach out via GitHub Issues.
 
 **Happy Coding!**
+
+---
+
+*Documents the Version 4.0 plugin API as shipped in **MoleditPy 4.7.1** (2026-08-15).*

--- a/moleditpy/pyproject.toml
+++ b/moleditpy/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "MoleditPy"
 
-version = "4.7.0"
+version = "4.7.1"
 
 license = {file = "LICENSE"}
 

--- a/moleditpy/src/moleditpy/plugins/plugin_interface.py
+++ b/moleditpy/src/moleditpy/plugins/plugin_interface.py
@@ -409,6 +409,43 @@ class PluginContext:
             mw.init_manager.settings[namespaced] = value
             mw.init_manager.settings_dirty = True
 
+    def get_current_file(self) -> Optional[str]:
+        """
+        Path of the file the application currently has open, or None.
+
+        Returns:
+            The path, or None when nothing is open.
+        """
+        mw = self.get_main_window()
+        if mw and hasattr(mw, "init_manager"):
+            path = mw.init_manager.current_file_path
+            return str(path) if path else None
+        return None
+
+    def set_current_file(self, path: Optional[str]) -> None:
+        """
+        Record *path* as the file the application has open and retitle its window.
+
+        Use this after a plugin file opener loads a file, so the window names it
+        the way it names a project. Assigning ``init_manager.current_file_path``
+        directly leaves the title showing the previous file: it is only rebuilt
+        on demand.
+
+        Args:
+            path: File path to show, or None for "Untitled".
+        """
+        mw = self.get_main_window()
+        if mw is None or not hasattr(mw, "init_manager"):
+            return
+        try:
+            mw.init_manager.current_file_path = path
+            if hasattr(mw, "state_manager"):
+                fn = getattr(mw.state_manager, "update_window_title", None)
+                if fn:
+                    fn()
+        except (AttributeError, RuntimeError):
+            logging.debug("set_current_file failed", exc_info=True)
+
     def mark_project_modified(self) -> None:
         """Mark the current project as having unsaved changes and update the window title."""
         mw = self.get_main_window()

--- a/tests/assertion_catalog.md
+++ b/tests/assertion_catalog.md
@@ -370,6 +370,16 @@ _No description provided._
 - assert title.startswith('benzene.pmeprj - MoleditPy')
 - assert not title.startswith('*')
 
+### test_plugin_set_current_file_titles_the_window
+_The plugin API names the file in the title, not just in a field._
+
+- assert mock_parser_host.setWindowTitle.call_args.args[0].startswith('job.out - MoleditPy')
+
+### test_plugin_set_current_file_none_restores_untitled
+_Clearing the path through the plugin API retitles the window Untitled._
+
+- assert mock_parser_host.setWindowTitle.call_args.args[0].startswith('Untitled - MoleditPy')
+
 ### test_update_window_title_named_file_dirty_marks_asterisk
 _No description provided._
 
@@ -6851,6 +6861,54 @@ _PluginContext exposes a callable mark_project_modified method._
 
 - self.assertTrue(hasattr(PluginContext, 'mark_project_modified'), 'PluginContext must expose mark_project_modified()')
 - self.assertTrue(callable(getattr(PluginContext, 'mark_project_modified')))
+
+### TestCurrentFile.test_set_records_the_path
+_set_current_file stores the path where the window title is read from._
+
+- self.assertEqual(mw.init_manager.current_file_path, '/tmp/job.out')
+
+### TestCurrentFile.test_set_retitles_the_window
+_set_current_file rebuilds the title; the path alone would not show._
+
+- mw.state_manager.update_window_title.assert_called_once()
+
+### TestCurrentFile.test_set_accepts_none
+_Passing None clears the path, titling the window Untitled._
+
+- self.assertIsNone(mw.init_manager.current_file_path)
+
+### TestCurrentFile.test_get_returns_the_path
+_get_current_file reads back what the application has open._
+
+- self.assertEqual(_make_context(mw).get_current_file(), '/tmp/job.out')
+
+### TestCurrentFile.test_get_returns_none_when_nothing_is_open
+_An empty path reads as None rather than an empty string._
+
+- self.assertIsNone(_make_context(mw).get_current_file())
+
+### TestCurrentFile.test_get_round_trips_a_set
+_What set_current_file records is what get_current_file returns._
+
+- self.assertEqual(ctx.get_current_file(), '/tmp/job.out')
+
+### TestCurrentFile.test_get_returns_none_without_init_manager
+_get_current_file does not raise when init_manager is absent._
+
+- self.assertIsNone(_make_context(MagicMock(spec=[])).get_current_file())
+
+### TestCurrentFile.test_set_no_crash_when_init_manager_missing
+_set_current_file does not raise when init_manager is absent._
+
+
+### TestCurrentFile.test_set_no_crash_when_update_window_title_missing
+_set_current_file still records the path when the title call is absent._
+
+- self.assertEqual(mw.init_manager.current_file_path, '/tmp/job.out')
+
+### TestCurrentFile.test_set_no_crash_when_state_manager_raises
+_set_current_file does not propagate exceptions from state_manager._
+
 
 ### TestRefreshUi.test_calls_all_required_managers
 _refresh_ui calls update_realtime_info, update_undo_redo_actions, and update_window_title._

--- a/tests/unit/test_app_state.py
+++ b/tests/unit/test_app_state.py
@@ -647,6 +647,47 @@ def test_update_window_title_named_file_clean(mock_parser_host):
     assert not title.startswith("*")
 
 
+def test_plugin_set_current_file_titles_the_window(mock_parser_host):
+    """The plugin API names the file in the title, not just in a field.
+
+    Wired to the real StateManager: a plugin assigning current_file_path by
+    hand leaves the title on the previous file, which is the whole reason
+    set_current_file exists.
+    """
+    from moleditpy.plugins.plugin_interface import PluginContext
+
+    sm = _make_state_manager(mock_parser_host)
+    sm.has_unsaved_changes = False
+    mock_parser_host.state_manager.update_window_title = sm.update_window_title
+
+    manager = MagicMock()
+    manager.get_main_window.return_value = mock_parser_host
+    PluginContext(manager, "TestPlugin").set_current_file("C:/tmp/job.out")
+
+    assert mock_parser_host.setWindowTitle.call_args.args[0].startswith(
+        "job.out - MoleditPy"
+    )
+
+
+def test_plugin_set_current_file_none_restores_untitled(mock_parser_host):
+    """Clearing the path through the plugin API retitles the window Untitled."""
+    from moleditpy.plugins.plugin_interface import PluginContext
+
+    sm = _make_state_manager(mock_parser_host)
+    sm.has_unsaved_changes = False
+    mock_parser_host.state_manager.update_window_title = sm.update_window_title
+
+    manager = MagicMock()
+    manager.get_main_window.return_value = mock_parser_host
+    ctx = PluginContext(manager, "TestPlugin")
+    ctx.set_current_file("C:/tmp/job.out")
+    ctx.set_current_file(None)
+
+    assert mock_parser_host.setWindowTitle.call_args.args[0].startswith(
+        "Untitled - MoleditPy"
+    )
+
+
 def test_update_window_title_named_file_dirty_marks_asterisk(mock_parser_host):
     sm = _make_state_manager(mock_parser_host)
     sm.has_unsaved_changes = True

--- a/tests/unit/test_plugin_context.py
+++ b/tests/unit/test_plugin_context.py
@@ -85,6 +85,66 @@ class TestMarkProjectModified(unittest.TestCase):
         self.assertTrue(callable(getattr(PluginContext, "mark_project_modified")))
 
 
+class TestCurrentFile(unittest.TestCase):
+    def test_set_records_the_path(self):
+        """set_current_file stores the path where the window title is read from."""
+        mw = MagicMock()
+        _make_context(mw).set_current_file("/tmp/job.out")
+        self.assertEqual(mw.init_manager.current_file_path, "/tmp/job.out")
+
+    def test_set_retitles_the_window(self):
+        """set_current_file rebuilds the title; the path alone would not show."""
+        mw = MagicMock()
+        _make_context(mw).set_current_file("/tmp/job.out")
+        mw.state_manager.update_window_title.assert_called_once()
+
+    def test_set_accepts_none(self):
+        """Passing None clears the path, titling the window Untitled."""
+        mw = MagicMock()
+        _make_context(mw).set_current_file(None)
+        self.assertIsNone(mw.init_manager.current_file_path)
+
+    def test_get_returns_the_path(self):
+        """get_current_file reads back what the application has open."""
+        mw = MagicMock()
+        mw.init_manager.current_file_path = "/tmp/job.out"
+        self.assertEqual(_make_context(mw).get_current_file(), "/tmp/job.out")
+
+    def test_get_returns_none_when_nothing_is_open(self):
+        """An empty path reads as None rather than an empty string."""
+        mw = MagicMock()
+        mw.init_manager.current_file_path = None
+        self.assertIsNone(_make_context(mw).get_current_file())
+
+    def test_get_round_trips_a_set(self):
+        """What set_current_file records is what get_current_file returns."""
+        mw = MagicMock()
+        ctx = _make_context(mw)
+        ctx.set_current_file("/tmp/job.out")
+        self.assertEqual(ctx.get_current_file(), "/tmp/job.out")
+
+    def test_get_returns_none_without_init_manager(self):
+        """get_current_file does not raise when init_manager is absent."""
+        self.assertIsNone(_make_context(MagicMock(spec=[])).get_current_file())
+
+    def test_set_no_crash_when_init_manager_missing(self):
+        """set_current_file does not raise when init_manager is absent."""
+        _make_context(MagicMock(spec=[])).set_current_file("/tmp/job.out")
+
+    def test_set_no_crash_when_update_window_title_missing(self):
+        """set_current_file still records the path when the title call is absent."""
+        mw = MagicMock()
+        del mw.state_manager.update_window_title
+        _make_context(mw).set_current_file("/tmp/job.out")
+        self.assertEqual(mw.init_manager.current_file_path, "/tmp/job.out")
+
+    def test_set_no_crash_when_state_manager_raises(self):
+        """set_current_file does not propagate exceptions from state_manager."""
+        mw = MagicMock()
+        mw.state_manager.update_window_title.side_effect = RuntimeError("boom")
+        _make_context(mw).set_current_file("/tmp/job.out")
+
+
 class TestRefreshUi(unittest.TestCase):
     def test_calls_all_required_managers(self):
         """refresh_ui calls update_realtime_info, update_undo_redo_actions, and update_window_title."""
@@ -204,6 +264,8 @@ class TestRefresh2dScene(unittest.TestCase):
         lambda ctx: ctx.set_analysis_enabled(True),
         lambda ctx: ctx.check_chemistry_problems(),
         lambda ctx: ctx.refresh_2d_scene(),
+        lambda ctx: ctx.set_current_file("/tmp/job.out"),
+        lambda ctx: ctx.get_current_file(),
     ],
     ids=[
         "mark_project_modified",
@@ -214,6 +276,8 @@ class TestRefresh2dScene(unittest.TestCase):
         "set_analysis_enabled",
         "check_chemistry_problems",
         "refresh_2d_scene",
+        "set_current_file",
+        "get_current_file",
     ],
 )
 def test_no_crash_when_mw_is_none(call):


### PR DESCRIPTION
## Summary

- Adds `context.set_current_file(path)` and `context.get_current_file()` to `PluginContext`, so a plugin that opens a file can have the window name it — `job.out - MoleditPy Ver. 4.x` — the way a project file is named.
- Fixes the gap that made this impossible: assigning `init_manager.current_file_path` sets the value but never repaints the title (it is rebuilt only on demand), and `mw.current_file_path`, which several plugins reach for, is not an attribute at all, so it silently did nothing. Only **File > Import** worked, because the host sets the path and retitles around the callback itself.
- Documents both methods in the plugin manual (API table, a Files section, two legacy-vs-modern rows) and adds a footer naming the MoleditPy version the manual documents.
- Bumps the version to 4.7.1.

Backwards-compatible: purely additive to `PluginContext`, no existing behaviour changed. Plugins that also support earlier 4.x hosts should guard with `hasattr(context, "set_current_file")`; the manual says so.

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Refactor / code cleanup
- [x] Documentation
- [x] Tests
- [ ] CI / build

## Related issues

None.

## Test plan

- [x] Ran `python tests/run_all_tests.py` — all pass (2038 unit + 75 integration)
- [ ] Manually tested in the GUI with the check list — not done; covered instead by the StateManager-wired tests below
- [x] Added new unit tests

12 new tests:

- `tests/unit/test_plugin_context.py` — set, get, round-trip, `None`, and every missing-manager / raising-manager path, plus the two new entries in the "no crash when mw is None" parametrization.
- `tests/unit/test_app_state.py` — two tests wired to the **real** `StateManager` asserting the window title text becomes `job.out - MoleditPy…` and reverts to `Untitled…`. Asserting a mock call would prove nothing here: the call was never the part that was missing.

CI on this branch: MoleditPy Tests and Full GUI Tests both green on `51f1430`; re-running on `01d46c3` (generated markdown only).

## Checklist

- [x] `python -m flake8 moleditpy/src/ --select=F` returns 0 issues
- [x] No bare `except:` clauses added (use `except Exception as e:` and log the error)
- [x] No new unused imports or variables
- [x] Plugin API changes are backwards-compatible (or documented in Summary)

Also clean: `ruff format --check`, `ruff check moleditpy/src`, `mypy` (68 files, no issues), `pylint` 9.36/10 (unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BnL6oe94Z3xGiXch41tMsT
