### PR TITLE
Template preview parity, clicked-atom replacement, and toolbar mode clarity (4.8.0)

### DIFF
--- a/moleditpy/pyproject.toml
+++ b/moleditpy/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "MoleditPy"
 
-version = "4.7.2"
+version = "4.8.0"
 
 license = {file = "LICENSE"}
 

--- a/moleditpy/src/moleditpy/ui/about_dialog.py
+++ b/moleditpy/src/moleditpy/ui/about_dialog.py
@@ -100,15 +100,16 @@ class AboutDialog(QDialog):
         layout.addLayout(button_layout)
 
     def image_clicked(self, event: QMouseEvent) -> None:
-        """Easter egg: Clear all and load bipyrimidine from SMILES"""
+        """Clear all, load bipyrimidine from SMILES, and build it in 3D."""
         # Clear the current scene
         self.main_window.edit_actions_manager.clear_all()
 
         bipyrimidine_smiles = "C1=CN=C(N=C1)C2=NC=CC=N2"
         self.main_window.string_importer_manager.load_from_smiles(bipyrimidine_smiles)
 
-        # Close the dialog
+        # Close the dialog first: the conversion puts up its own
         self.accept()
+        self.main_window.compute_manager.trigger_conversion()
 
     def image_mouse_press_event(self, event: QMouseEvent) -> None:
         """Handle mouse press on the image: trigger easter egg only for right-click."""
@@ -118,6 +119,7 @@ class AboutDialog(QDialog):
             else:
                 event.ignore()
         except (AttributeError, RuntimeError, ValueError, TypeError):
+            logging.warning("Image click handling failed", exc_info=True)
             try:
                 event.ignore()
             except (AttributeError, RuntimeError, ValueError, TypeError) as e:

--- a/moleditpy/src/moleditpy/ui/dialog_logic.py
+++ b/moleditpy/src/moleditpy/ui/dialog_logic.py
@@ -112,7 +112,6 @@ class DialogManager:
             # Bring existing dialog to front
             _template_dialog.raise_()
             _template_dialog.activateWindow()
-            self._sync_toolbar_to_mode()
             return
 
         # Create new dialog
@@ -135,16 +134,8 @@ class DialogManager:
 
                 # Update status
                 self.host.update_status_message(f"Template mode: {template_name}")
-            else:
-                self._sync_toolbar_to_mode()
 
         self.host.template_dialog.finished.connect(on_dialog_finished)
-
-    def _sync_toolbar_to_mode(self) -> None:
-        """Re-highlight the live mode; the USER button checked itself on click."""
-        self.host.ui_manager.set_mode_and_update_toolbar(
-            getattr(self.host.init_manager.scene, "mode", "select")
-        )
 
     def save_2d_as_template(self) -> None:
         """Save current 2D structure as a template"""

--- a/moleditpy/src/moleditpy/ui/dialog_logic.py
+++ b/moleditpy/src/moleditpy/ui/dialog_logic.py
@@ -114,28 +114,10 @@ class DialogManager:
             _template_dialog.activateWindow()
             return
 
-        # Create new dialog
+        # Create new dialog. Picking a template arms it right away, and closing
+        # the dialog cleans the mode up, so there is nothing to do on finish.
         self.host.template_dialog = UserTemplateDialog(self.host, self.host)
         self.host.template_dialog.show()
-
-        # Activate if a template is selected after dialog is closed
-        def on_dialog_finished() -> None:
-            if self.host.template_dialog.selected_template:
-                template_name = self.host.template_dialog.selected_template.get(
-                    "name", "user_template"
-                )
-                mode_name = f"template_user_{template_name}"
-
-                # Store template data for the scene to use
-                self.host.set_scene_user_template_data(
-                    self.host.template_dialog.selected_template
-                )
-                self.host.ui_manager.set_mode_and_update_toolbar(mode_name)
-
-                # Update status
-                self.host.update_status_message(f"Template mode: {template_name}")
-
-        self.host.template_dialog.finished.connect(on_dialog_finished)
 
     def save_2d_as_template(self) -> None:
         """Save current 2D structure as a template"""

--- a/moleditpy/src/moleditpy/ui/dialog_logic.py
+++ b/moleditpy/src/moleditpy/ui/dialog_logic.py
@@ -112,6 +112,7 @@ class DialogManager:
             # Bring existing dialog to front
             _template_dialog.raise_()
             _template_dialog.activateWindow()
+            self._sync_toolbar_to_mode()
             return
 
         # Create new dialog
@@ -130,12 +131,20 @@ class DialogManager:
                 self.host.set_scene_user_template_data(
                     self.host.template_dialog.selected_template
                 )
-                self.host.ui_manager.set_mode(mode_name)
+                self.host.ui_manager.set_mode_and_update_toolbar(mode_name)
 
                 # Update status
                 self.host.update_status_message(f"Template mode: {template_name}")
+            else:
+                self._sync_toolbar_to_mode()
 
         self.host.template_dialog.finished.connect(on_dialog_finished)
+
+    def _sync_toolbar_to_mode(self) -> None:
+        """Re-highlight the live mode; the USER button checked itself on click."""
+        self.host.ui_manager.set_mode_and_update_toolbar(
+            getattr(self.host.init_manager.scene, "mode", "select")
+        )
 
     def save_2d_as_template(self) -> None:
         """Save current 2D structure as a template"""

--- a/moleditpy/src/moleditpy/ui/molecular_scene_handler.py
+++ b/moleditpy/src/moleditpy/ui/molecular_scene_handler.py
@@ -448,6 +448,7 @@ class TemplateMixin:
             self.template_context["bonds_info"] = bonds_info
 
             # Snap individual preview vertices to nearby atoms to reflect template fusing visually
+            vertex_atoms: List[Optional[AtomItem]] = [None] * len(points)
             if self.get_setting("template_fusing_enabled_2d", True) and not alt_pressed:
                 fuse_dist = self.get_setting("template_fusing_distance_2d", 7.0)
                 mapped_atoms = set(self.template_context.get("items", []))
@@ -468,6 +469,7 @@ class TemplateMixin:
                         if best_idx != -1 and best_d <= click_map_threshold:
                             points[best_idx] = ex_pos
                             used_indices.add(best_idx)
+                            vertex_atoms[best_idx] = ex_item
                     except (AttributeError, TypeError, IndexError):
                         # Safe defensive fallback catching AttributeError, TypeError, IndexError
                         logging.debug("Suppressed non-critical error", exc_info=True)
@@ -497,8 +499,22 @@ class TemplateMixin:
                         if nearby and best_d <= fuse_dist:
                             points[i] = nearby.pos()
                             mapped_atoms.add(nearby)
+                            vertex_atoms[i] = nearby
 
-            self.template_preview.set_geometry(points, is_aromatic)
+            # add_molecule_fragment rotates a fused aromatic ring to match the
+            # bonds already there; the preview shows the same alternation. It
+            # rotates the placement copy itself, so template_context keeps the
+            # unrotated orders.
+            preview_bonds = bonds_info
+            if is_aromatic and n == 6:
+                rotation = self._calculate_6ring_rotation(n, bonds_info, vertex_atoms)
+                orders = [order for (_, _, order) in bonds_info]
+                preview_bonds = [
+                    (i, j, orders[(m + rotation) % n])
+                    for m, (i, j, _) in enumerate(bonds_info)
+                ]
+
+            self.template_preview.set_geometry(points, is_aromatic, preview_bonds)
 
             self.template_preview.show()
             if self.views():
@@ -560,8 +576,9 @@ class TemplateMixin:
     ) -> None:
         """Overwrite an existing atom with a user template atom's element/charge/radical."""
         symbol = atom_data.get("symbol", "C")
-        charge = atom_data.get("charge", 0)
-        radical = atom_data.get("radical", 0)
+        # A hand-written template may carry nulls here
+        charge = int(atom_data.get("charge") or 0)
+        radical = int(atom_data.get("radical") or 0)
 
         if (
             atom_item.symbol == symbol
@@ -582,6 +599,8 @@ class TemplateMixin:
                 record["charge"] = charge
                 record["radical"] = radical
 
+            # A bonded carbon is drawn as a bare vertex; the new element needs a label
+            atom_item.update_style()
             for bond in atom_item.bonds:
                 bond.update()
                 other = bond.atom1 if bond.atom2 is atom_item else bond.atom2

--- a/moleditpy/src/moleditpy/ui/molecular_scene_handler.py
+++ b/moleditpy/src/moleditpy/ui/molecular_scene_handler.py
@@ -555,6 +555,41 @@ class TemplateMixin:
             points.append(current_p)
         return points
 
+    def _apply_template_atom_to_existing(
+        self, atom_item: Any, atom_data: Dict[str, Any]
+    ) -> None:
+        """Overwrite an existing atom with a user template atom's element/charge/radical."""
+        symbol = atom_data.get("symbol", "C")
+        charge = atom_data.get("charge", 0)
+        radical = atom_data.get("radical", 0)
+
+        if (
+            atom_item.symbol == symbol
+            and atom_item.charge == charge
+            and atom_item.radical == radical
+        ):
+            return
+
+        try:
+            atom_item.prepareGeometryChange()
+            atom_item.symbol = symbol
+            atom_item.charge = charge
+            atom_item.radical = radical
+
+            record = self.data.atoms.get(atom_item.atom_id)
+            if record is not None:
+                record["symbol"] = symbol
+                record["charge"] = charge
+                record["radical"] = radical
+
+            for bond in atom_item.bonds:
+                bond.update()
+                other = bond.atom1 if bond.atom2 is atom_item else bond.atom2
+                if other is not None:
+                    other.update_style()
+        except (AttributeError, RuntimeError, KeyError, TypeError) as e:
+            logging.warning(f"Error applying template atom to existing atom: {e}")
+
     def add_user_template_fragment(self, context: Dict[str, Any]) -> None:
         """Place user template fragment"""
         points = context.get("points", [])
@@ -569,9 +604,10 @@ class TemplateMixin:
         atom_id_map = {}  # template id -> scene atom id
 
         for i, (pos, atom_data) in enumerate(zip(points, atoms_data)):
-            # Skip first atom if attaching to existing atom
+            # Reuse the clicked atom for the template's first atom, overwriting its element
             if i == 0 and attachment_atom:
                 atom_id_map[atom_data["id"]] = attachment_atom.atom_id
+                self._apply_template_atom_to_existing(attachment_atom, atom_data)
                 continue
 
             symbol = atom_data.get("symbol", "C")

--- a/moleditpy/src/moleditpy/ui/preview_molecule.py
+++ b/moleditpy/src/moleditpy/ui/preview_molecule.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+"""
+MoleditPy — A Python-based molecular editing software
+
+Author: Hiromichi Yokoyama
+License: GPL-3.0 license
+Repo: https://github.com/HiroYokoyama/python_molecular_editor
+DOI: 10.5281/zenodo.17268532
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, List, Sequence, Tuple
+
+from PyQt6.QtCore import QPointF, QRectF
+from PyQt6.QtWidgets import QGraphicsItem, QGraphicsScene
+
+from .atom_item import AtomItem
+from .bond_item import BondItem
+
+
+class PreviewScene(QGraphicsScene):
+    """Scene for preview-only atom/bond items.
+
+    AtomItem and BondItem read their font, colour and spacing through
+    scene().get_setting(), so any scene holding them has to answer it. ``host``
+    is the editor scene, so previews follow the user's 2D settings.
+    """
+
+    def __init__(self, host: Any = None) -> None:
+        super().__init__()
+        self.host: Any = host
+
+    def get_setting(self, key: str, default: Any = None) -> Any:
+        """Forward a settings lookup to the editor scene."""
+        host = self.host
+        if host is None or not hasattr(host, "get_setting"):
+            return default
+        try:
+            return host.get_setting(key, default)
+        except (AttributeError, RuntimeError, TypeError, ValueError):
+            return default
+
+    def views(self) -> List[Any]:
+        """Report the editor's views so zoom-dependent radii match the real items."""
+        host = self.host
+        if host is not None and hasattr(host, "views"):
+            try:
+                return list(host.views())
+            except (AttributeError, RuntimeError, TypeError):
+                return []
+        return list(super().views())
+
+
+def ensure_preview_settings(scene: Any, host: Any = None) -> None:
+    """Give a plain QGraphicsScene the get_setting() the preview items call."""
+    if hasattr(scene, "get_setting"):
+        return
+    if host is not None and hasattr(host, "get_setting"):
+        scene.get_setting = host.get_setting
+    else:
+        scene.get_setting = lambda key, default=None: default
+
+
+def build_preview_items(
+    atoms: Sequence[Dict[str, Any]],
+    bonds: Sequence[Sequence[int]],
+) -> Tuple[List[AtomItem], List[BondItem], Dict[int, Tuple[int, ...]]]:
+    """Build the atom/bond items that draw a template the way the editor draws it.
+
+    ``atoms`` entries need ``pos`` plus the usual ``symbol``/``charge``/``radical``;
+    ``bonds`` are ``(index1, index2[, order[, stereo]])``. The items are returned
+    unparented — the caller decides which scene they belong to — together with the
+    ring each bond belongs to, so a moved preview can recompute its ring centres.
+    """
+    atom_items: List[AtomItem] = []
+    for i, atom_data in enumerate(atoms):
+        item = AtomItem(
+            i,
+            atom_data.get("symbol", "C"),
+            QPointF(atom_data.get("pos", QPointF())),
+            charge=int(atom_data.get("charge", 0) or 0),
+            radical=int(atom_data.get("radical", 0) or 0),
+        )
+        item.setFlag(QGraphicsItem.GraphicsItemFlag.ItemIsMovable, False)
+        item.setFlag(QGraphicsItem.GraphicsItemFlag.ItemIsSelectable, False)
+        item.setAcceptHoverEvents(False)
+        atom_items.append(item)
+
+    bond_items: List[BondItem] = []
+    for bond in bonds:
+        if len(bond) < 2:
+            continue
+        i, j = bond[0], bond[1]
+        if not isinstance(i, int) or not isinstance(j, int):
+            continue
+        if not (0 <= i < len(atom_items) and 0 <= j < len(atom_items)) or i == j:
+            continue
+        order = int(bond[2]) if len(bond) > 2 else 1
+        stereo = int(bond[3]) if len(bond) > 3 else 0
+        atom1, atom2 = atom_items[i], atom_items[j]
+        bond_item = BondItem(atom1, atom2, order, stereo)
+        bond_item.setFlag(QGraphicsItem.GraphicsItemFlag.ItemIsSelectable, False)
+        bond_item.setAcceptHoverEvents(False)
+        # create_bond() does this too; without it carbons never turn invisible
+        atom1.bonds.append(bond_item)
+        atom2.bonds.append(bond_item)
+        bond_items.append(bond_item)
+
+    ring_atoms = apply_preview_topology(atom_items, bond_items)
+    for item in atom_items:
+        item.update_style()
+    return atom_items, bond_items, ring_atoms
+
+
+def preview_content_rect(
+    atom_items: Sequence[AtomItem], bond_items: Sequence[BondItem]
+) -> QRectF:
+    """Return the rect the preview actually draws into, without any hit padding."""
+    rect = QRectF()
+    for atom in atom_items:
+        rect = rect.united(atom.visual_rect().translated(atom.pos()))
+    for bond in bond_items:
+        line = bond.get_line_in_local_coords()
+        rect = rect.united(
+            QRectF(line.p1(), line.p2()).normalized().translated(bond.pos())
+        )
+    return rect
+
+
+def apply_preview_topology(
+    atom_items: Sequence[AtomItem], bond_items: Sequence[BondItem]
+) -> Dict[int, Tuple[int, ...]]:
+    """Fill in implicit hydrogens and ring info for the preview.
+
+    Deliberately no sanitization: a preview must draw whatever the template says,
+    so the valence is never checked and an odd one still gets its H count.
+    """
+    try:
+        from rdkit import Chem  # pylint: disable=import-outside-toplevel
+
+        bond_types = {
+            1: Chem.BondType.SINGLE,
+            2: Chem.BondType.DOUBLE,
+            3: Chem.BondType.TRIPLE,
+            4: Chem.BondType.AROMATIC,
+        }
+        mol = Chem.RWMol()
+        for item in atom_items:
+            atom = Chem.Atom(item.symbol)
+            atom.SetFormalCharge(item.charge)
+            atom.SetNumRadicalElectrons(item.radical)
+            mol.AddAtom(atom)
+        index_of = {id(item): i for i, item in enumerate(atom_items)}
+        for bond in bond_items:
+            mol.AddBond(
+                index_of[id(bond.atom1)],
+                index_of[id(bond.atom2)],
+                bond_types.get(bond.order, Chem.BondType.SINGLE),
+            )
+        mol.UpdatePropertyCache(strict=False)
+        Chem.FastFindRings(mol)
+    except (ValueError, RuntimeError, TypeError, AttributeError, ImportError):
+        logging.debug("Preview topology unavailable", exc_info=True)
+        return {}
+
+    for item, atom in zip(atom_items, mol.GetAtoms()):
+        item.implicit_h_count = atom.GetTotalNumHs()
+
+    ring_info = mol.GetRingInfo()
+    ring_atoms: Dict[int, Tuple[int, ...]] = {}
+    best_ring_size: Dict[int, int] = {}
+    for atom_ring, bond_ring in zip(ring_info.AtomRings(), ring_info.BondRings()):
+        positions = [atom_items[idx].pos() for idx in atom_ring]
+        center = (
+            sum(p.x() for p in positions) / len(positions),
+            sum(p.y() for p in positions) / len(positions),
+        )
+        for bond_idx in bond_ring:
+            if bond_idx >= len(bond_items):
+                continue
+            bond = bond_items[bond_idx]
+            bond.is_in_ring = True
+            if best_ring_size.get(bond_idx, len(atom_items) + 1) > len(atom_ring):
+                bond.ring_center = center
+                best_ring_size[bond_idx] = len(atom_ring)
+                ring_atoms[bond_idx] = tuple(atom_ring)
+    return ring_atoms

--- a/moleditpy/src/moleditpy/ui/preview_molecule.py
+++ b/moleditpy/src/moleditpy/ui/preview_molecule.py
@@ -99,6 +99,7 @@ def build_preview_items(
         atom_items.append(item)
 
     bond_items: List[BondItem] = []
+    seen_pairs: set[Tuple[int, int]] = set()
     for bond in bonds:
         if len(bond) < 2:
             continue
@@ -107,6 +108,10 @@ def build_preview_items(
             continue
         if not (0 <= i < len(atom_items) and 0 <= j < len(atom_items)) or i == j:
             continue
+        # A repeated pair would make RDKit reject the whole preview molecule
+        if (min(i, j), max(i, j)) in seen_pairs:
+            continue
+        seen_pairs.add((min(i, j), max(i, j)))
         order = int(bond[2]) if len(bond) > 2 else 1
         stereo = int(bond[3]) if len(bond) > 3 else 0
         atom1, atom2 = atom_items[i], atom_items[j]

--- a/moleditpy/src/moleditpy/ui/preview_molecule.py
+++ b/moleditpy/src/moleditpy/ui/preview_molecule.py
@@ -59,10 +59,18 @@ def ensure_preview_settings(scene: Any, host: Any = None) -> None:
     """Give a plain QGraphicsScene the get_setting() the preview items call."""
     if hasattr(scene, "get_setting"):
         return
-    if host is not None and hasattr(host, "get_setting"):
-        scene.get_setting = host.get_setting
-    else:
-        scene.get_setting = lambda key, default=None: default
+
+    def get_setting(key: str, default: Any = None) -> Any:
+        if host is None or not hasattr(host, "get_setting"):
+            return default
+        try:
+            # The host outlives the preview normally, but a closed editor would
+            # otherwise raise out of paint()
+            return host.get_setting(key, default)
+        except (AttributeError, RuntimeError, TypeError, ValueError):
+            return default
+
+    scene.get_setting = get_setting
 
 
 def build_preview_items(

--- a/moleditpy/src/moleditpy/ui/template_preview_item.py
+++ b/moleditpy/src/moleditpy/ui/template_preview_item.py
@@ -23,7 +23,6 @@ from PyQt6.QtGui import (
     QPainter,
     QPainterPath,
     QPen,
-    QPolygonF,
 )
 from PyQt6.QtWidgets import QGraphicsItem, QStyleOptionGraphicsItem, QWidget
 
@@ -47,13 +46,6 @@ class TemplatePreviewItem(QGraphicsItem):
     def __init__(self) -> None:
         super().__init__()
         self.setZValue(2)
-        self.pen = QPen(GHOST_COLOR, 2)
-        self.polygon = QPolygonF()
-        self.is_aromatic = False
-        self.user_template_points: List[QPointF] = []
-        self.user_template_bonds: List[Any] = []
-        self.user_template_atoms: List[Any] = []
-        self.is_user_template = False
         self.chain_points: List[QPointF] = []
         self.chain_label = ""
         self.chain_label_pos = QPointF()
@@ -69,21 +61,27 @@ class TemplatePreviewItem(QGraphicsItem):
         self.ring_atoms: Dict[int, Any] = {}
         self.cached_rect = QRectF()
 
-    def set_geometry(self, points: list[QPointF], is_aromatic: bool = False) -> None:
-        """Set polygon points for a standard ring template preview."""
+    def set_geometry(
+        self,
+        points: list[QPointF],
+        is_aromatic: bool = False,
+        bonds_info: Optional[list[Any]] = None,
+    ) -> None:
+        """Set polygon points for a standard ring template preview.
+
+        ``bonds_info`` carries the orders the placement will use; without it the
+        ring falls back to a plain alternation.
+        """
         self.prepareGeometryChange()
-        self.polygon = QPolygonF(points)
-        self.is_aromatic = is_aromatic
-        self.is_user_template = False
         self.is_chain = False
         self.mark_first_atom = False
 
-        # add_molecule_fragment lays aromatic rings out as alternating Kekulé bonds
         n = len(points)
-        bonds_info = [
-            (i, (i + 1) % n, 2 if (is_aromatic and i % 2 == 0) else 1, 0)
-            for i in range(n)
-        ]
+        if bonds_info is None:
+            bonds_info = [
+                (i, (i + 1) % n, 2 if (is_aromatic and i % 2 == 0) else 1)
+                for i in range(n)
+            ]
         self._rebuild_ghost(points, bonds_info, [{"symbol": "C"} for _ in points])
         self.update()
 
@@ -96,10 +94,7 @@ class TemplatePreviewItem(QGraphicsItem):
         self.chain_label = label
         self.chain_label_pos = QPointF(label_pos)
         self.is_chain = True
-        self.is_user_template = False
-        self.is_aromatic = False
         self.mark_first_atom = False
-        self.polygon = QPolygonF()
         self._clear_ghost()
         self.update()
 
@@ -111,13 +106,7 @@ class TemplatePreviewItem(QGraphicsItem):
     ) -> None:
         """Set point and bond data for a user-defined template preview."""
         self.prepareGeometryChange()
-        self.user_template_points = points
-        self.user_template_bonds = bonds_info
-        self.user_template_atoms = atoms_data
-        self.is_user_template = True
         self.is_chain = False
-        self.is_aromatic = False
-        self.polygon = QPolygonF()
         # The first template atom is what a clicked existing atom turns into
         self.mark_first_atom = True
         self._rebuild_ghost(points, bonds_info, atoms_data)
@@ -302,11 +291,7 @@ class TemplatePreviewItem(QGraphicsItem):
             rect = rect.united(atom.boundingRect().translated(atom.pos()))
         for bond in self.ghost_bonds:
             rect = rect.united(bond.boundingRect().translated(bond.pos()))
-        self.cached_rect = (
-            rect.adjusted(-10, -10, 10, 10)
-            if not rect.isNull()
-            else self.polygon.boundingRect().adjusted(-5, -5, 5, 5)
-        )
+        self.cached_rect = rect.adjusted(-10, -10, 10, 10)
 
     def boundingRect(self) -> QRectF:
         """Return the bounding rect encompassing the preview geometry."""
@@ -364,14 +349,6 @@ class TemplatePreviewItem(QGraphicsItem):
         painter.drawRoundedRect(rect, 4, 4)
         painter.setPen(QPen(QColor(40, 40, 40)))
         painter.drawText(rect, Qt.AlignmentFlag.AlignCenter, self.chain_label)
-
-    def paint_regular_template(self, painter: QPainter) -> None:
-        """Paint a ring template; rings and user templates share one renderer."""
-        self.paint_ghost(painter)
-
-    def paint_user_template(self, painter: QPainter) -> None:
-        """Paint a user template; rings and user templates share one renderer."""
-        self.paint_ghost(painter)
 
     def paint_ghost(
         self, painter: QPainter, option: Optional[QStyleOptionGraphicsItem] = None

--- a/moleditpy/src/moleditpy/ui/template_preview_item.py
+++ b/moleditpy/src/moleditpy/ui/template_preview_item.py
@@ -185,7 +185,7 @@ class TemplatePreviewItem(QGraphicsItem):
             atom_data["pos"] = QPointF(point)
             preview_atoms.append(atom_data)
 
-        signature = self._signature(preview_atoms, bonds_info, existing_indices)
+        signature = self._signature(preview_atoms, bonds_info, existing_h_counts)
         self.existing_indices = existing_indices
         self.existing_h_counts = existing_h_counts
         self.replaced_label_path = replaced_label_path
@@ -220,9 +220,14 @@ class TemplatePreviewItem(QGraphicsItem):
     def _signature(
         preview_atoms: List[Dict[str, Any]],
         bonds_info: list[Any],
-        existing_indices: Set[int],
+        existing_h_counts: Dict[int, int],
     ) -> Any:
-        """Identify the ghost molecule, ignoring where the cursor put it."""
+        """Identify the ghost molecule, ignoring where the cursor put it.
+
+        The fused atoms' hydrogen counts belong here: they come from the editor,
+        not from the template, so a ghost reused across cursor moves would keep
+        the label of whichever atom it was fused to before.
+        """
         return (
             tuple(
                 (
@@ -233,7 +238,7 @@ class TemplatePreviewItem(QGraphicsItem):
                 for atom in preview_atoms
             ),
             tuple(tuple(bond) for bond in bonds_info),
-            tuple(sorted(existing_indices)),
+            tuple(sorted(existing_h_counts.items())),
         )
 
     def _move_ghost(self, points: list[QPointF]) -> None:
@@ -395,16 +400,16 @@ class TemplatePreviewItem(QGraphicsItem):
         painter.restore()
 
     def _paint_label_backings(self, painter: QPainter) -> None:
-        """Lay a light backing under the ghost labels and mark the first atom."""
+        """Cover the label the first atom replaces and mark that atom.
+
+        Ghost labels themselves need no backing: the bonds are shortened around
+        them, exactly as in the editor.
+        """
         painter.save()
         painter.setPen(Qt.PenStyle.NoPen)
         painter.setBrush(QBrush(LABEL_BACKING))
         if not self.replaced_label_path.isEmpty():
             painter.drawPath(self.replaced_label_path)
-        for i, atom in enumerate(self.ghost_atoms):
-            if i in self.existing_indices or not atom.is_visible:
-                continue
-            painter.drawPath(atom.get_bg_ellipse_path().translated(atom.pos()))
 
         if self.mark_first_atom and self.ghost_atoms:
             first = self.ghost_atoms[0]

--- a/moleditpy/src/moleditpy/ui/template_preview_item.py
+++ b/moleditpy/src/moleditpy/ui/template_preview_item.py
@@ -161,8 +161,8 @@ class TemplatePreviewItem(QGraphicsItem):
                 replaced_label_path = existing.get_bg_ellipse_path().translated(
                     existing.pos()
                 )
-            elif existing is not None:
-                # A fused vertex keeps the atom already drawn there
+            elif existing is not None and not self.mark_first_atom:
+                # Only rings fuse; a user template's other vertices become new atoms
                 existing_indices.add(i)
                 # Its real H count comes from bonds the ghost molecule cannot see
                 existing_h_counts[i] = getattr(existing, "implicit_h_count", 0)

--- a/moleditpy/src/moleditpy/ui/template_preview_item.py
+++ b/moleditpy/src/moleditpy/ui/template_preview_item.py
@@ -12,13 +12,33 @@ DOI: 10.5281/zenodo.17268532
 
 from __future__ import annotations
 
-from typing import Any, List, Optional
+import math
+from typing import Any, Dict, List, Optional, Set
 
 from PyQt6.QtCore import QLineF, QPointF, QRectF, Qt
-from PyQt6.QtGui import QBrush, QColor, QFont, QPainter, QPen, QPolygonF
+from PyQt6.QtGui import (
+    QBrush,
+    QColor,
+    QFont,
+    QPainter,
+    QPainterPath,
+    QPen,
+    QPolygonF,
+)
 from PyQt6.QtWidgets import QGraphicsItem, QStyleOptionGraphicsItem, QWidget
 
-from ..utils.constants import CPK_COLORS
+from .atom_item import AtomItem
+from .bond_item import BondItem
+from .preview_molecule import PreviewScene, build_preview_items
+
+GHOST_OPACITY = 0.55
+GHOST_COLOR = QColor(80, 80, 80, 180)
+LABEL_BACKING = QColor(255, 255, 255, 240)
+FIRST_ATOM_FILL = QColor(175, 215, 255, 85)
+FIRST_ATOM_BORDER = QColor(140, 195, 245, 120)
+FIRST_ATOM_RADIUS = 15.0
+SNAP_CELL = 4.0
+SNAP_TOLERANCE = 2.0
 
 
 class TemplatePreviewItem(QGraphicsItem):
@@ -27,7 +47,7 @@ class TemplatePreviewItem(QGraphicsItem):
     def __init__(self) -> None:
         super().__init__()
         self.setZValue(2)
-        self.pen = QPen(QColor(80, 80, 80, 180), 2)
+        self.pen = QPen(GHOST_COLOR, 2)
         self.polygon = QPolygonF()
         self.is_aromatic = False
         self.user_template_points: List[QPointF] = []
@@ -38,6 +58,16 @@ class TemplatePreviewItem(QGraphicsItem):
         self.chain_label = ""
         self.chain_label_pos = QPointF()
         self.is_chain = False
+        self.ghost_scene = PreviewScene()
+        self.ghost_atoms: List[AtomItem] = []
+        self.ghost_bonds: List[BondItem] = []
+        self.existing_indices: Set[int] = set()
+        self.existing_h_counts: Dict[int, int] = {}
+        self.replaced_label_path = QPainterPath()
+        self.mark_first_atom = False
+        self.ghost_signature: Any = None
+        self.ring_atoms: Dict[int, Any] = {}
+        self.cached_rect = QRectF()
 
     def set_geometry(self, points: list[QPointF], is_aromatic: bool = False) -> None:
         """Set polygon points for a standard ring template preview."""
@@ -46,6 +76,15 @@ class TemplatePreviewItem(QGraphicsItem):
         self.is_aromatic = is_aromatic
         self.is_user_template = False
         self.is_chain = False
+        self.mark_first_atom = False
+
+        # add_molecule_fragment lays aromatic rings out as alternating Kekulé bonds
+        n = len(points)
+        bonds_info = [
+            (i, (i + 1) % n, 2 if (is_aromatic and i % 2 == 0) else 1, 0)
+            for i in range(n)
+        ]
+        self._rebuild_ghost(points, bonds_info, [{"symbol": "C"} for _ in points])
         self.update()
 
     def set_chain_geometry(
@@ -59,7 +98,9 @@ class TemplatePreviewItem(QGraphicsItem):
         self.is_chain = True
         self.is_user_template = False
         self.is_aromatic = False
+        self.mark_first_atom = False
         self.polygon = QPolygonF()
+        self._clear_ghost()
         self.update()
 
     def set_user_template_geometry(
@@ -77,7 +118,190 @@ class TemplatePreviewItem(QGraphicsItem):
         self.is_chain = False
         self.is_aromatic = False
         self.polygon = QPolygonF()
+        # The first template atom is what a clicked existing atom turns into
+        self.mark_first_atom = True
+        self._rebuild_ghost(points, bonds_info, atoms_data)
         self.update()
+
+    # ------------------------------------------------------------------
+    # Ghost molecule: real AtomItem/BondItem instances, off-scene
+    # ------------------------------------------------------------------
+
+    def _clear_ghost_items(self) -> None:
+        """Drop the ghost atom and bond items."""
+        for item in list(self.ghost_scene.items()):
+            self.ghost_scene.removeItem(item)
+        self.ghost_atoms = []
+        self.ghost_bonds = []
+        self.ring_atoms = {}
+        self.ghost_signature = None
+        self.cached_rect = QRectF()
+
+    def _clear_ghost(self) -> None:
+        """Drop the ghost molecule and everything derived from the editor scene."""
+        self._clear_ghost_items()
+        self.existing_indices = set()
+        self.existing_h_counts = {}
+        self.replaced_label_path = QPainterPath()
+
+    def _rebuild_ghost(
+        self,
+        points: list[QPointF],
+        bonds_info: list[Any],
+        atoms_data: list[dict[str, Any]],
+    ) -> None:
+        """Rebuild the preview as real atom/bond items so it renders like the result."""
+        self.ghost_scene.host = self.scene()
+        if not points:
+            self._clear_ghost()
+            return
+
+        existing_indices: Set[int] = set()
+        existing_h_counts: Dict[int, int] = {}
+        replaced_label_path = QPainterPath()
+        preview_atoms: List[Dict[str, Any]] = []
+        occupied = self._occupied_cells()
+        for i, point in enumerate(points):
+            atom_data: Dict[str, Any] = (
+                dict(atoms_data[i]) if i < len(atoms_data) else {"symbol": "C"}
+            )
+            existing = self._existing_atom_at(point, occupied)
+            replaces_existing = i == 0 and self.mark_first_atom
+            if existing is not None and replaces_existing:
+                # Its label has to be covered, or the ghost reads as "N over OH"
+                replaced_label_path = existing.get_bg_ellipse_path().translated(
+                    existing.pos()
+                )
+            elif existing is not None:
+                # A fused vertex keeps the atom already drawn there
+                existing_indices.add(i)
+                # Its real H count comes from bonds the ghost molecule cannot see
+                existing_h_counts[i] = getattr(existing, "implicit_h_count", 0)
+                atom_data = {
+                    "symbol": existing.symbol,
+                    "charge": existing.charge,
+                    "radical": existing.radical,
+                }
+            atom_data["pos"] = QPointF(point)
+            preview_atoms.append(atom_data)
+
+        signature = self._signature(preview_atoms, bonds_info, existing_indices)
+        self.existing_indices = existing_indices
+        self.existing_h_counts = existing_h_counts
+        self.replaced_label_path = replaced_label_path
+
+        if signature == self.ghost_signature:
+            # Same molecule, new cursor position: moving it beats rebuilding it
+            self._move_ghost(points)
+            self._refresh_bounding_rect()
+            self.prepareGeometryChange()
+            return
+
+        self._clear_ghost_items()
+        self.ghost_atoms, self.ghost_bonds, self.ring_atoms = build_preview_items(
+            preview_atoms, bonds_info
+        )
+        self.ghost_signature = signature
+        for item in self.ghost_bonds:
+            self.ghost_scene.addItem(item)
+        for atom in self.ghost_atoms:
+            self.ghost_scene.addItem(atom)
+
+        for index, h_count in existing_h_counts.items():
+            if index < len(self.ghost_atoms):
+                self.ghost_atoms[index].implicit_h_count = h_count
+                self.ghost_atoms[index].update_style()
+
+        self._refresh_bounding_rect()
+        # find_atom_near() above made the scene cache an empty boundingRect
+        self.prepareGeometryChange()
+
+    @staticmethod
+    def _signature(
+        preview_atoms: List[Dict[str, Any]],
+        bonds_info: list[Any],
+        existing_indices: Set[int],
+    ) -> Any:
+        """Identify the ghost molecule, ignoring where the cursor put it."""
+        return (
+            tuple(
+                (
+                    atom.get("symbol", "C"),
+                    atom.get("charge", 0),
+                    atom.get("radical", 0),
+                )
+                for atom in preview_atoms
+            ),
+            tuple(tuple(bond) for bond in bonds_info),
+            tuple(sorted(existing_indices)),
+        )
+
+    def _move_ghost(self, points: list[QPointF]) -> None:
+        """Move an unchanged ghost molecule to the new cursor position."""
+        for atom, point in zip(self.ghost_atoms, points):
+            atom.setPos(point)
+        for bond in self.ghost_bonds:
+            bond.update_position()
+        for bond_index, ring in self.ring_atoms.items():
+            positions = [self.ghost_atoms[i].pos() for i in ring]
+            self.ghost_bonds[bond_index].ring_center = (
+                sum(p.x() for p in positions) / len(positions),
+                sum(p.y() for p in positions) / len(positions),
+            )
+
+    def _occupied_cells(self) -> Dict[Any, List[AtomItem]]:
+        """Bucket the editor's atoms by position.
+
+        One pass per preview update; asking the scene per template atom instead
+        makes every vertex of a big template re-walk the whole scene.
+        """
+        scene: Any = self.scene()
+        atom_items = getattr(scene, "atom_items", None)
+        if not atom_items:
+            return {}
+        cells: Dict[Any, List[AtomItem]] = {}
+        for atom in atom_items.values():
+            try:
+                pos = atom.pos()
+            except (AttributeError, RuntimeError, TypeError):
+                continue
+            key = (int(pos.x() // SNAP_CELL), int(pos.y() // SNAP_CELL))
+            cells.setdefault(key, []).append(atom)
+        return cells
+
+    @staticmethod
+    def _existing_atom_at(
+        point: QPointF, cells: Dict[Any, List[AtomItem]]
+    ) -> Optional[AtomItem]:
+        """Return the editor atom sitting on point, if the preview snapped onto one."""
+        cell_x, cell_y = int(point.x() // SNAP_CELL), int(point.y() // SNAP_CELL)
+        best: Optional[AtomItem] = None
+        best_distance = SNAP_TOLERANCE
+        for dx in (-1, 0, 1):
+            for dy in (-1, 0, 1):
+                for atom in cells.get((cell_x + dx, cell_y + dy), ()):
+                    pos = atom.pos()
+                    distance = math.hypot(pos.x() - point.x(), pos.y() - point.y())
+                    if distance <= best_distance:
+                        best, best_distance = atom, distance
+        return best
+
+    # ------------------------------------------------------------------
+    # Painting
+    # ------------------------------------------------------------------
+
+    def _refresh_bounding_rect(self) -> None:
+        """Recompute the cached rect; Qt asks for it far too often to do it live."""
+        rect = QRectF()
+        for atom in self.ghost_atoms:
+            rect = rect.united(atom.boundingRect().translated(atom.pos()))
+        for bond in self.ghost_bonds:
+            rect = rect.united(bond.boundingRect().translated(bond.pos()))
+        self.cached_rect = (
+            rect.adjusted(-10, -10, 10, 10)
+            if not rect.isNull()
+            else self.polygon.boundingRect().adjusted(-5, -5, 5, 5)
+        )
 
     def boundingRect(self) -> QRectF:
         """Return the bounding rect encompassing the preview geometry."""
@@ -90,16 +314,7 @@ class TemplatePreviewItem(QGraphicsItem):
                 max(xs) - min(xs) + 90,
                 max(ys) - min(ys) + 40,
             )
-        if self.is_user_template and self.user_template_points:
-            # Calculate bounding rect for user template
-            min_x = min(p.x() for p in self.user_template_points)
-            max_x = max(p.x() for p in self.user_template_points)
-            min_y = min(p.y() for p in self.user_template_points)
-            max_y = max(p.y() for p in self.user_template_points)
-            return QRectF(
-                min_x - 20, min_y - 20, max_x - min_x + 40, max_y - min_y + 40
-            )
-        return self.polygon.boundingRect().adjusted(-5, -5, 5, 5)
+        return QRectF(self.cached_rect)
 
     def paint(
         self,
@@ -107,22 +322,20 @@ class TemplatePreviewItem(QGraphicsItem):
         option: Optional[QStyleOptionGraphicsItem],
         widget: Optional[QWidget] = None,
     ) -> None:
-        """Dispatch to the regular or user-template painter."""
+        """Dispatch to the chain or ghost-molecule painter."""
         if painter is None:
             return
         if self.is_chain:
             self.paint_chain(painter)
-        elif self.is_user_template:
-            self.paint_user_template(painter)
         else:
-            self.paint_regular_template(painter)
+            self.paint_ghost(painter, option)
 
     def paint_chain(self, painter: QPainter) -> None:
         """Paint the ghost zigzag chain plus the repeat count next to the cursor."""
         if len(self.chain_points) < 2:
             return
 
-        painter.setPen(QPen(QColor(80, 80, 80, 180), 2.5))
+        painter.setPen(QPen(GHOST_COLOR, 2.5))
         painter.setBrush(Qt.BrushStyle.NoBrush)
         for i in range(len(self.chain_points) - 1):
             painter.drawLine(QLineF(self.chain_points[i], self.chain_points[i + 1]))
@@ -141,111 +354,71 @@ class TemplatePreviewItem(QGraphicsItem):
         rect = QRectF(metrics.boundingRect(self.chain_label))
         rect.moveTopLeft(self.chain_label_pos)
         rect = rect.adjusted(-5, -3, 5, 3)
-        painter.setPen(QPen(QColor(80, 80, 80, 180), 1))
+        painter.setPen(QPen(GHOST_COLOR, 1))
         painter.setBrush(QBrush(QColor(255, 255, 255, 225)))
         painter.drawRoundedRect(rect, 4, 4)
         painter.setPen(QPen(QColor(40, 40, 40)))
         painter.drawText(rect, Qt.AlignmentFlag.AlignCenter, self.chain_label)
 
     def paint_regular_template(self, painter: QPainter) -> None:
-        """Paint a standard ring or aromatic template as a polygon outline."""
-        painter.setPen(self.pen)
-        painter.setBrush(Qt.BrushStyle.NoBrush)
-        if not self.polygon.isEmpty():
-            painter.drawPolygon(self.polygon)
-            if self.is_aromatic:
-                center = self.polygon.boundingRect().center()
-                radius = QLineF(center, self.polygon.first()).length() * 0.6
-                painter.drawEllipse(center, radius, radius)
+        """Paint a ring template; rings and user templates share one renderer."""
+        self.paint_ghost(painter)
 
     def paint_user_template(self, painter: QPainter) -> None:
-        """Paint bonds and atom symbols for a user-defined template preview."""
-        if not self.user_template_points:
+        """Paint a user template; rings and user templates share one renderer."""
+        self.paint_ghost(painter)
+
+    def paint_ghost(
+        self, painter: QPainter, option: Optional[QStyleOptionGraphicsItem] = None
+    ) -> None:
+        """Paint the ghost molecule using the real atom and bond renderers."""
+        if not self.ghost_atoms:
             return
 
-        # Draw bonds first with better visibility
-        # Use gray (ghost) color for template preview to distinguish from real bonds
-        bond_pen = QPen(QColor(80, 80, 80, 180), 2.5)
-        painter.setPen(bond_pen)
+        self._paint_label_backings(painter)
 
-        for bond_info in self.user_template_bonds:
-            if len(bond_info) >= 3:
-                atom1_idx, atom2_idx, order = bond_info[:3]
+        painter.save()
+        painter.setOpacity(GHOST_OPACITY)
+        for bond in self.ghost_bonds:
+            painter.save()
+            painter.translate(bond.pos())
+            bond.paint(painter, option)  # type: ignore[arg-type]
+            painter.restore()
+        for i, atom in enumerate(self.ghost_atoms):
+            if i in self.existing_indices:
+                # Already drawn by the editor itself; do not double-paint it
+                continue
+            painter.save()
+            painter.translate(atom.pos())
+            atom.paint(painter, option)  # type: ignore[arg-type]
+            painter.restore()
+        painter.restore()
+
+    def _paint_label_backings(self, painter: QPainter) -> None:
+        """Lay a light backing under the ghost labels and mark the first atom."""
+        painter.save()
+        painter.setPen(Qt.PenStyle.NoPen)
+        painter.setBrush(QBrush(LABEL_BACKING))
+        if not self.replaced_label_path.isEmpty():
+            painter.drawPath(self.replaced_label_path)
+        for i, atom in enumerate(self.ghost_atoms):
+            if i in self.existing_indices or not atom.is_visible:
+                continue
+            painter.drawPath(atom.get_bg_ellipse_path().translated(atom.pos()))
+
+        if self.mark_first_atom and self.ghost_atoms:
+            first = self.ghost_atoms[0]
+            path = first.get_bg_ellipse_path()
+            if path.isEmpty():
+                rect = QRectF(
+                    -FIRST_ATOM_RADIUS,
+                    -FIRST_ATOM_RADIUS,
+                    FIRST_ATOM_RADIUS * 2,
+                    FIRST_ATOM_RADIUS * 2,
+                )
             else:
-                atom1_idx, atom2_idx = bond_info[:2]
-                order = 1
-
-            if atom1_idx < len(self.user_template_points) and atom2_idx < len(
-                self.user_template_points
-            ):
-                pos1 = self.user_template_points[atom1_idx]
-                pos2 = self.user_template_points[atom2_idx]
-
-                if order == 2:
-                    # Double bond - draw two parallel lines
-                    line = QLineF(pos1, pos2)
-                    normal = line.normalVector()
-                    normal.setLength(4)
-
-                    line1 = QLineF(
-                        pos1 + normal.p2() - normal.p1(),
-                        pos2 + normal.p2() - normal.p1(),
-                    )
-                    line2 = QLineF(
-                        pos1 - normal.p2() + normal.p1(),
-                        pos2 - normal.p2() + normal.p1(),
-                    )
-
-                    painter.drawLine(line1)
-                    painter.drawLine(line2)
-                elif order == 3:
-                    # Triple bond - draw three parallel lines
-                    line = QLineF(pos1, pos2)
-                    normal = line.normalVector()
-                    normal.setLength(6)
-
-                    painter.drawLine(line)
-                    line1 = QLineF(
-                        pos1 + normal.p2() - normal.p1(),
-                        pos2 + normal.p2() - normal.p1(),
-                    )
-                    line2 = QLineF(
-                        pos1 - normal.p2() + normal.p1(),
-                        pos2 - normal.p2() + normal.p1(),
-                    )
-
-                    painter.drawLine(line1)
-                    painter.drawLine(line2)
-                else:
-                    # Single bond
-                    painter.drawLine(QLineF(pos1, pos2))
-
-        # Draw atoms - white ellipse background to hide bonds, then CPK colored text
-        for i, pos in enumerate(self.user_template_points):
-            if i < len(self.user_template_atoms):
-                atom_data = self.user_template_atoms[i]
-                symbol = atom_data.get("symbol", "C")
-
-                # Draw all non-carbon atoms including hydrogen with white background ellipse + CPK colored text
-                if symbol != "C":
-                    # Get CPK color for text
-                    color = CPK_COLORS.get(
-                        symbol, CPK_COLORS.get("DEFAULT", QColor("#FF1493"))
-                    )
-
-                    # Draw white background ellipse to hide bonds
-                    painter.setPen(QPen(Qt.GlobalColor.white, 0))  # No border
-                    painter.setBrush(QBrush(Qt.GlobalColor.white))
-                    painter.drawEllipse(int(pos.x() - 12), int(pos.y() - 8), 24, 16)
-
-                    # Draw CPK colored text on top
-                    painter.setPen(QPen(color))
-                    font = QFont("Arial", 12, QFont.Weight.Bold)  # Larger font
-                    painter.setFont(font)
-                    metrics = painter.fontMetrics()
-                    text_rect = metrics.boundingRect(symbol)
-                    text_pos = QPointF(
-                        pos.x() - text_rect.width() / 2,
-                        pos.y() + text_rect.height() / 3,
-                    )
-                    painter.drawText(text_pos, symbol)
+                rect = path.boundingRect().adjusted(-3, -3, 3, 3)
+            painter.setPen(QPen(FIRST_ATOM_BORDER, 1.5))
+            painter.setBrush(QBrush(FIRST_ATOM_FILL))
+            painter.drawEllipse(rect.translated(first.pos()))
+        painter.restore()

--- a/moleditpy/src/moleditpy/ui/template_preview_view.py
+++ b/moleditpy/src/moleditpy/ui/template_preview_view.py
@@ -68,14 +68,14 @@ class TemplatePreviewView(QGraphicsView):
             self.parent_dialog.draw_template_preview(
                 self.scene(), self.template_data, view_size
             )
-            bounding_rect = self.scene().itemsBoundingRect()
+            bounding_rect = self.scene().sceneRect()
             if (
                 not bounding_rect.isEmpty()
                 and bounding_rect.width() > 0
                 and bounding_rect.height() > 0
             ):
                 content_size = max(bounding_rect.width(), bounding_rect.height())
-                padding = max(20, content_size * 0.2)
+                padding = max(6, content_size * 0.05)
                 padded_rect = bounding_rect.adjusted(
                     -padding, -padding, padding, padding
                 )

--- a/moleditpy/src/moleditpy/ui/ui_manager.py
+++ b/moleditpy/src/moleditpy/ui/ui_manager.py
@@ -76,6 +76,9 @@ class UIManager(QObject):
         elif not mode_str.startswith("template"):
             self.host.init_manager.scene.template_preview.hide()
 
+        if not mode_str.startswith("template_user"):
+            self._clear_template_dialog_selection()
+
         # Set cursor shape
         if mode_str == "select":
             self.host.init_manager.view_2d.setCursor(Qt.CursorShape.ArrowCursor)
@@ -142,6 +145,16 @@ class UIManager(QObject):
                 QGraphicsView.DragMode.RubberBandDrag
             )
             self.host.set_scene_bond_properties(1, 0)
+
+    def _clear_template_dialog_selection(self) -> None:
+        """Drop the template dialog's highlight once another mode takes over."""
+        dialog = getattr(self.host, "template_dialog", None)
+        if dialog is None:
+            return
+        try:
+            dialog.clear_selection()
+        except (AttributeError, RuntimeError):
+            logging.debug("Template dialog selection not cleared", exc_info=True)
 
     def set_mode_and_update_toolbar(self, mode_str: str) -> None:
         """Switch mode and synchronize the active toolbar button highlight."""

--- a/moleditpy/src/moleditpy/ui/ui_manager.py
+++ b/moleditpy/src/moleditpy/ui/ui_manager.py
@@ -159,11 +159,14 @@ class UIManager(QObject):
     def set_mode_and_update_toolbar(self, mode_str: str) -> None:
         """Switch mode and synchronize the active toolbar button highlight."""
         self.set_mode(mode_str)
-        # Map QAction to QToolButton
-        toolbar = getattr(self.host.init_manager, "toolbar", None)
+        # Map QAction to QToolButton. The templates live on the second toolbar,
+        # so looking at the main one alone never finds them.
         action_to_button = {}
-        if toolbar:
-            for key, action in self.host.init_manager.mode_actions.items():
+        for name in ("toolbar", "toolbar_bottom"):
+            toolbar = getattr(self.host.init_manager, name, None)
+            if not toolbar:
+                continue
+            for action in self.host.init_manager.mode_actions.values():
                 btn = toolbar.widgetForAction(action)
                 if btn:
                     action_to_button[action] = btn

--- a/moleditpy/src/moleditpy/ui/ui_manager.py
+++ b/moleditpy/src/moleditpy/ui/ui_manager.py
@@ -159,44 +159,18 @@ class UIManager(QObject):
     def set_mode_and_update_toolbar(self, mode_str: str) -> None:
         """Switch mode and synchronize the active toolbar button highlight."""
         self.set_mode(mode_str)
-        # Map QAction to QToolButton. The templates live on the second toolbar,
-        # so looking at the main one alone never finds them.
-        action_to_button = {}
-        for name in ("toolbar", "toolbar_bottom"):
-            toolbar = getattr(self.host.init_manager, name, None)
-            if not toolbar:
-                continue
-            for action in self.host.init_manager.mode_actions.values():
-                btn = toolbar.widgetForAction(action)
-                if btn:
-                    action_to_button[action] = btn
-
-        # Reset all mode buttons
-        for key, action in self.host.init_manager.mode_actions.items():
+        for action in self.host.init_manager.mode_actions.values():
             action.setChecked(False)
-            btn = action_to_button.get(action)
-            if btn:
-                btn.setStyleSheet("")
 
-        # Apply style to matching mode buttons (exact match or prefix for user templates)
+        # Exact match, or the one USER button standing for every user template
         matched_key = None
         if mode_str in self.host.init_manager.mode_actions:
             matched_key = mode_str
         elif mode_str.startswith("template_user"):
             matched_key = "template_user"
 
-        if matched_key and matched_key in self.host.init_manager.mode_actions:
-            action = self.host.init_manager.mode_actions[matched_key]
-            action.setChecked(True)
-            btn = action_to_button.get(action)
-            if btn:
-                # Highlight templates with specific color
-                if mode_str.startswith("template"):
-                    btn.setStyleSheet(
-                        "background-color: #2196F3; color: white; border-radius: 4px;"
-                    )
-                else:
-                    btn.setStyleSheet("")
+        if matched_key:
+            self.host.init_manager.mode_actions[matched_key].setChecked(True)
 
     def activate_select_mode(self) -> None:
         """Switch to selection mode and check the select toolbar button."""

--- a/moleditpy/src/moleditpy/ui/ui_manager.py
+++ b/moleditpy/src/moleditpy/ui/ui_manager.py
@@ -169,8 +169,9 @@ class UIManager(QObject):
         elif mode_str.startswith("template_user"):
             matched_key = "template_user"
 
-        if matched_key:
-            self.host.init_manager.mode_actions[matched_key].setChecked(True)
+        matched = self.host.init_manager.mode_actions.get(matched_key)
+        if matched is not None:
+            matched.setChecked(True)
 
     def activate_select_mode(self) -> None:
         """Switch to selection mode and check the select toolbar button."""

--- a/moleditpy/src/moleditpy/ui/user_template_dialog.py
+++ b/moleditpy/src/moleditpy/ui/user_template_dialog.py
@@ -345,7 +345,7 @@ class UserTemplateDialog(QDialog):
         """Return the editor scene, so thumbnails follow the user's 2D settings."""
         try:
             scene = self.main_window.init_manager.scene
-        except AttributeError:
+        except (AttributeError, RuntimeError):
             return None
         # A stand-in main window would answer get_setting() with junk sizes
         return scene if isinstance(scene, QGraphicsScene) else None

--- a/moleditpy/src/moleditpy/ui/user_template_dialog.py
+++ b/moleditpy/src/moleditpy/ui/user_template_dialog.py
@@ -411,28 +411,9 @@ class UserTemplateDialog(QDialog):
             self.main_window.init_manager.scene.user_template_data = template_data
 
         try:
-            # Uncheck all mode actions first
-            if hasattr(self.main_window, "mode_actions") and isinstance(
-                self.main_window.init_manager.mode_actions, dict
-            ):
-                for act in self.main_window.init_manager.mode_actions.values():
-                    act.setChecked(False)
-
-            # Switch mode via UIManager
-            if hasattr(self.main_window, "ui_manager") and hasattr(
-                self.main_window.ui_manager, "set_mode"
-            ):
-                self.main_window.ui_manager.set_mode(mode_name)
-
+            # Goes through the toolbar so the USER button shows the active mode
+            self.main_window.ui_manager.set_mode_and_update_toolbar(mode_name)
             self.main_window.statusBar().showMessage(f"Template mode: {template_name}")
-
-            # Check the matching action if present
-            if (
-                hasattr(self.main_window, "mode_actions")
-                and mode_name in self.main_window.init_manager.mode_actions
-            ):
-                self.main_window.init_manager.mode_actions[mode_name].setChecked(True)
-
         except (AttributeError, RuntimeError, ValueError) as e:
             logging.warning(f"Failed to switch main window to template mode: {e}")
 

--- a/moleditpy/src/moleditpy/ui/user_template_dialog.py
+++ b/moleditpy/src/moleditpy/ui/user_template_dialog.py
@@ -12,8 +12,8 @@ DOI: 10.5281/zenodo.17268532
 
 from typing import Any, List
 
-from PyQt6.QtCore import QDateTime, QLineF, QPointF, QRectF, Qt, QTimer
-from PyQt6.QtGui import QBrush, QColor, QFont, QPainter, QPen
+from PyQt6.QtCore import QDateTime, QPointF, QRectF, Qt, QTimer
+from PyQt6.QtGui import QColor, QFont, QPainter
 from PyQt6.QtWidgets import (
     QDialog,
     QGraphicsScene,
@@ -28,9 +28,14 @@ from PyQt6.QtWidgets import (
     QWidget,
 )
 
+from .preview_molecule import (
+    build_preview_items,
+    ensure_preview_settings,
+    preview_content_rect,
+)
 from .template_preview_view import TemplatePreviewView
 
-from ..utils.constants import CPK_COLORS, VERSION
+from ..utils.constants import VERSION
 import json
 import logging
 import os
@@ -283,15 +288,14 @@ class UserTemplateDialog(QDialog):
         self.draw_template_preview(preview_scene, template_data, view_size)
 
         # Improved fitting approach with better error handling
-        bounding_rect = preview_scene.itemsBoundingRect()
+        bounding_rect = preview_scene.sceneRect()
         if (
             not bounding_rect.isEmpty()
             and bounding_rect.width() > 0
             and bounding_rect.height() > 0
         ):
-            # Calculate appropriate padding based on content size
             content_size = max(bounding_rect.width(), bounding_rect.height())
-            padding = max(20, content_size * 0.2)  # At least 20 units or 20% of content
+            padding = max(6, content_size * 0.05)
 
             padded_rect = bounding_rect.adjusted(-padding, -padding, padding, padding)
             preview_scene.setSceneRect(padded_rect)
@@ -337,186 +341,62 @@ class UserTemplateDialog(QDialog):
         except (AttributeError, RuntimeError, ValueError) as e:
             logging.warning(f"Warning: Failed to fit preview view: {e}")
 
+    def _editor_scene(self) -> Any:
+        """Return the editor scene, so thumbnails follow the user's 2D settings."""
+        try:
+            scene = self.main_window.init_manager.scene
+        except AttributeError:
+            return None
+        # A stand-in main window would answer get_setting() with junk sizes
+        return scene if isinstance(scene, QGraphicsScene) else None
+
     def draw_template_preview(
-        self, scene: Any, template_data: Any, view_size: Any = None
+        self,
+        scene: Any,
+        template_data: Any,
+        view_size: Any = None,  # pylint: disable=unused-argument
     ) -> None:
-        """Draw the molecular structure in the preview scene with dynamic scaling."""
+        """Draw the template into the preview scene using the editor's own items.
+
+        ``view_size`` is kept for callers; the items are sized like the editor's
+        and the view's fitInView does the scaling.
+        """
         atoms = template_data.get("atoms", [])
         bonds = template_data.get("bonds", [])
+        ensure_preview_settings(scene, self._editor_scene())
 
         if not atoms:
-            # Add placeholder text when no atoms
             text = scene.addText("No structure", QFont("Arial", 12))
             text.setDefaultTextColor(QColor("gray"))
             return
 
-        # Calculate molecular dimensions
-        positions = [QPointF(atom["x"], atom["y"]) for atom in atoms]
-        min_x = min(pos.x() for pos in positions)
-        max_x = max(pos.x() for pos in positions)
-        min_y = min(pos.y() for pos in positions)
-        max_y = max(pos.y() for pos in positions)
-
-        mol_width = max_x - min_x
-        mol_height = max_y - min_y
-        mol_size = max(mol_width, mol_height)
-
-        # Calculate fit scale factor (how much fitInView will shrink the content)
-        if view_size is None:
-            view_size = (160, 140)  # Default preview view size
-
-        view_width, view_height = view_size
-
-        if mol_size > 0 and mol_width > 0 and mol_height > 0:
-            # Calculate the padding that will be added
-            padding = max(20, mol_size * 0.2)
-            padded_width = mol_width + 2 * padding
-            padded_height = mol_height + 2 * padding
-
-            # Calculate how much fitInView will scale down the content
-            # fitInView fits the padded rectangle into the view while maintaining aspect ratio
-            fit_scale_x = view_width / padded_width
-            fit_scale_y = view_height / padded_height
-            fit_scale = min(
-                fit_scale_x, fit_scale_y
-            )  # fitInView uses the smaller scale
-
-            # Compensate for the fit scaling to maintain visual thickness
-            # When fit_scale is small (content heavily shrunk), we need thicker lines/fonts
-            if fit_scale > 0:
-                scale_factor = max(0.4, min(4.0, 1.0 / fit_scale))
-            else:
-                scale_factor = 4.0
-
-            # Debug info (can be removed in production)
-            # logging.debug(f"Mol size: {mol_size:.1f}, Fit scale: {fit_scale:.3f}, Scale factor: {scale_factor:.2f}")
-        else:
-            scale_factor = 1.0
-
-        # Base sizes that look good at 1:1 scale
-        base_bond_width = 1.8
-        base_font_size = 11
-        base_ellipse_width = 18
-        base_ellipse_height = 14
-        base_double_bond_offset = 3.5
-        base_triple_bond_offset = 2.5
-
-        # Apply inverse fit scaling to maintain visual consistency
-        bond_width = max(1.0, min(8.0, base_bond_width * scale_factor))
-        font_size = max(8, min(24, int(base_font_size * scale_factor)))
-        ellipse_width = max(10, min(40, base_ellipse_width * scale_factor))
-        ellipse_height = max(8, min(30, base_ellipse_height * scale_factor))
-        double_bond_offset = max(2.0, min(10.0, base_double_bond_offset * scale_factor))
-        triple_bond_offset = max(1.5, min(8.0, base_triple_bond_offset * scale_factor))
-
-        # Create atom ID to index mapping for bond drawing
-        atom_id_to_index = {}
-        for i, atom in enumerate(atoms):
-            atom_id = atom.get("id", i)  # Use id if available, otherwise use index
-            atom_id_to_index[atom_id] = i
-
-        # Draw bonds first using original coordinates with dynamic sizing
+        index_of_id = {atom.get("id", i): i for i, atom in enumerate(atoms)}
+        preview_atoms = [
+            {
+                "symbol": atom.get("symbol", "C"),
+                "charge": atom.get("charge", 0),
+                "radical": atom.get("radical", 0),
+                "pos": QPointF(atom["x"], atom["y"]),
+            }
+            for atom in atoms
+        ]
+        preview_bonds = []
         for bond in bonds:
-            atom1_id, atom2_id = bond["atom1"], bond["atom2"]
-
-            # Get atom indices from IDs
-            atom1_idx = atom_id_to_index.get(atom1_id)
-            atom2_idx = atom_id_to_index.get(atom2_id)
-
-            if (
-                atom1_idx is not None
-                and atom2_idx is not None
-                and atom1_idx < len(atoms)
-                and atom2_idx < len(atoms)
-            ):
-                pos1 = QPointF(atoms[atom1_idx]["x"], atoms[atom1_idx]["y"])
-                pos2 = QPointF(atoms[atom2_idx]["x"], atoms[atom2_idx]["y"])
-
-                # Draw bonds with proper order - dynamic thickness
-                bond_order = bond.get("order", 1)
-                pen = QPen(QColor("black"), bond_width)
-
-                if bond_order == 2:
-                    # Double bond - draw two parallel lines
-                    line = QLineF(pos1, pos2)
-                    if line.length() > 0:
-                        normal = line.normalVector()
-                        normal.setLength(double_bond_offset)
-
-                        line1 = QLineF(
-                            pos1 + normal.p2() - normal.p1(),
-                            pos2 + normal.p2() - normal.p1(),
-                        )
-                        line2 = QLineF(
-                            pos1 - normal.p2() + normal.p1(),
-                            pos2 - normal.p2() + normal.p1(),
-                        )
-
-                        scene.addLine(line1, pen)
-                        scene.addLine(line2, pen)
-                    else:
-                        scene.addLine(line, pen)
-                elif bond_order == 3:
-                    # Triple bond - draw three parallel lines
-                    line = QLineF(pos1, pos2)
-                    if line.length() > 0:
-                        normal = line.normalVector()
-                        normal.setLength(triple_bond_offset)
-
-                        # Center line
-                        scene.addLine(line, pen)
-                        # Side lines
-                        line1 = QLineF(
-                            pos1 + normal.p2() - normal.p1(),
-                            pos2 + normal.p2() - normal.p1(),
-                        )
-                        line2 = QLineF(
-                            pos1 - normal.p2() + normal.p1(),
-                            pos2 - normal.p2() + normal.p1(),
-                        )
-
-                        scene.addLine(line1, pen)
-                        scene.addLine(line2, pen)
-                    else:
-                        scene.addLine(line, pen)
-                else:
-                    # Single bond
-                    scene.addLine(QLineF(pos1, pos2), pen)
-
-        # Draw only non-carbon atom labels with dynamic sizing
-        for i, atom in enumerate(atoms):
-            try:
-                pos = QPointF(atom["x"], atom["y"])
-                symbol = atom.get("symbol", "C")
-
-                # Draw atoms - white ellipse background to hide bonds, then CPK colored text
-                if symbol != "C":
-                    # All non-carbon atoms including hydrogen: white background ellipse + CPK colored text
-                    color = CPK_COLORS.get(
-                        symbol, CPK_COLORS.get("DEFAULT", QColor("#FF1493"))
-                    )
-
-                    # Add white background ellipse to hide bonds - dynamic size
-                    pen = QPen(Qt.GlobalColor.white, 0)  # No border
-                    brush = QBrush(Qt.GlobalColor.white)
-                    ellipse_x = pos.x() - ellipse_width / 2
-                    ellipse_y = pos.y() - ellipse_height / 2
-                    scene.addEllipse(
-                        ellipse_x, ellipse_y, ellipse_width, ellipse_height, pen, brush
-                    )
-
-                    # Add CPK colored text label on top - dynamic font size
-                    font = QFont("Arial", font_size, QFont.Weight.Bold)
-                    text = scene.addText(symbol, font)
-                    text.setDefaultTextColor(color)  # CPK colored text
-                    text_rect = text.boundingRect()
-                    text.setPos(
-                        pos.x() - text_rect.width() / 2,
-                        pos.y() - text_rect.height() / 2,
-                    )
-
-            except (AttributeError, RuntimeError, ValueError, TypeError):
+            atom1_idx = index_of_id.get(bond.get("atom1"))
+            atom2_idx = index_of_id.get(bond.get("atom2"))
+            if atom1_idx is None or atom2_idx is None:
                 continue
+            preview_bonds.append(
+                (atom1_idx, atom2_idx, bond.get("order", 1), bond.get("stereo", 0))
+            )
+
+        atom_items, bond_items, _ = build_preview_items(preview_atoms, preview_bonds)
+        for bond_item in bond_items:
+            scene.addItem(bond_item)
+        for atom_item in atom_items:
+            scene.addItem(atom_item)
+        # The item bounding rects carry hit padding; fit to what is drawn instead
+        scene.setSceneRect(preview_content_rect(atom_items, bond_items))
 
     def _activate_template_mode(self, template_data: Any) -> None:
         """Switch the main window into template placement mode for the given template."""

--- a/moleditpy/src/moleditpy/ui/user_template_dialog.py
+++ b/moleditpy/src/moleditpy/ui/user_template_dialog.py
@@ -436,9 +436,8 @@ class UserTemplateDialog(QDialog):
         except (AttributeError, RuntimeError, ValueError) as e:
             logging.warning(f"Failed to switch main window to template mode: {e}")
 
-    def select_template(self, template_data: Any, widget: Any) -> None:
-        """Select a template and activate template placement mode."""
-        # Clear previous selection styling
+    def clear_selection(self) -> None:
+        """Unhighlight every template; the editor left user-template mode."""
         for i in range(self.template_layout.count()):
             item = self.template_layout.itemAt(i)
             if item and item.widget():
@@ -453,6 +452,13 @@ class UserTemplateDialog(QDialog):
                         background-color: #f0f8ff;
                     }
                 """)
+        self.selected_template = None
+        if self.delete_button is not None:
+            self.delete_button.setEnabled(False)
+
+    def select_template(self, template_data: Any, widget: Any) -> None:
+        """Select a template and activate template placement mode."""
+        self.clear_selection()
 
         # Highlight selected widget
         widget.setStyleSheet("""

--- a/moleditpy/src/moleditpy/ui/user_template_dialog.py
+++ b/moleditpy/src/moleditpy/ui/user_template_dialog.py
@@ -114,6 +114,11 @@ class UserTemplateDialog(QDialog):
         self.cleanup_template_mode()
         super().closeEvent(event)
 
+    def reject(self) -> None:
+        """Esc never reaches closeEvent, so leave template mode from here too."""
+        self.cleanup_template_mode()
+        super().reject()
+
     def cleanup_template_mode(self) -> None:
         """Exit template mode and revert to atom_C (Carbon) mode."""
         # 1. Reset Dialog State

--- a/tests/assertion_catalog.md
+++ b/tests/assertion_catalog.md
@@ -2891,7 +2891,6 @@ _open_template_dialog_and_activate creates a new modeless dialog when none is op
 
 - MockUT.assert_called_once_with(dm.host, dm.host)
 - instance.show.assert_called_once()
-- instance.finished.connect.assert_called_once()
 
 ### TestOpenTemplateDialogAndActivate.test_raises_existing_visible_dialog
 _open_template_dialog_and_activate raises and activates an already-open dialog._
@@ -2900,15 +2899,8 @@ _open_template_dialog_and_activate raises and activates an already-open dialog._
 - existing.raise_.assert_called_once()
 - existing.activateWindow.assert_called_once()
 
-### TestOpenTemplateDialogAndActivate.test_on_finished_sets_mode_when_template_selected
-_Finishing with a template selected activates template mode and shows a status message._
-
-- assert captured_cb
-- dm.host.ui_manager.set_mode_and_update_toolbar.assert_called_once_with('template_user_benzene')
-- dm.host.statusBar_mock.showMessage.assert_called_once()
-
-### TestOpenTemplateDialogAndActivate.test_on_finished_noop_when_no_template_selected
-_Finishing without a selection does not change mode: the dialog's own_
+### TestOpenTemplateDialogAndActivate.test_opening_does_not_touch_the_mode
+_Opening the dialog only opens it; the template is armed when picked._
 
 - dm.host.ui_manager.set_mode_and_update_toolbar.assert_not_called()
 
@@ -11773,6 +11765,14 @@ _The toolbar has to say which mode is live: picking a user template checks_
 - assert window.init_manager.scene.mode == 'template_user_pyridine'
 - assert actions['template_user'].isChecked()
 - assert not actions['atom_C'].isChecked()
+
+### test_escape_leaves_template_mode_like_the_close_button
+_Esc calls reject() and never reaches closeEvent, so it used to leave the_
+
+- assert window.init_manager.scene.mode == 'template_user_pyridine'
+- assert window.init_manager.scene.mode == 'atom_C'
+- assert dialog.selected_template is None
+- assert not window.init_manager.mode_actions['template_user'].isChecked()
 
 ### test_ring_template_preview_appears
 _A built-in ring template previews as a ghost ring, Kekulé bonds included._

--- a/tests/assertion_catalog.md
+++ b/tests/assertion_catalog.md
@@ -13,6 +13,7 @@ _Verify the easter egg triggers correctly on right click._
 
 - mock_parser_host.edit_actions_manager.clear_all.assert_called_once()
 - mock_parser_host.string_importer_manager.load_from_smiles.assert_called_once_with('C1=CN=C(N=C1)C2=NC=CC=N2')
+- mock_parser_host.compute_manager.trigger_conversion.assert_called_once()
 
 ### test_about_dialog_ignore_left_click
 _Verify left clicks do not trigger the easter egg._
@@ -2903,13 +2904,13 @@ _open_template_dialog_and_activate raises and activates an already-open dialog._
 _Finishing with a template selected activates template mode and shows a status message._
 
 - assert captured_cb
-- dm.host.ui_manager.set_mode.assert_called_once_with('template_user_benzene')
+- dm.host.ui_manager.set_mode_and_update_toolbar.assert_called_once_with('template_user_benzene')
 - dm.host.statusBar_mock.showMessage.assert_called_once()
 
 ### TestOpenTemplateDialogAndActivate.test_on_finished_noop_when_no_template_selected
-_Finishing without a selection does not change mode._
+_Finishing without a selection does not change mode: the dialog's own_
 
-- dm.host.ui_manager.set_mode.assert_not_called()
+- dm.host.ui_manager.set_mode_and_update_toolbar.assert_not_called()
 
 ### TestSave2DAsTemplate.test_warns_when_no_atoms
 _save_2d_as_template shows a warning when the canvas has no atoms._
@@ -8377,6 +8378,14 @@ _Test benzene template rotation alignment._
 
 - assert data.add_atom.called
 
+### test_user_template_replaces_clicked_atom_with_first_template_atom
+_Regression: clicking an existing atom with a user template kept the clicked_
+
+- assert clicked.symbol == 'N'
+- assert clicked.charge == 1
+- assert data.atoms[0]['symbol'] == 'N'
+- assert data.atoms[0]['charge'] == 1
+
 ### test_wedge_flip_via_key_w_pushes_undo
 _Regression: pressing W on an already-wedge bond flips its direction_
 
@@ -9593,34 +9602,35 @@ _Preview geometry snaps nearby polygon vertices to existing scene atoms._
 ## tests/unit/test_template_preview.py
 
 ### test_preview_item_init_defaults
-_TemplatePreviewItem initialises with all geometry and flag attributes at their defaults._
+_TemplatePreviewItem initialises with no ghost molecule and nothing to draw._
 
-- assert item.is_aromatic is False
-- assert item.is_user_template is False
-- assert item.user_template_points == []
-- assert item.user_template_bonds == []
-- assert item.user_template_atoms == []
+- assert item.ghost_atoms == []
+- assert item.ghost_bonds == []
+- assert item.is_chain is False
+- assert item.boundingRect().isNull()
 
-### test_set_geometry_updates_polygon
-_set_geometry stores the polygon and clears is_user_template and is_aromatic flags._
+### test_set_geometry_builds_a_ring
+_set_geometry turns the polygon into single-bonded ghost atoms._
 
-- assert not item.polygon.isEmpty()
-- assert item.is_aromatic is False
-- assert item.is_user_template is False
+- assert [atom.pos() for atom in item.ghost_atoms] == pts
+- assert [bond.order for bond in item.ghost_bonds] == [1] * 6
 
-### test_set_geometry_aromatic_flag
-_set_geometry sets is_aromatic=True when the flag is passed._
+### test_set_geometry_aromatic_alternates_bonds
+_An aromatic ring previews as the Kekulé structure that gets placed._
 
-- assert item.is_aromatic is True
+- assert [bond.order for bond in item.ghost_bonds] == [2, 1, 2, 1, 2, 1]
+
+### test_set_geometry_takes_given_bond_orders
+_The caller can pass the orders the placement will use._
+
+- assert [bond.order for bond in item.ghost_bonds] == [1, 2, 1, 2, 1, 2]
 
 ### test_set_user_template_geometry
-_set_user_template_geometry stores points, bonds, atoms and sets is_user_template._
+_set_user_template_geometry builds the template's atoms and bonds._
 
-- assert item.is_user_template is True
-- assert item.user_template_points == pts
-- assert item.user_template_bonds == bonds
-- assert item.user_template_atoms == atoms
-- assert item.is_aromatic is False
+- assert [atom.symbol for atom in item.ghost_atoms] == ['C', 'N', 'O']
+- assert [bond.order for bond in item.ghost_bonds] == [1, 2]
+- assert item.is_chain is False
 
 ### test_bounding_rect_empty_polygon
 _boundingRect returns a QRectF when the polygon is empty._
@@ -9647,23 +9657,23 @@ _boundingRect returns a QRectF for a user template with no points._
 _paint with a None painter returns without raising._
 
 
-### test_paint_regular_template_non_aromatic
-_paint_regular_template draws a non-aromatic polygon without raising._
+### test_paint_ring_template_non_aromatic
+_A plain ring template paints without raising._
 
 
-### test_paint_regular_template_aromatic
-_paint_regular_template draws an aromatic polygon without raising._
+### test_paint_ring_template_aromatic
+_An aromatic ring template paints without raising._
 
 
-### test_paint_regular_template_empty_polygon
-_paint_regular_template with an empty polygon does not raise._
+### test_paint_without_geometry_draws_nothing
+_A preview with no ghost molecule paints nothing and does not raise._
 
 
 ### test_set_chain_geometry_stores_points_and_label
 _set_chain_geometry switches the item into chain mode and clears other modes._
 
 - assert item.is_chain is True
-- assert item.is_user_template is False
+- assert item.ghost_atoms == []
 - assert item.chain_points == pts
 - assert item.chain_label == 'n = 1'
 - assert item.chain_label_pos == QPointF(60, 10)
@@ -9690,23 +9700,23 @@ _A chain preview with a single vertex paints nothing._
 - assert _painted_pixel_count(img) == 0
 
 ### test_paint_user_template_no_points_returns_early
-_paint_user_template with no points returns without raising._
+_A user template with no points paints nothing and does not raise._
 
 
 ### test_paint_user_template_single_bond
-_paint_user_template renders a single bond without raising._
+_paint_ghost renders a single bond without raising._
 
 
 ### test_paint_user_template_double_bond
-_paint_user_template renders a double bond without raising._
+_paint_ghost renders a double bond without raising._
 
 
 ### test_paint_user_template_triple_bond
-_paint_user_template renders a triple bond without raising._
+_paint_ghost renders a triple bond without raising._
 
 
 ### test_paint_user_template_non_carbon_atom
-_paint_user_template renders non-carbon atom labels without raising._
+_paint_ghost renders non-carbon atom labels without raising._
 
 
 ### test_paint_user_template_bond_info_2_elements
@@ -9716,6 +9726,77 @@ _bond_info with only 2 elements (no order) defaults to single bond._
 ### test_paint_user_template_out_of_range_indices
 _Bond indices beyond point list should be skipped without error._
 
+
+### test_ghost_items_mirror_the_template
+_The preview builds one AtomItem per point and one BondItem per bond._
+
+- assert [a.symbol for a in item.ghost_atoms] == ['N', 'C', 'C']
+- assert [b.order for b in item.ghost_bonds] == [2, 1]
+- assert len(item.ghost_atoms[1].bonds) == 2
+
+### test_ghost_atoms_get_implicit_hydrogens
+_Implicit H counts come from RDKit, so O of an alcohol previews as OH._
+
+- assert item.ghost_atoms[0].implicit_h_count == 3
+- assert item.ghost_atoms[1].implicit_h_count == 1
+
+### test_ghost_ring_bonds_carry_ring_center
+_Ring double bonds need is_in_ring/ring_center to draw the inner short line._
+
+- assert all((b.is_in_ring for b in item.ghost_bonds))
+- assert all((b.ring_center is not None for b in item.ghost_bonds))
+- assert [b.order for b in item.ghost_bonds] == [2, 1, 2, 1, 2, 1]
+
+### test_impossible_valence_still_previews
+_The preview draws what the template says — the valence is never checked._
+
+- assert len(item.ghost_bonds) == 5
+- assert item.ghost_atoms[0].implicit_h_count == 0
+- assert item.ghost_atoms[1].implicit_h_count == 3
+
+### test_repeated_bond_pair_still_previews
+_A template listing the same pair twice must not cost the whole preview its_
+
+- assert len(item.ghost_bonds) == 1
+- assert item.ghost_atoms[1].implicit_h_count == 1
+
+### test_geometry_change_is_announced_after_the_ghost_exists
+_Regression: the scene cached this item's empty boundingRect during the_
+
+- assert seen[-1] == 2
+
+### test_moving_the_cursor_reuses_the_ghost_items
+_A cursor move must not rebuild the ghost; rebuilding every move made big_
+
+- assert item.ghost_atoms == first_atoms
+- assert item.ghost_atoms[0].pos() == QPointF(90, 30)
+- assert item.ghost_bonds[0].pos() == QPointF(90, 30)
+
+### test_changed_template_rebuilds_the_ghost
+_A different template must not reuse the previous ghost items._
+
+- assert item.ghost_atoms != first_atoms
+- assert item.ghost_atoms[0].symbol == 'O'
+- assert item.ghost_bonds[0].order == 2
+
+### test_ring_centres_follow_a_moved_ghost
+_The inner line of a ring double bond is placed from the ring centre, so the_
+
+- assert after[0] == pytest.approx(before[0] + 200)
+- assert after[1] == pytest.approx(before[1])
+
+### test_first_atom_is_marked_for_user_templates_only
+_The attachment atom is highlighted for user templates, not for rings._
+
+- assert item.mark_first_atom is True
+- assert item.mark_first_atom is False
+
+### test_ghosts_stay_out_of_the_editor_scene
+_Ghost atoms must never enter the editor scene or hit tests would find them._
+
+- assert item.ghost_atoms
+- assert all((a.scene() is item.ghost_scene for a in item.ghost_atoms))
+- assert scene.items() == [item]
 
 ### test_preview_view_init_defaults
 _TemplatePreviewView initialises with original_scene_rect, template_data, and parent_dialog all None._
@@ -10240,13 +10321,17 @@ _No description provided._
 
 - atom_action.setChecked.assert_called_with(True)
 - select_action.setChecked.assert_called_with(False)
-- btn.setStyleSheet.assert_called_with('')
 
-### test_set_mode_and_update_toolbar_user_template_highlight
+### test_set_mode_and_update_toolbar_without_a_user_template_button
+_A host that never registered the USER action must not raise._
+
+- ui.host.init_manager.mode_actions['atom_C'].setChecked.assert_called_with(False)
+
+### test_set_mode_and_update_toolbar_user_template_checks_user_button
 _No description provided._
 
 - template_action.setChecked.assert_called_with(True)
-- assert 'background-color' in btn.setStyleSheet.call_args.args[0]
+- other_action.setChecked.assert_called_with(False)
 
 ### test_activate_select_mode_checks_select_action
 _No description provided._
@@ -11220,6 +11305,13 @@ _Re-indexing per wheel tick dirties every item and made a zoom step ~40x_
 - assert probe.notified == 0
 - assert probe.notified == 1
 
+## tests/integration/test_about_dialog_integration.py
+
+### test_right_click_loads_and_converts
+_Right-clicking the image loads the molecule and builds it in 3D._
+
+- assert len(window.state_manager.data.atoms) == 12
+
 ## tests/integration/test_calculation_worker.py
 
 ### test_calculation_worker_bond_length_validation
@@ -11620,6 +11712,74 @@ _No description provided._
 
 - assert 'QUICK UFF' not in im.opt3d_actions
 - assert 'Quick UFF' not in _menu_labels(im)
+
+## tests/integration/test_template_preview_in_editor.py
+
+### test_user_template_preview_appears
+_Moving the cursor in user-template mode shows the ghost molecule._
+
+- assert preview.isVisible()
+- assert len(preview.ghost_atoms) == 6
+- assert len(preview.ghost_bonds) == 6
+- assert not preview.boundingRect().isEmpty()
+
+### test_preview_is_indexed_where_it_is_drawn
+_Regression: the scene index kept an empty rect from before the ghost was_
+
+- assert preview.sceneBoundingRect().contains(where)
+- assert preview in scene.items(preview.sceneBoundingRect())
+- assert _painted_pixels(scene, preview.sceneBoundingRect()) > 0
+
+### test_fused_atom_keeps_its_own_element
+_A ring vertex landing on an existing atom previews that atom, not a carbon,_
+
+- assert fused
+- assert fused[0] in preview.existing_indices
+- assert preview.ghost_atoms[fused[0]].pos() == scene.atom_items[nitrogen].pos()
+
+### test_fusing_onto_another_atom_relabels_the_ghost
+_The fused atom's hydrogens come from the editor, so a ghost reused across_
+
+- assert fused and preview.ghost_atoms[fused[0]].implicit_h_count == 2
+- assert fused and preview.ghost_atoms[fused[0]].implicit_h_count == 1
+
+### test_user_template_previews_its_own_atoms_over_existing_ones
+_Only the first atom of a user template reuses an existing one; a vertex that_
+
+- assert preview.ghost_atoms[1].symbol == 'C'
+- assert not preview.existing_indices
+- assert len(scene.data.atoms) == 3
+
+### test_ghost_labels_use_the_editors_font_settings
+_update_style() reads the font through scene(), so the ghost items have to be_
+
+- assert scene.template_preview.ghost_atoms[0].font.pointSize() == 13
+
+### test_fused_ring_preview_uses_the_placement_rotation
+_A fused aromatic ring is rotated to fit the bonds already there, so the_
+
+- assert [bond.order for bond in preview.ghost_bonds] == [1, 2, 1, 2, 1, 2]
+- assert [order for _, _, order in scene.template_context['bonds_info']] == [2, 1, 2, 1, 2, 1]
+
+### test_leaving_template_mode_clears_the_dialog_selection
+_Picking another mode has to unhighlight the template dialog's selection._
+
+- assert dialog.selected_template is None
+- assert not dialog.delete_button.isEnabled()
+
+### test_using_a_user_template_checks_the_user_toolbar_button
+_The toolbar has to say which mode is live: picking a user template checks_
+
+- assert window.init_manager.scene.mode == 'template_user_pyridine'
+- assert actions['template_user'].isChecked()
+- assert not actions['atom_C'].isChecked()
+
+### test_ring_template_preview_appears
+_A built-in ring template previews as a ghost ring, Kekulé bonds included._
+
+- assert preview.isVisible()
+- assert [b.order for b in preview.ghost_bonds] == [2, 1, 2, 1, 2, 1]
+- assert all((b.is_in_ring for b in preview.ghost_bonds))
 
 ## tests/integration/test_trigger_conversion_plugin_wrap.py
 

--- a/tests/coverage_report.md
+++ b/tests/coverage_report.md
@@ -1,6 +1,6 @@
 # MoleditPy Coverage Report
 
-- **Overall Project Coverage**: **89.75%**
+- **Overall Project Coverage**: **89.89%**
 
 ### Coverage Breakdown
 
@@ -14,16 +14,16 @@
 | moleditpy\src\moleditpy\plugins\plugin_manager.py       |    407 |     11 |   97.3% |
 | moleditpy\src\moleditpy\plugins\plugin_manager_window.py |    187 |      2 |   98.9% |
 | moleditpy\src\moleditpy\ui\__init__.py                  |      7 |      3 |   57.1% |
-| moleditpy\src\moleditpy\ui\about_dialog.py              |     64 |     13 |   79.7% |
+| moleditpy\src\moleditpy\ui\about_dialog.py              |     66 |     14 |   78.8% |
 | moleditpy\src\moleditpy\ui\align_plane_dialog.py        |    151 |     15 |   90.1% |
 | moleditpy\src\moleditpy\ui\alignment_dialog.py          |    147 |     10 |   93.2% |
 | moleditpy\src\moleditpy\ui\analysis_window.py           |    117 |     25 |   78.6% |
 | moleditpy\src\moleditpy\ui\angle_dialog.py              |    275 |     29 |   89.5% |
 | moleditpy\src\moleditpy\ui\app_state.py                 |    345 |     57 |   83.5% |
-| moleditpy\src\moleditpy\ui\atom_item.py                 |    327 |     35 |   89.3% |
+| moleditpy\src\moleditpy\ui\atom_item.py                 |    327 |     30 |   90.8% |
 | moleditpy\src\moleditpy\ui\atom_picking.py              |    167 |     13 |   92.2% |
 | moleditpy\src\moleditpy\ui\base_picking_dialog.py       |     81 |      4 |   95.1% |
-| moleditpy\src\moleditpy\ui\bond_item.py                 |    370 |     55 |   85.1% |
+| moleditpy\src\moleditpy\ui\bond_item.py                 |    370 |     54 |   85.4% |
 | moleditpy\src\moleditpy\ui\bond_length_dialog.py        |    260 |     18 |   93.1% |
 | moleditpy\src\moleditpy\ui\calculation_worker.py        |    583 |     90 |   84.6% |
 | moleditpy\src\moleditpy\ui\chain_mixin.py               |     97 |      2 |   97.9% |
@@ -43,20 +43,21 @@
 | moleditpy\src\moleditpy\ui\main_window.py               |    195 |     13 |   93.3% |
 | moleditpy\src\moleditpy\ui\main_window_init.py          |   1103 |     86 |   92.2% |
 | moleditpy\src\moleditpy\ui\mirror_dialog.py             |     72 |      7 |   90.3% |
-| moleditpy\src\moleditpy\ui\molecular_scene_handler.py   |   1005 |    143 |   85.8% |
+| moleditpy\src\moleditpy\ui\molecular_scene_handler.py   |   1038 |    135 |   87.0% |
 | moleditpy\src\moleditpy\ui\molecule_scene.py            |    637 |     82 |   87.1% |
 | moleditpy\src\moleditpy\ui\move_group_dialog.py         |    386 |     41 |   89.4% |
 | moleditpy\src\moleditpy\ui\move_selected_atoms_dialog.py |    464 |     44 |   90.5% |
 | moleditpy\src\moleditpy\ui\periodic_table_dialog.py     |     37 |      2 |   94.6% |
 | moleditpy\src\moleditpy\ui\planarize_dialog.py          |    112 |      9 |   92.0% |
 | moleditpy\src\moleditpy\ui\plugin_menu_manager.py       |    287 |     30 |   89.5% |
+| moleditpy\src\moleditpy\ui\preview_molecule.py          |    116 |     14 |   87.9% |
 | moleditpy\src\moleditpy\ui\settings_dialog.py           |    101 |      3 |   97.0% |
 | moleditpy\src\moleditpy\ui\string_importers.py          |    121 |      0 |  100.0% |
-| moleditpy\src\moleditpy\ui\template_preview_item.py     |    149 |      4 |   97.3% |
+| moleditpy\src\moleditpy\ui\template_preview_item.py     |    233 |      5 |   97.9% |
 | moleditpy\src\moleditpy\ui\template_preview_view.py     |     46 |      4 |   91.3% |
 | moleditpy\src\moleditpy\ui\translation_dialog.py        |    276 |     21 |   92.4% |
-| moleditpy\src\moleditpy\ui\ui_manager.py                |    403 |     36 |   91.1% |
-| moleditpy\src\moleditpy\ui\user_template_dialog.py      |    360 |     45 |   87.5% |
+| moleditpy\src\moleditpy\ui\ui_manager.py                |    398 |     38 |   90.5% |
+| moleditpy\src\moleditpy\ui\user_template_dialog.py      |    295 |     34 |   88.5% |
 | moleditpy\src\moleditpy\ui\view_3d_logic.py             |   1007 |    179 |   82.2% |
 | moleditpy\src\moleditpy\ui\zoomable_view.py             |    101 |      5 |   95.0% |
 | moleditpy\src\moleditpy\ui\settings_tabs\settings_2d_tab.py |    144 |      0 |  100.0% |
@@ -69,12 +70,12 @@
 | moleditpy\src\moleditpy\utils\sip_isdeleted_safe.py     |     19 |      0 |  100.0% |
 | moleditpy\src\moleditpy\utils\suppress_log.py           |     10 |      0 |  100.0% |
 | moleditpy\src\moleditpy\utils\system_utils.py           |     40 |      0 |  100.0% |
-| **TOTAL** | **16945** | **1737** | **89.75%** |
+| **TOTAL** | **17110** | **1730** | **89.89%** |
 
 ## Test Suite Status
-- **Total tests passed**: 2236 (1 skipped)
-- **Unit tests**: PASSED (2041 passed)
-- **Integration tests**: PASSED (75 passed)
+- **Total tests passed**: 2261 (1 skipped)
+- **Unit tests**: PASSED (2055 passed)
+- **Integration tests**: PASSED (86 passed)
 - **E2E tests**: PASSED (34 passed, 1 skipped)
 - **GUI tests**: PASSED (86 passed)
 

--- a/tests/coverage_report.md
+++ b/tests/coverage_report.md
@@ -33,7 +33,7 @@
 | moleditpy\src\moleditpy\ui\custom_interactor_style.py   |    775 |    113 |   85.4% |
 | moleditpy\src\moleditpy\ui\custom_qt_interactor.py      |     24 |      0 |  100.0% |
 | moleditpy\src\moleditpy\ui\dialog_3d_picking_mixin.py   |    137 |     19 |   86.1% |
-| moleditpy\src\moleditpy\ui\dialog_logic.py              |    230 |     25 |   89.1% |
+| moleditpy\src\moleditpy\ui\dialog_logic.py              |    222 |     25 |   88.7% |
 | moleditpy\src\moleditpy\ui\dihedral_dialog.py           |    280 |     33 |   88.2% |
 | moleditpy\src\moleditpy\ui\edit_3d_logic.py             |    221 |     32 |   85.5% |
 | moleditpy\src\moleditpy\ui\edit_actions_logic.py        |    817 |    127 |   84.5% |
@@ -57,7 +57,7 @@
 | moleditpy\src\moleditpy\ui\template_preview_view.py     |     46 |      4 |   91.3% |
 | moleditpy\src\moleditpy\ui\translation_dialog.py        |    276 |     21 |   92.4% |
 | moleditpy\src\moleditpy\ui\ui_manager.py                |    398 |     38 |   90.5% |
-| moleditpy\src\moleditpy\ui\user_template_dialog.py      |    295 |     34 |   88.5% |
+| moleditpy\src\moleditpy\ui\user_template_dialog.py      |    298 |     34 |   88.6% |
 | moleditpy\src\moleditpy\ui\view_3d_logic.py             |   1007 |    179 |   82.2% |
 | moleditpy\src\moleditpy\ui\zoomable_view.py             |    101 |      5 |   95.0% |
 | moleditpy\src\moleditpy\ui\settings_tabs\settings_2d_tab.py |    144 |      0 |  100.0% |
@@ -70,12 +70,12 @@
 | moleditpy\src\moleditpy\utils\sip_isdeleted_safe.py     |     19 |      0 |  100.0% |
 | moleditpy\src\moleditpy\utils\suppress_log.py           |     10 |      0 |  100.0% |
 | moleditpy\src\moleditpy\utils\system_utils.py           |     40 |      0 |  100.0% |
-| **TOTAL** | **17110** | **1730** | **89.89%** |
+| **TOTAL** | **17105** | **1730** | **89.89%** |
 
 ## Test Suite Status
 - **Total tests passed**: 2261 (1 skipped)
-- **Unit tests**: PASSED (2055 passed)
-- **Integration tests**: PASSED (86 passed)
+- **Unit tests**: PASSED (2054 passed)
+- **Integration tests**: PASSED (87 passed)
 - **E2E tests**: PASSED (34 passed, 1 skipped)
 - **GUI tests**: PASSED (86 passed)
 

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -360,6 +360,9 @@ def window(app, qtbot, monkeypatch, tmp_path):
         f"{_PKG}.ui.main_window", fromlist=["MainWindow"]
     ).MainWindow
     win = MainWindow()
+    # A test that touches settings must never rewrite the real ~/.moleditpy
+    win.init_manager.settings_dir = str(tmp_path / ".moleditpy")
+    win.init_manager.settings_file = str(tmp_path / ".moleditpy" / "settings.json")
     qtbot.addWidget(win)
     monkeypatch.setattr(win, "isVisible", lambda *a, **k: True, raising=False)
 

--- a/tests/full_gui/conftest.py
+++ b/tests/full_gui/conftest.py
@@ -156,6 +156,9 @@ def full_window(app, qtbot, monkeypatch, tmp_path):
 
     # safe_mode keeps the developer's own plugin folder out of the run.
     win = MainWindow(initial_file=None, safe_mode=True)
+    # A test that touches settings must never rewrite the real ~/.moleditpy
+    win.init_manager.settings_dir = str(tmp_path / ".moleditpy")
+    win.init_manager.settings_file = str(tmp_path / ".moleditpy" / "settings.json")
     _make_rendering_synchronous(win)
     qtbot.addWidget(win)
     win.resize(1280, 800)

--- a/tests/gui/conftest.py
+++ b/tests/gui/conftest.py
@@ -653,7 +653,7 @@ _CACHED_MAIN_WINDOW_CLASS = None
 
 
 @pytest.fixture
-def window(app, qtbot, monkeypatch):
+def window(app, qtbot, monkeypatch, tmp_path):
     """
     Creates a new MainWindow instance for each test and mocks
     time-consuming operations and external windows.
@@ -1351,6 +1351,11 @@ def window(app, qtbot, monkeypatch):
         monkeypatch.setattr(MainWindowClass, "__init__", patched_init)
 
     main_window = MainWindowClass()
+    # A test that touches settings must never rewrite the real ~/.moleditpy
+    main_window.init_manager.settings_dir = str(tmp_path / ".moleditpy")
+    main_window.init_manager.settings_file = str(
+        tmp_path / ".moleditpy" / "settings.json"
+    )
     qtbot.addWidget(main_window)
     main_window.show()
     # Allow GUI event loop to process showing the window

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -335,6 +335,9 @@ def window(app, qtbot, monkeypatch, tmp_path):
         def discover_plugins(self, parent=None):
             return []
 
+        def invoke_document_reset_handlers(self):
+            pass
+
         def update_plugin_menu(self, menu):
             pass
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -301,7 +301,7 @@ def app():
 
 
 @pytest.fixture
-def window(app, qtbot, monkeypatch):
+def window(app, qtbot, monkeypatch, tmp_path):
     """
     Create a MainWindow instance with necessary mocks for integration tests.
     """
@@ -427,6 +427,9 @@ def window(app, qtbot, monkeypatch):
 
     # 6. Instantiate
     win = MainWindow()
+    # A test that touches settings must never rewrite the real ~/.moleditpy
+    win.init_manager.settings_dir = str(tmp_path / ".moleditpy")
+    win.init_manager.settings_file = str(tmp_path / ".moleditpy" / "settings.json")
     qtbot.addWidget(win)
     # Don't win.show() if headless to be safer, or win.show() if needed by qtbot
     if os.environ.get("MOLEDITPY_HEADLESS", "0") != "1":

--- a/tests/integration/test_about_dialog_integration.py
+++ b/tests/integration/test_about_dialog_integration.py
@@ -1,0 +1,21 @@
+"""The About image's right-click shortcut has to reach the 3D view."""
+
+from unittest.mock import MagicMock
+
+from PyQt6.QtCore import Qt
+
+from moleditpy.ui.about_dialog import AboutDialog
+
+
+def test_right_click_loads_and_converts(window, qtbot):
+    """Right-clicking the image loads the molecule and builds it in 3D."""
+    dialog = AboutDialog(window, window)
+    event = MagicMock()
+    event.button.return_value = Qt.MouseButton.RightButton
+
+    dialog.image_mouse_press_event(event)
+
+    assert len(window.state_manager.data.atoms) == 12
+    qtbot.waitUntil(
+        lambda: window.view_3d_manager.current_mol is not None, timeout=15000
+    )

--- a/tests/integration/test_template_preview_in_editor.py
+++ b/tests/integration/test_template_preview_in_editor.py
@@ -225,13 +225,6 @@ def test_using_a_user_template_checks_the_user_toolbar_button(window):
     assert actions["template_user"].isChecked()
     assert not actions["atom_C"].isChecked()
 
-    button = window.init_manager.toolbar_bottom.widgetForAction(
-        actions["template_user"]
-    )
-    assert "background-color" in button.styleSheet()
-    window.ui_manager.set_mode_and_update_toolbar("select")
-    assert button.styleSheet() == ""
-
 
 def test_ring_template_preview_appears(window):
     """A built-in ring template previews as a ghost ring, Kekulé bonds included."""

--- a/tests/integration/test_template_preview_in_editor.py
+++ b/tests/integration/test_template_preview_in_editor.py
@@ -1,5 +1,7 @@
 """The template ghost preview has to actually appear in the real 2D editor."""
 
+from unittest.mock import patch
+
 from PyQt6.QtCore import QPointF, QRectF
 from PyQt6.QtGui import QColor, QImage, QPainter
 
@@ -96,6 +98,46 @@ def test_fused_atom_keeps_its_own_element(window):
     assert fused, "the ring should have picked up the existing nitrogen"
     assert fused[0] in preview.existing_indices
     assert preview.ghost_atoms[fused[0]].pos() == scene.atom_items[nitrogen].pos()
+
+
+def test_fusing_onto_another_atom_relabels_the_ghost(window):
+    """The fused atom's hydrogens come from the editor, so a ghost reused across
+    cursor moves must not keep the label of the atom it was fused to before."""
+    scene = window.init_manager.scene
+    lone = scene.create_atom("O", QPointF(0, 0))
+    bonded = scene.create_atom("O", QPointF(300, 0))
+    partner = scene.create_atom("C", QPointF(350, 0))
+    scene.create_bond(scene.atom_items[bonded], scene.atom_items[partner], 1, 0)
+    scene.atom_items[lone].implicit_h_count = 2
+    scene.atom_items[bonded].implicit_h_count = 1
+    scene.update_all_items()
+
+    window.ui_manager.set_mode("template_benzene")
+    preview = scene.template_preview
+
+    scene.update_template_preview(scene.atom_items[lone].pos())
+    fused = [i for i in preview.existing_indices]
+    assert fused and preview.ghost_atoms[fused[0]].implicit_h_count == 2
+
+    scene.update_template_preview(scene.atom_items[bonded].pos())
+    fused = [i for i in preview.existing_indices]
+    assert fused and preview.ghost_atoms[fused[0]].implicit_h_count == 1
+
+
+def test_leaving_template_mode_clears_the_dialog_selection(window):
+    """Picking another mode has to unhighlight the template dialog's selection."""
+    from moleditpy.ui.user_template_dialog import UserTemplateDialog
+
+    with patch.object(UserTemplateDialog, "load_user_templates"):
+        dialog = UserTemplateDialog(window, window)
+    window.template_dialog = dialog
+    dialog.selected_template = PYRIDINE
+    dialog.delete_button.setEnabled(True)
+
+    window.ui_manager.set_mode("select")
+
+    assert dialog.selected_template is None
+    assert not dialog.delete_button.isEnabled()
 
 
 def test_ring_template_preview_appears(window):

--- a/tests/integration/test_template_preview_in_editor.py
+++ b/tests/integration/test_template_preview_in_editor.py
@@ -124,6 +124,33 @@ def test_fusing_onto_another_atom_relabels_the_ghost(window):
     assert fused and preview.ghost_atoms[fused[0]].implicit_h_count == 1
 
 
+def test_user_template_previews_its_own_atoms_over_existing_ones(window):
+    """Only the first atom of a user template reuses an existing one; a vertex that
+    merely lands on another becomes a new atom, so the ghost must not fuse it."""
+    scene = window.init_manager.scene
+    anchor = scene.create_atom("C", QPointF(0, 0))
+    scene.create_atom("N", QPointF(50, 0))
+    scene.update_all_items()
+
+    scene.user_template_data = {
+        "name": "ethanol_stub",
+        "atoms": [
+            {"id": 0, "symbol": "C", "x": 0, "y": 0},
+            {"id": 1, "symbol": "C", "x": 50, "y": 0},
+        ],
+        "bonds": [{"atom1": 0, "atom2": 1, "order": 1}],
+    }
+    window.ui_manager.set_mode("template_user_ethanol_stub")
+    scene.update_template_preview(scene.atom_items[anchor].pos())
+
+    preview = scene.template_preview
+    assert preview.ghost_atoms[1].symbol == "C"
+    assert not preview.existing_indices
+
+    scene.add_user_template_fragment(scene.template_context)
+    assert len(scene.data.atoms) == 3
+
+
 def test_fused_ring_preview_uses_the_placement_rotation(window):
     """A fused aromatic ring is rotated to fit the bonds already there, so the
     preview has to show the double bonds where the click will put them — while
@@ -166,6 +193,24 @@ def test_leaving_template_mode_clears_the_dialog_selection(window):
 
     assert dialog.selected_template is None
     assert not dialog.delete_button.isEnabled()
+
+
+def test_using_a_user_template_checks_the_user_toolbar_button(window):
+    """The toolbar has to say which mode is live: picking a user template checks
+    USER and drops the highlight from whatever was active before."""
+    from moleditpy.ui.user_template_dialog import UserTemplateDialog
+
+    with patch.object(UserTemplateDialog, "load_user_templates"):
+        dialog = UserTemplateDialog(window, window)
+    window.template_dialog = dialog
+    actions = window.init_manager.mode_actions
+    window.ui_manager.set_mode_and_update_toolbar("atom_C")
+
+    dialog.use_template(PYRIDINE)
+
+    assert window.init_manager.scene.mode == "template_user_pyridine"
+    assert actions["template_user"].isChecked()
+    assert not actions["atom_C"].isChecked()
 
 
 def test_ring_template_preview_appears(window):

--- a/tests/integration/test_template_preview_in_editor.py
+++ b/tests/integration/test_template_preview_in_editor.py
@@ -226,6 +226,24 @@ def test_using_a_user_template_checks_the_user_toolbar_button(window):
     assert not actions["atom_C"].isChecked()
 
 
+def test_escape_leaves_template_mode_like_the_close_button(window):
+    """Esc calls reject() and never reaches closeEvent, so it used to leave the
+    editor armed with a template the dialog had already forgotten."""
+    from moleditpy.ui.user_template_dialog import UserTemplateDialog
+
+    with patch.object(UserTemplateDialog, "load_user_templates"):
+        dialog = UserTemplateDialog(window, window)
+    window.template_dialog = dialog
+    dialog.use_template(PYRIDINE)
+    assert window.init_manager.scene.mode == "template_user_pyridine"
+
+    dialog.reject()
+
+    assert window.init_manager.scene.mode == "atom_C"
+    assert dialog.selected_template is None
+    assert not window.init_manager.mode_actions["template_user"].isChecked()
+
+
 def test_ring_template_preview_appears(window):
     """A built-in ring template previews as a ghost ring, Kekulé bonds included."""
     scene = window.init_manager.scene

--- a/tests/integration/test_template_preview_in_editor.py
+++ b/tests/integration/test_template_preview_in_editor.py
@@ -225,6 +225,13 @@ def test_using_a_user_template_checks_the_user_toolbar_button(window):
     assert actions["template_user"].isChecked()
     assert not actions["atom_C"].isChecked()
 
+    button = window.init_manager.toolbar_bottom.widgetForAction(
+        actions["template_user"]
+    )
+    assert "background-color" in button.styleSheet()
+    window.ui_manager.set_mode_and_update_toolbar("select")
+    assert button.styleSheet() == ""
+
 
 def test_ring_template_preview_appears(window):
     """A built-in ring template previews as a ghost ring, Kekulé bonds included."""

--- a/tests/integration/test_template_preview_in_editor.py
+++ b/tests/integration/test_template_preview_in_editor.py
@@ -1,0 +1,111 @@
+"""The template ghost preview has to actually appear in the real 2D editor."""
+
+from PyQt6.QtCore import QPointF, QRectF
+from PyQt6.QtGui import QColor, QImage, QPainter
+
+PYRIDINE = {
+    "name": "pyridine",
+    "atoms": [
+        {"id": 0, "symbol": "N", "x": 0, "y": 0},
+        {"id": 1, "symbol": "C", "x": 43, "y": 25},
+        {"id": 2, "symbol": "C", "x": 43, "y": 75},
+        {"id": 3, "symbol": "C", "x": 0, "y": 100},
+        {"id": 4, "symbol": "C", "x": -43, "y": 75},
+        {"id": 5, "symbol": "C", "x": -43, "y": 25},
+    ],
+    "bonds": [
+        {"atom1": 0, "atom2": 1, "order": 2},
+        {"atom1": 1, "atom2": 2, "order": 1},
+        {"atom1": 2, "atom2": 3, "order": 2},
+        {"atom1": 3, "atom2": 4, "order": 1},
+        {"atom1": 4, "atom2": 5, "order": 2},
+        {"atom1": 5, "atom2": 0, "order": 1},
+    ],
+}
+
+
+def _painted_pixels(scene, region):
+    """Render a scene region and count the pixels that are not background."""
+    image = QImage(240, 240, QImage.Format.Format_ARGB32)
+    image.fill(QColor("white"))
+    painter = QPainter(image)
+    scene.render(painter, target=QRectF(image.rect()), source=region)
+    painter.end()
+    return sum(
+        1
+        for y in range(image.height())
+        for x in range(image.width())
+        if image.pixel(x, y) != 0xFFFFFFFF
+    )
+
+
+def test_user_template_preview_appears(window):
+    """Moving the cursor in user-template mode shows the ghost molecule."""
+    scene = window.init_manager.scene
+    scene.user_template_data = PYRIDINE
+    window.ui_manager.set_mode("template_user_pyridine")
+
+    scene.update_template_preview(QPointF(300, 250))
+
+    preview = scene.template_preview
+    assert preview.isVisible()
+    assert len(preview.ghost_atoms) == 6
+    assert len(preview.ghost_bonds) == 6
+    assert not preview.boundingRect().isEmpty()
+
+
+def test_preview_is_indexed_where_it_is_drawn(window):
+    """Regression: the scene index kept an empty rect from before the ghost was
+    built, so items(exposed) never returned the preview and Qt culled it — the
+    ghost was invisible in the editor even though the item was visible."""
+    scene = window.init_manager.scene
+    first = scene.create_atom("C", QPointF(0, 0))
+    second = scene.create_atom("O", QPointF(50, 0))
+    scene.create_bond(scene.atom_items[first], scene.atom_items[second], 1, 0)
+    scene.update_all_items()
+
+    scene.user_template_data = PYRIDINE
+    window.ui_manager.set_mode("template_user_pyridine")
+    # Paint once first: that is what puts the preview into the scene index
+    _painted_pixels(scene, QRectF(-100, -100, 600, 600))
+
+    where = QPointF(300, 250)
+    scene.update_template_preview(where)
+
+    preview = scene.template_preview
+    assert preview.sceneBoundingRect().contains(where)
+    assert preview in scene.items(preview.sceneBoundingRect())
+    # Rendering the scene is what the editor does; the ghost must show up in it
+    assert _painted_pixels(scene, preview.sceneBoundingRect()) > 0
+
+
+def test_fused_atom_keeps_its_own_element(window):
+    """A ring vertex landing on an existing atom previews that atom, not a carbon,
+    and the editor keeps drawing it."""
+    scene = window.init_manager.scene
+    nitrogen = scene.create_atom("N", QPointF(0, 0))
+    carbon = scene.create_atom("C", QPointF(50, 0))
+    scene.create_bond(scene.atom_items[nitrogen], scene.atom_items[carbon], 1, 0)
+    scene.update_all_items()
+
+    window.ui_manager.set_mode("template_benzene")
+    scene.update_template_preview(QPointF(25, 2))
+
+    preview = scene.template_preview
+    fused = [i for i, a in enumerate(preview.ghost_atoms) if a.symbol == "N"]
+    assert fused, "the ring should have picked up the existing nitrogen"
+    assert fused[0] in preview.existing_indices
+    assert preview.ghost_atoms[fused[0]].pos() == scene.atom_items[nitrogen].pos()
+
+
+def test_ring_template_preview_appears(window):
+    """A built-in ring template previews as a ghost ring, Kekulé bonds included."""
+    scene = window.init_manager.scene
+    window.ui_manager.set_mode("template_benzene")
+
+    scene.update_template_preview(QPointF(320, 260))
+
+    preview = scene.template_preview
+    assert preview.isVisible()
+    assert [b.order for b in preview.ghost_bonds] == [2, 1, 2, 1, 2, 1]
+    assert all(b.is_in_ring for b in preview.ghost_bonds)

--- a/tests/integration/test_template_preview_in_editor.py
+++ b/tests/integration/test_template_preview_in_editor.py
@@ -124,6 +124,34 @@ def test_fusing_onto_another_atom_relabels_the_ghost(window):
     assert fused and preview.ghost_atoms[fused[0]].implicit_h_count == 1
 
 
+def test_fused_ring_preview_uses_the_placement_rotation(window):
+    """A fused aromatic ring is rotated to fit the bonds already there, so the
+    preview has to show the double bonds where the click will put them — while
+    the placement context keeps the unrotated orders it rotates itself."""
+    scene = window.init_manager.scene
+    left = scene.create_atom("C", QPointF(0, 0))
+    right = scene.create_atom("C", QPointF(50, 0))
+    scene.create_bond(scene.atom_items[left], scene.atom_items[right], 1, 0)
+    scene.update_all_items()
+
+    window.ui_manager.set_mode("template_benzene")
+    with patch.object(
+        type(scene), "_calculate_6ring_rotation", return_value=1, create=False
+    ):
+        scene.update_template_preview(QPointF(25, 2))
+
+    preview = scene.template_preview
+    assert [bond.order for bond in preview.ghost_bonds] == [1, 2, 1, 2, 1, 2]
+    assert [order for (_, _, order) in scene.template_context["bonds_info"]] == [
+        2,
+        1,
+        2,
+        1,
+        2,
+        1,
+    ]
+
+
 def test_leaving_template_mode_clears_the_dialog_selection(window):
     """Picking another mode has to unhighlight the template dialog's selection."""
     from moleditpy.ui.user_template_dialog import UserTemplateDialog

--- a/tests/integration/test_template_preview_in_editor.py
+++ b/tests/integration/test_template_preview_in_editor.py
@@ -151,6 +151,19 @@ def test_user_template_previews_its_own_atoms_over_existing_ones(window):
     assert len(scene.data.atoms) == 3
 
 
+def test_ghost_labels_use_the_editors_font_settings(window):
+    """update_style() reads the font through scene(), so the ghost items have to be
+    styled after they join a scene or they keep the built-in default size."""
+    scene = window.init_manager.scene
+    window.init_manager.settings["atom_font_size_2d"] = 13
+    scene.user_template_data = PYRIDINE
+    window.ui_manager.set_mode("template_user_pyridine")
+
+    scene.update_template_preview(QPointF(300, 250))
+
+    assert scene.template_preview.ghost_atoms[0].font.pointSize() == 13
+
+
 def test_fused_ring_preview_uses_the_placement_rotation(window):
     """A fused aromatic ring is rotated to fit the bonds already there, so the
     preview has to show the double bonds where the click will put them — while

--- a/tests/pylint-score.txt
+++ b/tests/pylint-score.txt
@@ -1,1 +1,1 @@
-Your code has been rated at 9.37/10
+Your code has been rated at 9.38/10

--- a/tests/unit/test_about_dialog.py
+++ b/tests/unit/test_about_dialog.py
@@ -27,6 +27,7 @@ def test_about_dialog_easter_egg(app, mock_parser_host):
     mock_parser_host.string_importer_manager.load_from_smiles.assert_called_once_with(
         "C1=CN=C(N=C1)C2=NC=CC=N2"
     )
+    mock_parser_host.compute_manager.trigger_conversion.assert_called_once()
 
 
 def test_about_dialog_ignore_left_click(app, mock_parser_host):

--- a/tests/unit/test_dialog_manager.py
+++ b/tests/unit/test_dialog_manager.py
@@ -287,7 +287,8 @@ class TestOpenTemplateDialogAndActivate:
         dm.host.statusBar_mock.showMessage.assert_called_once()
 
     def test_on_finished_noop_when_no_template_selected(self, dm):
-        """Finishing without a selection restores the toolbar to the live mode."""
+        """Finishing without a selection does not change mode: the dialog's own
+        closeEvent has already put the toolbar back."""
         dm.host.template_dialog = None
         captured_cb = []
 
@@ -299,9 +300,7 @@ class TestOpenTemplateDialogAndActivate:
 
         dm.host.template_dialog.selected_template = None
         captured_cb[0]()
-        dm.host.ui_manager.set_mode_and_update_toolbar.assert_called_once_with(
-            dm.host.init_manager.scene.mode
-        )
+        dm.host.ui_manager.set_mode_and_update_toolbar.assert_not_called()
 
 
 # ===========================================================================

--- a/tests/unit/test_dialog_manager.py
+++ b/tests/unit/test_dialog_manager.py
@@ -281,11 +281,13 @@ class TestOpenTemplateDialogAndActivate:
         assert captured_cb, "finished.connect was never called"
         captured_cb[0]()
 
-        dm.host.ui_manager.set_mode.assert_called_once_with("template_user_benzene")
+        dm.host.ui_manager.set_mode_and_update_toolbar.assert_called_once_with(
+            "template_user_benzene"
+        )
         dm.host.statusBar_mock.showMessage.assert_called_once()
 
     def test_on_finished_noop_when_no_template_selected(self, dm):
-        """Finishing without a selection does not change mode."""
+        """Finishing without a selection restores the toolbar to the live mode."""
         dm.host.template_dialog = None
         captured_cb = []
 
@@ -297,7 +299,9 @@ class TestOpenTemplateDialogAndActivate:
 
         dm.host.template_dialog.selected_template = None
         captured_cb[0]()
-        dm.host.ui_manager.set_mode.assert_not_called()
+        dm.host.ui_manager.set_mode_and_update_toolbar.assert_called_once_with(
+            dm.host.init_manager.scene.mode
+        )
 
 
 # ===========================================================================

--- a/tests/unit/test_dialog_manager.py
+++ b/tests/unit/test_dialog_manager.py
@@ -252,7 +252,6 @@ class TestOpenTemplateDialogAndActivate:
             dm.open_template_dialog_and_activate()
         MockUT.assert_called_once_with(dm.host, dm.host)
         instance.show.assert_called_once()
-        instance.finished.connect.assert_called_once()
 
     def test_raises_existing_visible_dialog(self, dm):
         """open_template_dialog_and_activate raises and activates an already-open dialog."""
@@ -265,41 +264,14 @@ class TestOpenTemplateDialogAndActivate:
         existing.raise_.assert_called_once()
         existing.activateWindow.assert_called_once()
 
-    def test_on_finished_sets_mode_when_template_selected(self, dm):
-        """Finishing with a template selected activates template mode and shows a status message."""
+    def test_opening_does_not_touch_the_mode(self, dm):
+        """Opening the dialog only opens it; the template is armed when picked."""
         dm.host.template_dialog = None
-        captured_cb = []
 
         with patch("moleditpy.ui.dialog_logic.UserTemplateDialog") as MockUT:
-            instance = MagicMock()
-            MockUT.return_value = instance
-            instance.finished.connect.side_effect = lambda cb: captured_cb.append(cb)
+            MockUT.return_value = MagicMock()
             dm.open_template_dialog_and_activate()
 
-        # Simulate template selection on the newly stored dialog
-        dm.host.template_dialog.selected_template = {"name": "benzene"}
-        assert captured_cb, "finished.connect was never called"
-        captured_cb[0]()
-
-        dm.host.ui_manager.set_mode_and_update_toolbar.assert_called_once_with(
-            "template_user_benzene"
-        )
-        dm.host.statusBar_mock.showMessage.assert_called_once()
-
-    def test_on_finished_noop_when_no_template_selected(self, dm):
-        """Finishing without a selection does not change mode: the dialog's own
-        closeEvent has already put the toolbar back."""
-        dm.host.template_dialog = None
-        captured_cb = []
-
-        with patch("moleditpy.ui.dialog_logic.UserTemplateDialog") as MockUT:
-            instance = MagicMock()
-            MockUT.return_value = instance
-            instance.finished.connect.side_effect = lambda cb: captured_cb.append(cb)
-            dm.open_template_dialog_and_activate()
-
-        dm.host.template_dialog.selected_template = None
-        captured_cb[0]()
         dm.host.ui_manager.set_mode_and_update_toolbar.assert_not_called()
 
 

--- a/tests/unit/test_scene_extended_logic.py
+++ b/tests/unit/test_scene_extended_logic.py
@@ -187,6 +187,46 @@ def test_benzene_template_rotation_logic(scene_setup):
     assert data.add_atom.called
 
 
+def test_user_template_replaces_clicked_atom_with_first_template_atom(scene_setup):
+    """Regression: clicking an existing atom with a user template kept the clicked
+    atom's element, so a template starting with N/O/charged atom silently placed a
+    carbon there. The clicked atom must become the template's first atom."""
+    scene, data, win = scene_setup
+
+    clicked = AtomItem(0, "C", QPointF(0, 0))
+    clicked.atom_id = 0
+    scene.atom_items[0] = clicked
+    data.atoms[0] = {"symbol": "C", "charge": 0, "radical": 0}
+
+    def mock_add_atom(symbol, pos, charge=0, radical=0):
+        new_id = len(data.atoms) + 100
+        data.atoms[new_id] = {"symbol": symbol, "charge": charge, "radical": radical}
+        return new_id
+
+    data.add_atom.side_effect = mock_add_atom
+    data.add_bond.side_effect = lambda id1, id2, order=1, stereo=0: (
+        (id1, id2),
+        "created",
+    )
+
+    context = {
+        "points": [QPointF(0, 0), QPointF(50, 0)],
+        "bonds_info": [(0, 1, 1, 0)],
+        "atoms_data": [
+            {"symbol": "N", "id": 0, "charge": 1, "radical": 0},
+            {"symbol": "O", "id": 1, "charge": 0, "radical": 0},
+        ],
+        "attachment_atom": clicked,
+    }
+
+    scene.add_user_template_fragment(context)
+
+    assert clicked.symbol == "N"
+    assert clicked.charge == 1
+    assert data.atoms[0]["symbol"] == "N"
+    assert data.atoms[0]["charge"] == 1
+
+
 def test_wedge_flip_via_key_w_pushes_undo(scene_setup):
     """Regression: pressing W on an already-wedge bond flips its direction
     (swaps the data-model key and the bond's atoms) but left order/stereo

--- a/tests/unit/test_template_fusing_preview.py
+++ b/tests/unit/test_template_fusing_preview.py
@@ -28,6 +28,9 @@ class MockTemplateScene(TemplateMixin):
         self.find_atom_near_args.append((pos, tol))
         return None
 
+    def find_bond_between(self, atom1, atom2):
+        return None
+
     def items(self, *args):
         return self.items_returned
 

--- a/tests/unit/test_template_preview.py
+++ b/tests/unit/test_template_preview.py
@@ -7,8 +7,7 @@ Covers:
     - set_geometry / set_user_template_geometry
     - boundingRect: empty polygon, regular polygon, user-template points
     - paint: None painter early-return
-    - paint_regular_template: non-aromatic, aromatic, empty polygon
-    - paint_user_template: no points, single/double/triple bonds, non-C atoms
+    - paint_ghost: ring and user templates, single/double/triple bonds, non-C atoms
     - set_chain_geometry / paint_chain: alkyl chain ghost + repeat-count label
 
   TemplatePreviewView (ui/template_preview_view.py):
@@ -75,44 +74,48 @@ def _points(n: int = 6) -> list:
 
 
 def test_preview_item_init_defaults(app):
-    """TemplatePreviewItem initialises with all geometry and flag attributes at their defaults."""
+    """TemplatePreviewItem initialises with no ghost molecule and nothing to draw."""
     item = TemplatePreviewItem()
-    assert item.is_aromatic is False
-    assert item.is_user_template is False
-    assert item.user_template_points == []
-    assert item.user_template_bonds == []
-    assert item.user_template_atoms == []
+    assert item.ghost_atoms == []
+    assert item.ghost_bonds == []
+    assert item.is_chain is False
+    assert item.boundingRect().isNull()
 
 
-def test_set_geometry_updates_polygon(app):
-    """set_geometry stores the polygon and clears is_user_template and is_aromatic flags."""
+def test_set_geometry_builds_a_ring(app):
+    """set_geometry turns the polygon into single-bonded ghost atoms."""
     item = TemplatePreviewItem()
     pts = _points(6)
     item.set_geometry(pts, is_aromatic=False)
-    assert not item.polygon.isEmpty()
-    assert item.is_aromatic is False
-    assert item.is_user_template is False
+    assert [atom.pos() for atom in item.ghost_atoms] == pts
+    assert [bond.order for bond in item.ghost_bonds] == [1] * 6
 
 
-def test_set_geometry_aromatic_flag(app):
-    """set_geometry sets is_aromatic=True when the flag is passed."""
+def test_set_geometry_aromatic_alternates_bonds(app):
+    """An aromatic ring previews as the Kekulé structure that gets placed."""
     item = TemplatePreviewItem()
     item.set_geometry(_points(6), is_aromatic=True)
-    assert item.is_aromatic is True
+    assert [bond.order for bond in item.ghost_bonds] == [2, 1, 2, 1, 2, 1]
+
+
+def test_set_geometry_takes_given_bond_orders(app):
+    """The caller can pass the orders the placement will use."""
+    item = TemplatePreviewItem()
+    orders = [(i, (i + 1) % 6, 1 if i % 2 == 0 else 2) for i in range(6)]
+    item.set_geometry(_points(6), is_aromatic=True, bonds_info=orders)
+    assert [bond.order for bond in item.ghost_bonds] == [1, 2, 1, 2, 1, 2]
 
 
 def test_set_user_template_geometry(app):
-    """set_user_template_geometry stores points, bonds, atoms and sets is_user_template."""
+    """set_user_template_geometry builds the template's atoms and bonds."""
     item = TemplatePreviewItem()
     pts = _points(3)
     bonds = [(0, 1, 1), (1, 2, 2)]
     atoms = [{"symbol": "C"}, {"symbol": "N"}, {"symbol": "O"}]
     item.set_user_template_geometry(pts, bonds, atoms)
-    assert item.is_user_template is True
-    assert item.user_template_points == pts
-    assert item.user_template_bonds == bonds
-    assert item.user_template_atoms == atoms
-    assert item.is_aromatic is False
+    assert [atom.symbol for atom in item.ghost_atoms] == ["C", "N", "O"]
+    assert [bond.order for bond in item.ghost_bonds] == [1, 2]
+    assert item.is_chain is False
 
 
 # ---------------------------------------------------------------------------
@@ -149,8 +152,7 @@ def test_bounding_rect_user_template_with_points(app):
 def test_bounding_rect_user_template_no_points(app):
     """boundingRect returns a QRectF for a user template with no points."""
     item = TemplatePreviewItem()
-    item.is_user_template = True
-    item.user_template_points = []
+    item.set_user_template_geometry([], [], [])
     rect = item.boundingRect()
     assert isinstance(rect, QRectF)
 
@@ -169,34 +171,33 @@ def test_paint_none_painter_returns_early(app):
 
 
 # ---------------------------------------------------------------------------
-# TemplatePreviewItem — paint_regular_template
+# TemplatePreviewItem — painting a ring template
 # ---------------------------------------------------------------------------
 
 
-def test_paint_regular_template_non_aromatic(app):
-    """paint_regular_template draws a non-aromatic polygon without raising."""
+def test_paint_ring_template_non_aromatic(app):
+    """A plain ring template paints without raising."""
     item = TemplatePreviewItem()
     item.set_geometry(_points(6), is_aromatic=False)
     _, p = _painter()
-    item.paint_regular_template(p)
+    item.paint_ghost(p)
     p.end()
 
 
-def test_paint_regular_template_aromatic(app):
-    """paint_regular_template draws an aromatic polygon without raising."""
+def test_paint_ring_template_aromatic(app):
+    """An aromatic ring template paints without raising."""
     item = TemplatePreviewItem()
     item.set_geometry(_points(6), is_aromatic=True)
     _, p = _painter()
-    item.paint_regular_template(p)
+    item.paint_ghost(p)
     p.end()
 
 
-def test_paint_regular_template_empty_polygon(app):
-    """paint_regular_template with an empty polygon does not raise."""
+def test_paint_without_geometry_draws_nothing(app):
+    """A preview with no ghost molecule paints nothing and does not raise."""
     item = TemplatePreviewItem()
-    # polygon is empty by default — should not raise
     _, p = _painter()
-    item.paint_regular_template(p)
+    item.paint_ghost(p)
     p.end()
 
 
@@ -229,7 +230,7 @@ def test_set_chain_geometry_stores_points_and_label(app):
     item.set_chain_geometry(pts, "n = 1", QPointF(60, 10))
 
     assert item.is_chain is True
-    assert item.is_user_template is False
+    assert item.ghost_atoms == []
     assert item.chain_points == pts
     assert item.chain_label == "n = 1"
     assert item.chain_label_pos == QPointF(60, 10)
@@ -277,64 +278,64 @@ def test_paint_chain_needs_at_least_one_bond(app):
 
 
 # ---------------------------------------------------------------------------
-# TemplatePreviewItem — paint_user_template
+# TemplatePreviewItem — painting a user template
 # ---------------------------------------------------------------------------
 
 
 def test_paint_user_template_no_points_returns_early(app):
-    """paint_user_template with no points returns without raising."""
+    """A user template with no points paints nothing and does not raise."""
     item = TemplatePreviewItem()
-    item.user_template_points = []
+    item.set_user_template_geometry([], [], [])
     _, p = _painter()
-    item.paint_user_template(p)  # should not raise
+    item.paint_ghost(p)
     p.end()
 
 
 def test_paint_user_template_single_bond(app):
-    """paint_user_template renders a single bond without raising."""
+    """paint_ghost renders a single bond without raising."""
     item = TemplatePreviewItem()
     pts = [QPointF(10, 10), QPointF(60, 10)]
     bonds = [(0, 1, 1)]
     atoms = [{"symbol": "C"}, {"symbol": "C"}]
     item.set_user_template_geometry(pts, bonds, atoms)
     _, p = _painter()
-    item.paint_user_template(p)
+    item.paint_ghost(p)
     p.end()
 
 
 def test_paint_user_template_double_bond(app):
-    """paint_user_template renders a double bond without raising."""
+    """paint_ghost renders a double bond without raising."""
     item = TemplatePreviewItem()
     pts = [QPointF(10, 10), QPointF(60, 10)]
     bonds = [(0, 1, 2)]
     atoms = [{"symbol": "C"}, {"symbol": "C"}]
     item.set_user_template_geometry(pts, bonds, atoms)
     _, p = _painter()
-    item.paint_user_template(p)
+    item.paint_ghost(p)
     p.end()
 
 
 def test_paint_user_template_triple_bond(app):
-    """paint_user_template renders a triple bond without raising."""
+    """paint_ghost renders a triple bond without raising."""
     item = TemplatePreviewItem()
     pts = [QPointF(10, 10), QPointF(60, 10)]
     bonds = [(0, 1, 3)]
     atoms = [{"symbol": "C"}, {"symbol": "C"}]
     item.set_user_template_geometry(pts, bonds, atoms)
     _, p = _painter()
-    item.paint_user_template(p)
+    item.paint_ghost(p)
     p.end()
 
 
 def test_paint_user_template_non_carbon_atom(app):
-    """paint_user_template renders non-carbon atom labels without raising."""
+    """paint_ghost renders non-carbon atom labels without raising."""
     item = TemplatePreviewItem()
     pts = [QPointF(50, 50), QPointF(100, 50)]
     bonds = [(0, 1, 1)]
     atoms = [{"symbol": "N"}, {"symbol": "O"}]
     item.set_user_template_geometry(pts, bonds, atoms)
     _, p = _painter()
-    item.paint_user_template(p)
+    item.paint_ghost(p)
     p.end()
 
 
@@ -346,7 +347,7 @@ def test_paint_user_template_bond_info_2_elements(app):
     atoms = [{"symbol": "C"}, {"symbol": "C"}]
     item.set_user_template_geometry(pts, bonds, atoms)
     _, p = _painter()
-    item.paint_user_template(p)
+    item.paint_ghost(p)
     p.end()
 
 
@@ -358,7 +359,7 @@ def test_paint_user_template_out_of_range_indices(app):
     atoms = [{"symbol": "C"}]
     item.set_user_template_geometry(pts, bonds, atoms)
     _, p = _painter()
-    item.paint_user_template(p)
+    item.paint_ghost(p)
     p.end()
 
 

--- a/tests/unit/test_template_preview.py
+++ b/tests/unit/test_template_preview.py
@@ -420,6 +420,19 @@ def test_impossible_valence_still_previews(app):
     p.end()
 
 
+def test_repeated_bond_pair_still_previews(app):
+    """A template listing the same pair twice must not cost the whole preview its
+    hydrogens: RDKit rejects a duplicate bond and the topology pass would bail."""
+    item = TemplatePreviewItem()
+    item.set_user_template_geometry(
+        [QPointF(0, 0), QPointF(50, 0)],
+        [(0, 1, 1, 0), (1, 0, 1, 0)],
+        [{"symbol": "C"}, {"symbol": "O"}],
+    )
+    assert len(item.ghost_bonds) == 1
+    assert item.ghost_atoms[1].implicit_h_count == 1
+
+
 def test_geometry_change_is_announced_after_the_ghost_exists(app):
     """Regression: the scene cached this item's empty boundingRect during the
     rebuild (find_atom_near queries it), so Qt culled the preview and no ghost

--- a/tests/unit/test_template_preview.py
+++ b/tests/unit/test_template_preview.py
@@ -33,6 +33,7 @@ Covers:
 """
 
 import json
+import pytest
 from unittest.mock import MagicMock, patch
 from PyQt6.QtCore import QPointF, QRectF, QSize
 from PyQt6.QtGui import QImage, QPainter, QResizeEvent, QShowEvent
@@ -359,6 +360,157 @@ def test_paint_user_template_out_of_range_indices(app):
     _, p = _painter()
     item.paint_user_template(p)
     p.end()
+
+
+# ---------------------------------------------------------------------------
+# TemplatePreviewItem — ghost molecule built from the real AtomItem/BondItem
+# ---------------------------------------------------------------------------
+
+
+def test_ghost_items_mirror_the_template(app):
+    """The preview builds one AtomItem per point and one BondItem per bond."""
+    item = TemplatePreviewItem()
+    item.set_user_template_geometry(
+        [QPointF(0, 0), QPointF(50, 0), QPointF(75, 43)],
+        [(0, 1, 2, 0), (1, 2, 1, 0)],
+        [{"symbol": "N"}, {"symbol": "C"}, {"symbol": "C"}],
+    )
+    assert [a.symbol for a in item.ghost_atoms] == ["N", "C", "C"]
+    assert [b.order for b in item.ghost_bonds] == [2, 1]
+    # The bonds have to be registered on the atoms or carbons stay visible
+    assert len(item.ghost_atoms[1].bonds) == 2
+
+
+def test_ghost_atoms_get_implicit_hydrogens(app):
+    """Implicit H counts come from RDKit, so O of an alcohol previews as OH."""
+    item = TemplatePreviewItem()
+    item.set_user_template_geometry(
+        [QPointF(0, 0), QPointF(50, 0)],
+        [(0, 1, 1, 0)],
+        [{"symbol": "C"}, {"symbol": "O"}],
+    )
+    assert item.ghost_atoms[0].implicit_h_count == 3
+    assert item.ghost_atoms[1].implicit_h_count == 1
+
+
+def test_ghost_ring_bonds_carry_ring_center(app):
+    """Ring double bonds need is_in_ring/ring_center to draw the inner short line."""
+    item = TemplatePreviewItem()
+    item.set_geometry(_points(6), is_aromatic=True)
+    assert all(b.is_in_ring for b in item.ghost_bonds)
+    assert all(b.ring_center is not None for b in item.ghost_bonds)
+    # Kekulé alternation, matching what add_molecule_fragment creates
+    assert [b.order for b in item.ghost_bonds] == [2, 1, 2, 1, 2, 1]
+
+
+def test_impossible_valence_still_previews(app):
+    """The preview draws what the template says — the valence is never checked."""
+    item = TemplatePreviewItem()
+    pts = [QPointF(0, 0)] + _points(5)
+    bonds = [(0, i, 1, 0) for i in range(1, 6)]
+    atoms = [{"symbol": "C"}] * 6
+    item.set_user_template_geometry(pts, bonds, atoms)
+    assert len(item.ghost_bonds) == 5
+    # The five-bonded carbon simply gets no hydrogens; the rest keep theirs
+    assert item.ghost_atoms[0].implicit_h_count == 0
+    assert item.ghost_atoms[1].implicit_h_count == 3
+    _, p = _painter()
+    item.paint_ghost(p)
+    p.end()
+
+
+def test_geometry_change_is_announced_after_the_ghost_exists(app):
+    """Regression: the scene cached this item's empty boundingRect during the
+    rebuild (find_atom_near queries it), so Qt culled the preview and no ghost
+    was painted in the editor. The rebuild must announce the geometry again
+    once the ghost items are in place."""
+    item = TemplatePreviewItem()
+    seen = []
+    item.prepareGeometryChange = lambda: seen.append(len(item.ghost_atoms))
+
+    item.set_user_template_geometry(
+        [QPointF(0, 0), QPointF(50, 0)],
+        [(0, 1, 1, 0)],
+        [{"symbol": "N"}, {"symbol": "C"}],
+    )
+
+    assert seen[-1] == 2
+
+
+def test_moving_the_cursor_reuses_the_ghost_items(app):
+    """A cursor move must not rebuild the ghost; rebuilding every move made big
+    templates lag."""
+    item = TemplatePreviewItem()
+    bonds = [(0, 1, 1, 0)]
+    atoms = [{"symbol": "N"}, {"symbol": "C"}]
+    item.set_user_template_geometry([QPointF(0, 0), QPointF(50, 0)], bonds, atoms)
+    first_atoms = list(item.ghost_atoms)
+
+    item.set_user_template_geometry([QPointF(90, 30), QPointF(140, 30)], bonds, atoms)
+
+    assert item.ghost_atoms == first_atoms
+    assert item.ghost_atoms[0].pos() == QPointF(90, 30)
+    assert item.ghost_bonds[0].pos() == QPointF(90, 30)
+
+
+def test_changed_template_rebuilds_the_ghost(app):
+    """A different template must not reuse the previous ghost items."""
+    item = TemplatePreviewItem()
+    points = [QPointF(0, 0), QPointF(50, 0)]
+    item.set_user_template_geometry(
+        points, [(0, 1, 1, 0)], [{"symbol": "N"}, {"symbol": "C"}]
+    )
+    first_atoms = list(item.ghost_atoms)
+
+    item.set_user_template_geometry(
+        points, [(0, 1, 2, 0)], [{"symbol": "O"}, {"symbol": "C"}]
+    )
+
+    assert item.ghost_atoms != first_atoms
+    assert item.ghost_atoms[0].symbol == "O"
+    assert item.ghost_bonds[0].order == 2
+
+
+def test_ring_centres_follow_a_moved_ghost(app):
+    """The inner line of a ring double bond is placed from the ring centre, so the
+    centre has to move with the preview."""
+    item = TemplatePreviewItem()
+    item.set_geometry(_points(6), is_aromatic=True)
+    before = item.ghost_bonds[0].ring_center
+
+    item.set_geometry([p + QPointF(200, 0) for p in _points(6)], is_aromatic=True)
+    after = item.ghost_bonds[0].ring_center
+
+    assert after[0] == pytest.approx(before[0] + 200)
+    assert after[1] == pytest.approx(before[1])
+
+
+def test_first_atom_is_marked_for_user_templates_only(app):
+    """The attachment atom is highlighted for user templates, not for rings."""
+    item = TemplatePreviewItem()
+    item.set_user_template_geometry(
+        [QPointF(0, 0), QPointF(50, 0)],
+        [(0, 1, 1, 0)],
+        [{"symbol": "N"}, {"symbol": "C"}],
+    )
+    assert item.mark_first_atom is True
+    item.set_geometry(_points(6))
+    assert item.mark_first_atom is False
+
+
+def test_ghosts_stay_out_of_the_editor_scene(app):
+    """Ghost atoms must never enter the editor scene or hit tests would find them."""
+    scene = QGraphicsScene()
+    item = TemplatePreviewItem()
+    scene.addItem(item)
+    item.set_user_template_geometry(
+        [QPointF(0, 0), QPointF(50, 0)],
+        [(0, 1, 1, 0)],
+        [{"symbol": "C"}, {"symbol": "C"}],
+    )
+    assert item.ghost_atoms
+    assert all(a.scene() is item.ghost_scene for a in item.ghost_atoms)
+    assert scene.items() == [item]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_ui_manager_robustness.py
+++ b/tests/unit/test_ui_manager_robustness.py
@@ -287,6 +287,16 @@ def test_set_mode_and_update_toolbar_checks_matching_action():
     select_action.setChecked.assert_called_with(False)
 
 
+def test_set_mode_and_update_toolbar_without_a_user_template_button():
+    """A host that never registered the USER action must not raise."""
+    ui = _make_ui_manager()
+    ui.host.init_manager.mode_actions = {"atom_C": MagicMock()}
+
+    ui.set_mode_and_update_toolbar("template_user_MyFrag")
+
+    ui.host.init_manager.mode_actions["atom_C"].setChecked.assert_called_with(False)
+
+
 def test_set_mode_and_update_toolbar_user_template_checks_user_button():
     ui = _make_ui_manager()
     template_action = MagicMock()

--- a/tests/unit/test_ui_manager_robustness.py
+++ b/tests/unit/test_ui_manager_robustness.py
@@ -281,30 +281,25 @@ def test_set_mode_and_update_toolbar_checks_matching_action():
         "select": select_action,
         "atom_C": atom_action,
     }
-    btn = MagicMock()
-    ui.host.init_manager.toolbar.widgetForAction.return_value = btn
-    ui.host.init_manager.toolbar_bottom.widgetForAction.return_value = None
-
     ui.set_mode_and_update_toolbar("atom_C")
 
     atom_action.setChecked.assert_called_with(True)
     select_action.setChecked.assert_called_with(False)
-    btn.setStyleSheet.assert_called_with("")
 
 
-def test_set_mode_and_update_toolbar_user_template_highlight():
+def test_set_mode_and_update_toolbar_user_template_checks_user_button():
     ui = _make_ui_manager()
     template_action = MagicMock()
-    ui.host.init_manager.mode_actions = {"template_user": template_action}
-    btn = MagicMock()
-    # The template buttons live on the second toolbar, not the main one
-    ui.host.init_manager.toolbar.widgetForAction.return_value = None
-    ui.host.init_manager.toolbar_bottom.widgetForAction.return_value = btn
+    other_action = MagicMock()
+    ui.host.init_manager.mode_actions = {
+        "template_user": template_action,
+        "atom_C": other_action,
+    }
 
     ui.set_mode_and_update_toolbar("template_user_MyFrag")
 
     template_action.setChecked.assert_called_with(True)
-    assert "background-color" in btn.setStyleSheet.call_args.args[0]
+    other_action.setChecked.assert_called_with(False)
 
 
 def test_activate_select_mode_checks_select_action():

--- a/tests/unit/test_ui_manager_robustness.py
+++ b/tests/unit/test_ui_manager_robustness.py
@@ -283,6 +283,7 @@ def test_set_mode_and_update_toolbar_checks_matching_action():
     }
     btn = MagicMock()
     ui.host.init_manager.toolbar.widgetForAction.return_value = btn
+    ui.host.init_manager.toolbar_bottom.widgetForAction.return_value = None
 
     ui.set_mode_and_update_toolbar("atom_C")
 
@@ -296,7 +297,9 @@ def test_set_mode_and_update_toolbar_user_template_highlight():
     template_action = MagicMock()
     ui.host.init_manager.mode_actions = {"template_user": template_action}
     btn = MagicMock()
-    ui.host.init_manager.toolbar.widgetForAction.return_value = btn
+    # The template buttons live on the second toolbar, not the main one
+    ui.host.init_manager.toolbar.widgetForAction.return_value = None
+    ui.host.init_manager.toolbar_bottom.widgetForAction.return_value = btn
 
     ui.set_mode_and_update_toolbar("template_user_MyFrag")
 


### PR DESCRIPTION
## Summary

- **Clicking an existing atom with a user template now overwrites it with the template's first atom** (element, charge, radical) instead of silently keeping the old element — placing a template that starts with N/O/a charged atom used to leave a carbon there.
- **The placement ghost is drawn with the editor's own `AtomItem`/`BondItem`**, so the preview shows what the click will actually produce: implicit hydrogens, label-aware bond trimming, ring inner-double-bond shortening, and the Kekulé rotation a fused six-ring will get. The attachment atom is marked, and the dialog thumbnails are built from the same code. Chemistry is deliberately never validated for a preview.
- **Toolbar mode clarity**: picking a user template checks the USER button (it tried to check a `mode_actions` key that never existed, behind a guard that was always false), leaving template mode clears the dialog's highlight, and Esc now exits template mode exactly like the Close button.
- **Version bumped to 4.8.0**, and the test suite no longer writes the developer's real `~/.moleditpy/settings.json`.

Preview performance was the reason for most of the rework: a large template cost ~238 ms per mouse move (per-atom `scene.items()` walks plus repeated bounding-rect computation) and now costs ~9.5 ms via position bucketing, a cached rect, and ghost reuse keyed on a molecule signature.

## Type of change

- [x] Bug fix
- [x] New feature
- [x] Refactor / code cleanup
- [ ] Documentation
- [x] Tests
- [ ] CI / build

## Related issues

<!-- none -->

## Test plan

- [x] Ran `python tests/run_all_tests.py` — all pass (2055 unit + 87 integration)
- [x] Manually tested in the GUI with the check list
- [x] Added new unit tests

Notable regressions covered by new tests, each verified to fail without its fix:

| Test | Bug it pins |
|---|---|
| `test_preview_is_indexed_where_it_is_drawn` | the scene cached an empty `boundingRect` during the rebuild, so Qt culled the ghost and nothing was painted |
| `test_fused_ring_preview_uses_the_placement_rotation` | preview drew the unrotated Kekulé pattern while placement rotated it |
| `test_user_template_previews_its_own_atoms_over_existing_ones` | ghost promised a fusion `add_user_template_fragment` does not perform |
| `test_repeated_bond_pair_still_previews` | a duplicate bond pair made RDKit reject the molecule, costing every atom its implicit hydrogens |
| `test_using_a_user_template_checks_the_user_toolbar_button` | USER never showed the active mode |
| `test_escape_leaves_template_mode_like_the_close_button` | Esc skips `closeEvent`, leaving a template armed the dialog had forgotten |

## Checklist

- [x] `python -m flake8 moleditpy/src/ --select=F` returns 0 issues
- [x] No bare `except:` clauses added (use `except Exception as e:` and log the error)
- [x] No new unused imports or variables
- [x] Plugin API changes are backwards-compatible (or documented in Summary)

`ruff format` / `ruff check` / `mypy` clean; pylint 9.38 project-wide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016rPLs4LjFgBPhaBKyJphew
