### PR TITLE
Write OBJ/MTL as UTF-8, and report a failed export (4.7.2)

### DIFF
--- a/moleditpy-linux/pyproject.toml
+++ b/moleditpy-linux/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "MoleditPy-linux"
 
-version = "4.7.1"
+version = "4.7.2"
 
 license = {file = "LICENSE"}
 

--- a/moleditpy-linux/src/moleditpy_linux/ui/export_logic.py
+++ b/moleditpy-linux/src/moleditpy_linux/ui/export_logic.py
@@ -136,7 +136,7 @@ class ExportManager:
         """
         try:
             # Create MTL file
-            with open(mtl_path, "w") as mtl_file:
+            with open(mtl_path, "w", encoding="utf-8") as mtl_file:
                 mtl_file.write(f"# Material file for {os.path.basename(obj_path)}\n")
                 mtl_file.write("# Generated with individual object colors\n\n")
 
@@ -157,7 +157,7 @@ class ExportManager:
                     mtl_file.write("\n")
 
             # Create OBJ file
-            with open(obj_path, "w") as obj_file:
+            with open(obj_path, "w", encoding="utf-8") as obj_file:
                 obj_file.write("# OBJ file with multiple materials\n")
                 obj_file.write("# Generated with individual object colors\n")
                 obj_file.write(f"mtllib {os.path.basename(mtl_path)}\n\n")
@@ -225,8 +225,10 @@ class ExportManager:
                     vertex_offset += mesh.n_points
                     obj_file.write("\n")
 
-        except (AttributeError, RuntimeError, ValueError) as e:
-            raise Exception(f"Failed to create multi-material OBJ: {e}")
+        except (AttributeError, OSError, RuntimeError, ValueError) as e:
+            # ValueError, not Exception: export_obj_mtl catches this to report
+            # the failure in the status bar.
+            raise ValueError(f"Failed to create multi-material OBJ: {e}") from e
 
     def export_color_stl(self) -> None:
         """Export as Color STL."""

--- a/moleditpy/pyproject.toml
+++ b/moleditpy/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "MoleditPy"
 
-version = "4.7.1"
+version = "4.7.2"
 
 license = {file = "LICENSE"}
 

--- a/moleditpy/src/moleditpy/ui/export_logic.py
+++ b/moleditpy/src/moleditpy/ui/export_logic.py
@@ -136,7 +136,7 @@ class ExportManager:
         """
         try:
             # Create MTL file
-            with open(mtl_path, "w") as mtl_file:
+            with open(mtl_path, "w", encoding="utf-8") as mtl_file:
                 mtl_file.write(f"# Material file for {os.path.basename(obj_path)}\n")
                 mtl_file.write("# Generated with individual object colors\n\n")
 
@@ -157,7 +157,7 @@ class ExportManager:
                     mtl_file.write("\n")
 
             # Create OBJ file
-            with open(obj_path, "w") as obj_file:
+            with open(obj_path, "w", encoding="utf-8") as obj_file:
                 obj_file.write("# OBJ file with multiple materials\n")
                 obj_file.write("# Generated with individual object colors\n")
                 obj_file.write(f"mtllib {os.path.basename(mtl_path)}\n\n")
@@ -225,8 +225,10 @@ class ExportManager:
                     vertex_offset += mesh.n_points
                     obj_file.write("\n")
 
-        except (AttributeError, RuntimeError, ValueError) as e:
-            raise Exception(f"Failed to create multi-material OBJ: {e}")
+        except (AttributeError, OSError, RuntimeError, ValueError) as e:
+            # ValueError, not Exception: export_obj_mtl catches this to report
+            # the failure in the status bar.
+            raise ValueError(f"Failed to create multi-material OBJ: {e}") from e
 
     def export_color_stl(self) -> None:
         """Export as Color STL."""

--- a/tests/assertion_catalog.md
+++ b/tests/assertion_catalog.md
@@ -3934,6 +3934,21 @@ _No description provided._
 
 - assert any(('error occurred during SVG export' in str(c.args[0]) for c in mock_parser_host.statusBar().showMessage.call_args_list))
 
+### test_create_multi_material_obj_writes_utf8
+_The mtllib reference must be UTF-8, not the OS locale encoding._
+
+- assert 'mtllib 分子.mtl' in obj_bytes.decode('utf-8')
+- assert '分子.obj' in mtl_bytes.decode('utf-8')
+
+### test_create_multi_material_obj_raises_value_error
+_A write failure must raise what export_obj_mtl catches, not bare Exception._
+
+
+### test_export_obj_mtl_reports_write_failure
+_A failed write is reported in the status bar, not raised at the user._
+
+- assert any(('Error exporting OBJ/MTL' in str(args) for args, _ in exporter.statusBar().showMessage.call_args_list))
+
 ## tests/unit/test_font_cache_warmup.py
 
 ### TestSubscriptMap.test_maps_every_digit
@@ -5221,8 +5236,8 @@ _Test export_color_stl success path._
 ### test_create_multi_material_obj_logic
 _Test the file writing logic of create_multi_material_obj._
 
-- mock_file.assert_any_call(obj_path, 'w')
-- mock_file.assert_any_call(mtl_path, 'w')
+- mock_file.assert_any_call(obj_path, 'w', encoding='utf-8')
+- mock_file.assert_any_call(mtl_path, 'w', encoding='utf-8')
 - assert 'mtllib test.mtl' in content
 - assert 'usemtl material_0_test_mesh' in content
 - assert 'v 0.000000 0.000000 0.000000' in content

--- a/tests/coverage_report.md
+++ b/tests/coverage_report.md
@@ -1,6 +1,6 @@
 # MoleditPy Coverage Report
 
-- **Overall Project Coverage**: **89.73%**
+- **Overall Project Coverage**: **89.75%**
 
 ### Coverage Breakdown
 
@@ -10,7 +10,7 @@
 | moleditpy\src\moleditpy\main.py                         |    170 |     35 |   79.4% |
 | moleditpy\src\moleditpy\core\mol_geometry.py            |    292 |      4 |   98.6% |
 | moleditpy\src\moleditpy\core\molecular_data.py          |    284 |      0 |  100.0% |
-| moleditpy\src\moleditpy\plugins\plugin_interface.py     |    238 |      6 |   97.5% |
+| moleditpy\src\moleditpy\plugins\plugin_interface.py     |    256 |      6 |   97.7% |
 | moleditpy\src\moleditpy\plugins\plugin_manager.py       |    407 |     11 |   97.3% |
 | moleditpy\src\moleditpy\plugins\plugin_manager_window.py |    187 |      2 |   98.9% |
 | moleditpy\src\moleditpy\ui\__init__.py                  |      7 |      3 |   57.1% |
@@ -37,7 +37,7 @@
 | moleditpy\src\moleditpy\ui\dihedral_dialog.py           |    280 |     33 |   88.2% |
 | moleditpy\src\moleditpy\ui\edit_3d_logic.py             |    221 |     32 |   85.5% |
 | moleditpy\src\moleditpy\ui\edit_actions_logic.py        |    817 |    127 |   84.5% |
-| moleditpy\src\moleditpy\ui\export_logic.py              |    520 |     85 |   83.7% |
+| moleditpy\src\moleditpy\ui\export_logic.py              |    520 |     83 |   84.0% |
 | moleditpy\src\moleditpy\ui\geometry_base_dialog.py      |     52 |      1 |   98.1% |
 | moleditpy\src\moleditpy\ui\io_logic.py                  |    751 |     76 |   89.9% |
 | moleditpy\src\moleditpy\ui\main_window.py               |    195 |     13 |   93.3% |
@@ -69,11 +69,11 @@
 | moleditpy\src\moleditpy\utils\sip_isdeleted_safe.py     |     19 |      0 |  100.0% |
 | moleditpy\src\moleditpy\utils\suppress_log.py           |     10 |      0 |  100.0% |
 | moleditpy\src\moleditpy\utils\system_utils.py           |     40 |      0 |  100.0% |
-| **TOTAL** | **16927** | **1739** | **89.73%** |
+| **TOTAL** | **16945** | **1737** | **89.75%** |
 
 ## Test Suite Status
-- **Total tests passed**: 2219 (1 skipped)
-- **Unit tests**: PASSED (2024 passed)
+- **Total tests passed**: 2236 (1 skipped)
+- **Unit tests**: PASSED (2041 passed)
 - **Integration tests**: PASSED (75 passed)
 - **E2E tests**: PASSED (34 passed, 1 skipped)
 - **GUI tests**: PASSED (86 passed)

--- a/tests/pylint-score.txt
+++ b/tests/pylint-score.txt
@@ -1,1 +1,1 @@
-Your code has been rated at 9.36/10
+Your code has been rated at 9.37/10

--- a/tests/unit/test_export_logic.py
+++ b/tests/unit/test_export_logic.py
@@ -1,6 +1,7 @@
 """Unit tests for ExportManager file export operations."""
 
 import os
+import pytest
 from rdkit import Chem
 from rdkit.Chem import AllChem
 from moleditpy.ui.export_logic import ExportManager
@@ -987,4 +988,69 @@ def test_export_2d_svg_reports_render_exception(mock_parser_host, tmp_path):
     assert any(
         "error occurred during SVG export" in str(c.args[0])
         for c in mock_parser_host.statusBar().showMessage.call_args_list
+    )
+
+
+def _single_triangle_mesh():
+    """One VTK triangle, enough for create_multi_material_obj to write a file."""
+    mesh = MagicMock()
+    mesh.points = np.array([[0, 0, 0], [1, 0, 0], [0, 1, 0]], dtype=float)
+    mesh.n_points = 3
+    mesh.n_cells = 1
+    cell = MagicMock()
+    cell.type = 5  # VTK_TRIANGLE
+    cell.point_ids = [0, 1, 2]
+    mesh.get_cell.return_value = cell
+    return mesh
+
+
+def test_create_multi_material_obj_writes_utf8(mock_parser_host, tmp_path):
+    """The mtllib reference must be UTF-8, not the OS locale encoding.
+
+    Written in cp932 on a Japanese Windows, `mtllib 分子.mtl` is unreadable to
+    Blender and the model imports with no colors.
+    """
+    exporter = DummyExport(mock_parser_host)
+    meshes = [{"mesh": _single_triangle_mesh(), "color": [255, 0, 0], "name": "Atom1"}]
+    obj_path = str(tmp_path / "分子.obj")
+    mtl_path = str(tmp_path / "分子.mtl")
+
+    exporter.create_multi_material_obj(meshes, obj_path, mtl_path)
+
+    obj_bytes = open(obj_path, "rb").read()
+    mtl_bytes = open(mtl_path, "rb").read()
+    assert "mtllib 分子.mtl" in obj_bytes.decode("utf-8")
+    assert "分子.obj" in mtl_bytes.decode("utf-8")
+
+
+def test_create_multi_material_obj_raises_value_error(mock_parser_host, tmp_path):
+    """A write failure must raise what export_obj_mtl catches, not bare Exception."""
+    exporter = DummyExport(mock_parser_host)
+    meshes = [{"mesh": _single_triangle_mesh(), "color": [1, 2, 3], "name": "a"}]
+    missing_dir = tmp_path / "no_such_dir"
+
+    with pytest.raises(ValueError):
+        exporter.create_multi_material_obj(
+            meshes, str(missing_dir / "m.obj"), str(missing_dir / "m.mtl")
+        )
+
+
+def test_export_obj_mtl_reports_write_failure(mock_parser_host, tmp_path):
+    """A failed write is reported in the status bar, not raised at the user."""
+    exporter = DummyExport(mock_parser_host)
+    exporter.export_from_3d_view_with_colors = MagicMock(
+        return_value=[
+            {"mesh": _single_triangle_mesh(), "color": [1, 2, 3], "name": "a"}
+        ]
+    )
+    chosen = str(tmp_path / "no_such_dir" / "model.obj")
+
+    with patch(
+        "PyQt6.QtWidgets.QFileDialog.getSaveFileName", return_value=(chosen, "")
+    ):
+        exporter.export_obj_mtl()
+
+    assert any(
+        "Error exporting OBJ/MTL" in str(args)
+        for args, _ in exporter.statusBar().showMessage.call_args_list
     )

--- a/tests/unit/test_main_window_export_extended.py
+++ b/tests/unit/test_main_window_export_extended.py
@@ -231,8 +231,8 @@ def test_create_multi_material_obj_logic(window):
 
     with patch("builtins.open", mock_open()) as mock_file:
         window.create_multi_material_obj(meshes, obj_path, mtl_path)
-        mock_file.assert_any_call(obj_path, "w")
-        mock_file.assert_any_call(mtl_path, "w")
+        mock_file.assert_any_call(obj_path, "w", encoding="utf-8")
+        mock_file.assert_any_call(mtl_path, "w", encoding="utf-8")
 
         handle = mock_file()
         write_calls = handle.write.call_args_list


### PR DESCRIPTION
## Summary

<!-- What does this PR do? List the key changes in 2–4 bullet points. -->

- **OBJ/MTL are now written as UTF-8.** The two writers in `export_logic.py` were the only text-mode `open()` calls in the package without an `encoding=`, so both files were written in the OS locale encoding. On a Japanese Windows (cp932), exporting `分子.obj` emits the `mtllib` line as cp932 bytes; Blender reads it as UTF-8, cannot resolve the `.mtl`, and imports the model with no colors — the entire point of OBJ+MTL over plain OBJ. A character outside the codepage failed the export outright, leaving a 0-byte `.mtl` and no `.obj`.
- **A failed OBJ export is reported instead of crashing.** `create_multi_material_obj` re-raised every failure as a bare `Exception`, which its only caller cannot catch (`except (AttributeError, RuntimeError, ValueError)`). A write error — read-only folder, missing directory — escaped `export_obj_mtl` entirely and surfaced as the uncaught-exception dialog rather than the status message written for it. `UnicodeEncodeError` is a `ValueError`, so the re-wrap was what broke it; it now raises `ValueError ... from e` and catches `OSError` too.
- Version bumped to **4.7.2**, carried into `moleditpy-linux` by `scripts/sync_linux_version.py`.

## Type of change

<!-- Check all that apply. -->

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation
- [x] Tests
- [ ] CI / build

## Related issues

None.

## Test plan

<!-- How did you verify the change works? -->

- [x] Ran `python tests/run_all_tests.py` — all pass (2041 unit + 75 integration = **2116 passed**)
- [ ] Manually tested in the GUI with the check list
- [x] Added new unit tests

Both bugs were first reproduced by executing the real writer, on a cp932 machine:

```
locale encoding : cp932
mtl first line raw bytes: b'# Material file for \x95\xaa\x8eq.obj\r'
decodes as UTF-8 : NO -> invalid start byte

raised: Exception -> Failed to create multi-material OBJ: 'cp932' codec can't encode '\U0001f9ea'
caught by caller's except (AttributeError, RuntimeError, ValueError)?  False
partial .mtl left behind: 0 bytes;  .obj written: False
```

Three new tests pin the fixed behaviour — the UTF-8 bytes on disk for a non-ASCII path, the raised exception type, and the status-bar message on a failed write. **All three fail on `main`**, verified by stashing the fix and re-running:

```
FAILED test_create_multi_material_obj_writes_utf8
FAILED test_create_multi_material_obj_raises_value_error
FAILED test_export_obj_mtl_reports_write_failure
```

`test_main_window_export_extended.py::test_create_multi_material_obj_logic` asserted `open(path, "w")` exactly, pinning the buggy call, and is updated to expect the encoding.

Not covered: no manual GUI export was performed — I have no 3D-capable session here, so the writer was driven directly with a stub mesh.

## Checklist

- [x] `python -m flake8 moleditpy/src/ --select=F` returns 0 issues
- [x] No bare `except:` clauses added (use `except Exception as e:` and log the error)
- [x] No new unused imports or variables
- [x] Plugin API changes are backwards-compatible (or documented in Summary) — no API change

Also clean: `ruff format --check` (189 files), `ruff check moleditpy/src`, `mypy` (0 errors, 68 files), `pylint` 9.37/10, and the Tests CI matrix on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017oe2nUGihifQMrjHr1WBjM
