### PR TITLE
Plugin menu ordering, template ghost fidelity, and Clear All zoom

### DIFF
--- a/docs/PLUGIN_DEVELOPMENT_MANUAL_V4.md
+++ b/docs/PLUGIN_DEVELOPMENT_MANUAL_V4.md
@@ -75,7 +75,7 @@ Define these at the top of your script. They are used for the UI and the interna
 | `PLUGIN_VERSION` | Version string (e.g., `"1.0.2"` or `"2026.03.31"`). |
 | `PLUGIN_AUTHOR` | Name of the developer. |
 | `PLUGIN_DESCRIPTION` | A short summary shown in the Plugin Manager. |
-| `PLUGIN_CATEGORY` | Optional category (e.g., `"Analysis"`, `"Visualization"`). |
+| `PLUGIN_CATEGORY` | Optional category (e.g., `"Analysis"`, `"Visualization"`), used as the sub-menu for `run()`-based plugins. **Applies only when the plugin file sits directly in the plugins root.** If the user filed it inside a category folder, that folder wins — where they put it is their decision, not the plugin's. |
 | `PLUGIN_SUPPORTED_MOLEDITPY_VERSION` | Optional: Version specifier matching the current MoleditPy app version (e.g., `"3.*"`, `">=3.5"`). |
 | `PLUGIN_TAGS` | Optional: List of tags/categories (e.g., `["Utility", "Analysis"]`). |
 | `PLUGIN_DEPENDENCIES` | Optional: List of package dependency strings the plugin **requires**. Supports standard PEP-508 version constraints (e.g. `["numpy>=1.20", "rdkit>=2022.03"]`) or packages without version constraints. |
@@ -170,7 +170,7 @@ Display a temporary message in the application's bottom status bar.
 - **message** (`str`): The text to display.
 - **timeout** (`int`): Duration in milliseconds before the message disappears. Default is 3000ms.
 
-#### `add_menu_action(path, callback, text=None, icon=None, shortcut=None)`
+#### `add_menu_action(path, callback, text=None, icon=None, shortcut=None, pin=None)`
 Register a custom item in the main menu. MoleditPy will automatically create any sub-menus defined in the path.
 - **path** (`str`): The full menu path.
     - Use `File/My Action` to add to existing menus.
@@ -179,17 +179,41 @@ Register a custom item in the main menu. MoleditPy will automatically create any
 - **text** (`str`, optional): The label of the menu item. Defaults to the last part of `path`.
 - **icon** (`str`, optional): Path to an image file or a standard icon name.
 - **shortcut** (`str`, optional): Keyboard shortcut (e.g., `"Ctrl+Shift+X"`).
+- **pin** (`str`, optional): Placement request — see [Pinning to the Plugin menu header](#pinning-to-the-plugin-menu-header) below. Added in 4.8.1.
 
 > [!NOTE]
 > `register_menu_action` is a deprecated alias kept for V2 compatibility. New plugins should always use `add_menu_action`.
 
-#### `add_plugin_menu(path, callback, text=None, icon=None, shortcut=None)`
+##### Pinning to the Plugin menu header
+
+The Plugin menu opens with `Plugin Manager...`, then a divider, then the installed plugins. A plugin that **manages the plugin system itself** — rather than acting on a molecule — belongs with the manager above that divider, not among the plugins it installs. Pass `pin="header"` to ask for that slot:
+
+```python
+context.add_menu_action("Plugin/My Installer...", open_installer, pin="header")
+```
+
+The request is granted only for a direct `Plugin/<entry>` path — a nested path such as `Plugin/Tools/My Installer...` is placed normally. Any other `pin` value is ignored, so unrecognised values stay forward compatible.
+
+This is for plugin-management tools. An ordinary plugin that pins itself just crowds the header and pushes the real plugin list further down.
+
+> [!WARNING]
+> `pin` did not exist before 4.8.1, and passing it to an older MoleditPy raises `TypeError` out of `initialize()` — which drops your plugin entirely, not just its placement. If you support older releases, guard the call:
+>
+> ```python
+> try:
+>     context.add_menu_action("Plugin/My Installer...", open_installer, pin="header")
+> except TypeError:
+>     context.add_menu_action("Plugin/My Installer...", open_installer)
+> ```
+
+#### `add_plugin_menu(path, callback, text=None, icon=None, shortcut=None, pin=None)`
 Register an action nested inside the **Plugins** menu. This is the preferred way to keep the main menu bar clean if your plugin has many tools.
 - **path** (`str`): The sub-path within the Plugin menu (e.g., `"Utils/My Tool"`).
 - **callback** (`Callable`): Function to execute.
 - **text** (`str`, optional): Label for the action.
 - **icon** (`str`, optional): Icon path.
 - **shortcut** (`str`, optional): Keyboard shortcut.
+- **pin** (`str`, optional): Placement request; see `add_menu_action`. Added in 4.8.1.
 
 #### `add_toolbar_action(callback, text, icon=None, tooltip=None)`
 Add a button to the dedicated **Plugin Toolbar**. The toolbar is hidden until at least one plugin registers an action — it appears automatically the first time this method is called.

--- a/moleditpy/pyproject.toml
+++ b/moleditpy/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "MoleditPy"
 
-version = "4.8.0"
+version = "4.8.1"
 
 license = {file = "LICENSE"}
 

--- a/moleditpy/src/moleditpy/plugins/plugin_interface.py
+++ b/moleditpy/src/moleditpy/plugins/plugin_interface.py
@@ -31,6 +31,7 @@ class PluginContext:
         text: Optional[str] = None,
         icon: Optional[str] = None,
         shortcut: Optional[str] = None,
+        pin: Optional[str] = None,
     ) -> None:
         """
         Register a menu action.
@@ -41,9 +42,16 @@ class PluginContext:
             text: Label for the action (defaults to last part of path if None).
             icon: Path to icon or icon name (optional).
             shortcut: Keyboard shortcut (optional).
+            pin: Placement request. ``"header"`` puts a direct "Plugin/<entry>"
+                registration next to "Plugin Manager..." above the first
+                divider, for plugins that manage the plugin system itself.
+                Anything else is ignored, so unknown values stay forward
+                compatible. Added in 4.8.1 — passing it to an older MoleditPy
+                raises TypeError, so guard the call if your plugin supports
+                both (see PLUGIN_DEVELOPMENT_MANUAL_V4.md).
         """
         self._manager.register_menu_action(
-            self._plugin_name, path, callback, text, icon, shortcut
+            self._plugin_name, path, callback, text, icon, shortcut, pin
         )
 
     def register_menu_action(
@@ -72,6 +80,7 @@ class PluginContext:
         text: Optional[str] = None,
         icon: Optional[str] = None,
         shortcut: Optional[str] = None,
+        pin: Optional[str] = None,
     ) -> None:
         """
         Register an action nested inside the Plugin menu.
@@ -87,9 +96,10 @@ class PluginContext:
             text: Label override (defaults to last part of path).
             icon: Path to icon (optional).
             shortcut: Keyboard shortcut (optional).
+            pin: Placement request; see add_menu_action.
         """
         full_path = f"Plugin/{path.lstrip('/')}"
-        self.add_menu_action(full_path, callback, text, icon, shortcut)
+        self.add_menu_action(full_path, callback, text, icon, shortcut, pin)
 
     def add_toolbar_action(
         self,

--- a/moleditpy/src/moleditpy/plugins/plugin_manager.py
+++ b/moleditpy/src/moleditpy/plugins/plugin_manager.py
@@ -358,7 +358,13 @@ class PluginManager:
                 plugin_desc = getattr(
                     module, "PLUGIN_DESCRIPTION", getattr(module, "__doc__", "")
                 )
-                plugin_category = getattr(module, "PLUGIN_CATEGORY", category)
+                # The folder the user filed the plugin under wins: that
+                # placement is a deliberate, user-controlled ordering. A
+                # plugin's own PLUGIN_CATEGORY only applies when the file sits
+                # at the plugins root, where there is no folder to honour.
+                plugin_category = category or str(
+                    getattr(module, "PLUGIN_CATEGORY", "") or ""
+                )
 
                 # Additional cleanup for docstring (strip whitespace)
                 if plugin_desc is None:

--- a/moleditpy/src/moleditpy/plugins/plugin_manager.py
+++ b/moleditpy/src/moleditpy/plugins/plugin_manager.py
@@ -451,8 +451,13 @@ class PluginManager:
         text: str,
         icon: str,
         shortcut: str,
+        pin: Optional[str] = None,
     ) -> None:
-        """Register a plugin menu action with its path, callback, and display metadata."""
+        """Register a plugin menu action with its path, callback, and display metadata.
+
+        ``pin`` is optional so a V3-era caller reaching this method directly
+        keeps working.
+        """
         self.menu_actions.append(
             {
                 "plugin": plugin_name,
@@ -461,6 +466,7 @@ class PluginManager:
                 "text": text,
                 "icon": icon,
                 "shortcut": shortcut,
+                "pin": pin,
             }
         )
 

--- a/moleditpy/src/moleditpy/ui/edit_actions_logic.py
+++ b/moleditpy/src/moleditpy/ui/edit_actions_logic.py
@@ -883,9 +883,11 @@ class EditActionsManager:
         self.host.set_current_file_path(None)
         self.host.state_manager.update_window_title()
 
-        # Reset 2D zoom
+        # Reset 2D zoom to the launch default (75%), not the bare identity
+        # transform -- resetTransform() left the view at 100%, so Clear All
+        # came back zoomed in compared to a freshly started session.
         if self.host.init_manager.view_2d:
-            self.host.init_manager.view_2d.resetTransform()
+            self.host.view_3d_manager.reset_zoom()
 
         # Update scene and view
         self.host.init_manager.scene.update()

--- a/moleditpy/src/moleditpy/ui/molecular_scene_handler.py
+++ b/moleditpy/src/moleditpy/ui/molecular_scene_handler.py
@@ -197,6 +197,40 @@ class TemplateMixin:
 
         return not atom1_has_other_double and not atom2_has_other_double
 
+    def _resolve_shared_bonds(
+        self,
+        bonds: List[Tuple[int, int, int]],
+        vertex_atoms: List[Optional[AtomItem]],
+    ) -> Tuple[List[Tuple[int, int, int]], List[Tuple[int, int]]]:
+        """Reconcile the template's bond orders with the bonds already drawn.
+
+        A vertex that snapped onto an existing atom may share a bond with
+        another such vertex, and ``add_molecule_fragment`` leaves that bond
+        alone unless the benzene overwrite policy applies.
+
+        Returns the orders placement will actually leave, plus the vertex pairs
+        the editor is already drawing. The orders keep the ghost's implicit
+        hydrogens honest; the pairs keep the ghost from painting a second copy
+        of a bond that is not changing — over an existing double bond that
+        second copy reads as a triple.
+        """
+        is_benzene_template = len(bonds) == 6 and any(o == 2 for _, _, o in bonds)
+        resolved: List[Tuple[int, int, int]] = []
+        unchanged: List[Tuple[int, int]] = []
+        for i, j, order in bonds:
+            atom_i = vertex_atoms[i] if i < len(vertex_atoms) else None
+            atom_j = vertex_atoms[j] if j < len(vertex_atoms) else None
+            exist_b = (
+                self.find_bond_between(atom_i, atom_j) if atom_i and atom_j else None
+            )
+            if exist_b is not None and not (
+                is_benzene_template and self._should_overwrite_benzene_bond(exist_b)
+            ):
+                order = getattr(exist_b, "order", order)
+                unchanged.append((i, j))
+            resolved.append((i, j, order))
+        return resolved, unchanged
+
     def add_molecule_fragment(
         self,
         points: List[Union[QPointF, Tuple[float, float]]],
@@ -514,7 +548,12 @@ class TemplateMixin:
                     for m, (i, j, _) in enumerate(bonds_info)
                 ]
 
-            self.template_preview.set_geometry(points, is_aromatic, preview_bonds)
+            preview_bonds, editor_drawn = self._resolve_shared_bonds(
+                preview_bonds, vertex_atoms
+            )
+            self.template_preview.set_geometry(
+                points, is_aromatic, preview_bonds, editor_drawn
+            )
 
             self.template_preview.show()
             if self.views():

--- a/moleditpy/src/moleditpy/ui/molecular_scene_handler.py
+++ b/moleditpy/src/moleditpy/ui/molecular_scene_handler.py
@@ -24,6 +24,7 @@ from .bond_item import BondItem
 
 from ..utils.sip_isdeleted_safe import sip_isdeleted_safe
 
+from ..core.mol_geometry import is_problematic_valence
 from ..utils.constants import DEFAULT_BOND_LENGTH, SUM_TOLERANCE
 
 
@@ -197,6 +198,54 @@ class TemplateMixin:
 
         return not atom1_has_other_double and not atom2_has_other_double
 
+    @staticmethod
+    def _bond_load(atom: Optional[AtomItem]) -> float:
+        """Total bond order already attached to *atom*."""
+        if atom is None:
+            return 0.0
+        return sum(b.order for b in atom.bonds)
+
+    def _fit_bond_orders_to_valence(
+        self,
+        bonds: List[Tuple[int, int, int]],
+        vertex_atoms: List[Optional[AtomItem]],
+    ) -> List[Tuple[int, int, int]]:
+        """Lower template bond orders that would overfill an atom.
+
+        A Kekulé ring always carries a double next to its fused bond, so fusing
+        benzene onto a bond whose atoms each already hold a double — every
+        peripheral single bond of naphthalene — hands one of them a fifth bond.
+        Adding the ring with those bonds single instead leaves the new carbons
+        as methylene: a real molecule rather than a hypervalent one.
+
+        Loads are carried across the ring so several new bonds on the same atom
+        are counted together, and bonds that already exist are skipped — the
+        placement keeps those, and their order is in the load already.
+        """
+        loads = {i: self._bond_load(atom) for i, atom in enumerate(vertex_atoms)}
+        for i in range(len(bonds)):
+            loads.setdefault(i, 0.0)
+
+        def overloads(index: int, order: int) -> bool:
+            atom = vertex_atoms[index] if index < len(vertex_atoms) else None
+            symbol = getattr(atom, "symbol", "C")
+            charge = int(getattr(atom, "charge", 0) or 0)
+            return is_problematic_valence(symbol, loads.get(index, 0.0) + order, charge)
+
+        resolved: List[Tuple[int, int, int]] = []
+        for i, j, order in bonds:
+            atom_i = vertex_atoms[i] if i < len(vertex_atoms) else None
+            atom_j = vertex_atoms[j] if j < len(vertex_atoms) else None
+            if atom_i and atom_j and self.find_bond_between(atom_i, atom_j):
+                resolved.append((i, j, order))
+                continue
+            while order > 1 and (overloads(i, order) or overloads(j, order)):
+                order -= 1
+            loads[i] = loads.get(i, 0.0) + order
+            loads[j] = loads.get(j, 0.0) + order
+            resolved.append((i, j, order))
+        return resolved
+
     def _resolve_shared_bonds(
         self,
         bonds: List[Tuple[int, int, int]],
@@ -350,6 +399,12 @@ class TemplateMixin:
                 new_order = orig_orders[(m + best_rot) % num_points]
                 new_tb.append((i_idx, j_idx, new_order))
             template_bonds_to_use = new_tb
+
+        # Atoms exist but carry no template bonds yet, so their loads are the
+        # ones the fusion has to fit into.
+        template_bonds_to_use = self._fit_bond_orders_to_valence(
+            list(template_bonds_to_use), atom_items
+        )
 
         # --- 5) Bond Creation/Update ---
         for id1_idx, id2_idx, order in template_bonds_to_use:
@@ -549,6 +604,9 @@ class TemplateMixin:
                 ]
 
             preview_bonds, editor_drawn = self._resolve_shared_bonds(
+                preview_bonds, vertex_atoms
+            )
+            preview_bonds = self._fit_bond_orders_to_valence(
                 preview_bonds, vertex_atoms
             )
             self.template_preview.set_geometry(

--- a/moleditpy/src/moleditpy/ui/molecular_scene_handler.py
+++ b/moleditpy/src/moleditpy/ui/molecular_scene_handler.py
@@ -205,80 +205,98 @@ class TemplateMixin:
             return 0.0
         return sum(b.order for b in atom.bonds)
 
-    def _fit_bond_orders_to_valence(
-        self,
-        bonds: List[Tuple[int, int, int]],
-        vertex_atoms: List[Optional[AtomItem]],
-    ) -> List[Tuple[int, int, int]]:
-        """Lower template bond orders that would overfill an atom.
-
-        A Kekulé ring always carries a double next to its fused bond, so fusing
-        benzene onto a bond whose atoms each already hold a double — every
-        peripheral single bond of naphthalene — hands one of them a fifth bond.
-        Adding the ring with those bonds single instead leaves the new carbons
-        as methylene: a real molecule rather than a hypervalent one.
-
-        Loads are carried across the ring so several new bonds on the same atom
-        are counted together, and bonds that already exist are skipped — the
-        placement keeps those, and their order is in the load already.
-        """
-        loads = {i: self._bond_load(atom) for i, atom in enumerate(vertex_atoms)}
-        for i in range(len(bonds)):
-            loads.setdefault(i, 0.0)
-
-        def overloads(index: int, order: int) -> bool:
-            atom = vertex_atoms[index] if index < len(vertex_atoms) else None
-            symbol = getattr(atom, "symbol", "C")
-            charge = int(getattr(atom, "charge", 0) or 0)
-            return is_problematic_valence(symbol, loads.get(index, 0.0) + order, charge)
-
-        resolved: List[Tuple[int, int, int]] = []
-        for i, j, order in bonds:
-            atom_i = vertex_atoms[i] if i < len(vertex_atoms) else None
-            atom_j = vertex_atoms[j] if j < len(vertex_atoms) else None
-            if atom_i and atom_j and self.find_bond_between(atom_i, atom_j):
-                resolved.append((i, j, order))
-                continue
-            while order > 1 and (overloads(i, order) or overloads(j, order)):
-                order -= 1
-            loads[i] = loads.get(i, 0.0) + order
-            loads[j] = loads.get(j, 0.0) + order
-            resolved.append((i, j, order))
-        return resolved
-
-    def _resolve_shared_bonds(
+    def _plan_template_bonds(
         self,
         bonds: List[Tuple[int, int, int]],
         vertex_atoms: List[Optional[AtomItem]],
     ) -> Tuple[List[Tuple[int, int, int]], List[Tuple[int, int]]]:
-        """Reconcile the template's bond orders with the bonds already drawn.
+        """Decide the order every template bond ends up with once placed.
 
-        A vertex that snapped onto an existing atom may share a bond with
-        another such vertex, and ``add_molecule_fragment`` leaves that bond
-        alone unless the benzene overwrite policy applies.
+        Two things constrain the template's own alternation:
 
-        Returns the orders placement will actually leave, plus the vertex pairs
-        the editor is already drawing. The orders keep the ghost's implicit
-        hydrogens honest; the pairs keep the ghost from painting a second copy
-        of a bond that is not changing — over an existing double bond that
-        second copy reads as a triple.
+        * a bond that already exists is kept, unless the benzene policy allows
+          re-ordering it *and* both atoms have room for the extra order;
+        * a Kekule ring always carries a double next to its fused bond, so
+          fusing onto a single bond whose atoms each already hold a double --
+          every peripheral single bond of naphthalene -- would hand one of them
+          a fifth bond. Those bonds are lowered instead, which leaves the new
+          carbons as methylene: a real molecule rather than a hypervalent one.
+
+        Existing bonds are settled first so that an allowed upgrade is in the
+        atom's load before the new bonds hanging off it are fitted, and loads
+        are carried across the ring so several new bonds on one atom count
+        together.
+
+        Returns the planned orders and the vertex pairs the editor already
+        draws unchanged -- the ghost skips those, since painting a second copy
+        over a real double bond reads as a triple.
         """
         is_benzene_template = len(bonds) == 6 and any(o == 2 for _, _, o in bonds)
-        resolved: List[Tuple[int, int, int]] = []
+        loads = {i: self._bond_load(atom) for i, atom in enumerate(vertex_atoms)}
+
+        def vertex(index: int) -> Optional[AtomItem]:
+            return vertex_atoms[index] if index < len(vertex_atoms) else None
+
+        def fits(index: int, extra: float) -> bool:
+            atom = vertex(index)
+            if atom is None or extra <= 0:
+                return True
+            return not is_problematic_valence(
+                getattr(atom, "symbol", "C"),
+                loads.get(index, 0.0) + extra,
+                int(getattr(atom, "charge", 0) or 0),
+            )
+
+        planned: Dict[int, int] = {}
         unchanged: List[Tuple[int, int]] = []
-        for i, j, order in bonds:
-            atom_i = vertex_atoms[i] if i < len(vertex_atoms) else None
-            atom_j = vertex_atoms[j] if j < len(vertex_atoms) else None
+
+        # Every new bond needs at least a single, so an upgrade has to leave
+        # room for the ones still to come as well as for itself
+        incoming: Dict[int, int] = {}
+        for i, j, _order in bonds:
+            atom_i, atom_j = vertex(i), vertex(j)
+            if atom_i and atom_j and self.find_bond_between(atom_i, atom_j):
+                continue
+            incoming[i] = incoming.get(i, 0) + 1
+            incoming[j] = incoming.get(j, 0) + 1
+
+        # Pass 1 -- bonds that are already drawn
+        for position, (i, j, order) in enumerate(bonds):
+            atom_i, atom_j = vertex(i), vertex(j)
             exist_b = (
                 self.find_bond_between(atom_i, atom_j) if atom_i and atom_j else None
             )
-            if exist_b is not None and not (
-                is_benzene_template and self._should_overwrite_benzene_bond(exist_b)
+            if exist_b is None:
+                continue
+            current = int(getattr(exist_b, "order", order))
+            extra = order - current
+            if (
+                is_benzene_template
+                and self._should_overwrite_benzene_bond(exist_b)
+                and fits(i, extra + incoming.get(i, 0))
+                and fits(j, extra + incoming.get(j, 0))
             ):
-                order = getattr(exist_b, "order", order)
+                loads[i] = loads.get(i, 0.0) + extra
+                loads[j] = loads.get(j, 0.0) + extra
+                planned[position] = order
+            else:
+                planned[position] = current
                 unchanged.append((i, j))
-            resolved.append((i, j, order))
-        return resolved, unchanged
+
+        # Pass 2 -- bonds the placement will create
+        for position, (i, j, order) in enumerate(bonds):
+            if position in planned:
+                continue
+            while order > 1 and not (fits(i, order) and fits(j, order)):
+                order -= 1
+            loads[i] = loads.get(i, 0.0) + order
+            loads[j] = loads.get(j, 0.0) + order
+            planned[position] = order
+
+        return (
+            [(i, j, planned[position]) for position, (i, j, _) in enumerate(bonds)],
+            unchanged,
+        )
 
     def add_molecule_fragment(
         self,
@@ -296,8 +314,6 @@ class TemplateMixin:
 
         num_points = len(points)
         atom_items: List[Optional[AtomItem]] = [None] * num_points
-
-        is_benzene_template = num_points == 6 and any(o == 2 for _, _, o in bonds_info)
 
         def coords(p: Any) -> Any:
             if hasattr(p, "x") and hasattr(p, "y"):
@@ -402,7 +418,7 @@ class TemplateMixin:
 
         # Atoms exist but carry no template bonds yet, so their loads are the
         # ones the fusion has to fit into.
-        template_bonds_to_use = self._fit_bond_orders_to_valence(
+        template_bonds_to_use, _unchanged = self._plan_template_bonds(
             list(template_bonds_to_use), atom_items
         )
 
@@ -420,22 +436,15 @@ class TemplateMixin:
                 exist_b = self.find_bond_between(a_item, b_item)
 
                 if exist_b:
-                    # Keep existing bonds by default unless it's a safe benzene overwrite
-                    should_overwrite = (
-                        is_benzene_template
-                        and self._should_overwrite_benzene_bond(exist_b)
-                    )
-
-                    if should_overwrite:
-                        # Update bond order if conditions met
-                        exist_b.order = order
-                        exist_b.stereo = 0
-                        self.data.bonds[(id1, id2)]["order"] = order
-                        self.data.bonds[(id1, id2)]["stereo"] = 0
-                        exist_b.update()
-                    else:
-                        # Keep existing bond if conditions not met
+                    # _plan_template_bonds already applied the keep-or-overwrite
+                    # policy, so an unchanged order means keep this bond
+                    if order == exist_b.order:
                         continue
+                    exist_b.order = order
+                    exist_b.stereo = 0
+                    self.data.bonds[(id1, id2)]["order"] = order
+                    self.data.bonds[(id1, id2)]["stereo"] = 0
+                    exist_b.update()
                 else:
                     # Create new bond
                     self.create_bond(a_item, b_item, bond_order=order, bond_stereo=0)
@@ -603,10 +612,7 @@ class TemplateMixin:
                     for m, (i, j, _) in enumerate(bonds_info)
                 ]
 
-            preview_bonds, editor_drawn = self._resolve_shared_bonds(
-                preview_bonds, vertex_atoms
-            )
-            preview_bonds = self._fit_bond_orders_to_valence(
+            preview_bonds, editor_drawn = self._plan_template_bonds(
                 preview_bonds, vertex_atoms
             )
             self.template_preview.set_geometry(

--- a/moleditpy/src/moleditpy/ui/plugin_menu_manager.py
+++ b/moleditpy/src/moleditpy/ui/plugin_menu_manager.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 import logging
 import os
-from typing import Any, Callable, Dict, List, TYPE_CHECKING
+from typing import Any, Callable, Dict, List, Optional, TYPE_CHECKING
 
 from PyQt6.QtGui import QAction, QIcon, QKeySequence
 from PyQt6.QtWidgets import QFileDialog, QMenu, QMessageBox
@@ -37,6 +37,15 @@ class PluginMenuManager:
     # QAction.data() marker stamped on every plugin-owned menu entry/separator
     # so the rebuild pass can find and remove exactly those on the next reload.
     _PLUGIN_ACTION_TAG = "plugin_managed"
+
+    # Title of the menu that hosts "Plugin/<path>" registrations.
+    _PLUGIN_MENU_TITLE = "Plugin"
+
+    # Plugins that manage the plugin system itself. When installed, these sit
+    # with "Plugin Manager..." above the first divider instead of down among
+    # the plugins they install. Compared casefolded, with trailing dots
+    # stripped, against PLUGIN_NAME and the registered label.
+    _MANAGER_COMPANIONS = frozenset({"plugin installer"})
 
     def __init__(self, init_manager: MainInitManager) -> None:
         self._im = init_manager
@@ -99,12 +108,8 @@ class PluginMenuManager:
         if not self._im.host.plugin_manager:
             return
 
-        self._clear_all_plugin_actions(plugin_menu)
-
-        manage_action = QAction("Plugin Manager...", self._im.host)
-        manage_action.triggered.connect(lambda: self._show_plugin_manager(plugin_menu))
-        plugin_menu.addAction(manage_action)
-        plugin_menu.addSeparator()
+        self._clear_all_plugin_actions()
+        self._reset_plugin_menu(plugin_menu)
 
         plugins = self._im.host.plugin_manager.discover_plugins(self._im.host)
 
@@ -117,6 +122,14 @@ class PluginMenuManager:
         self.integrate_plugin_analysis_tools()
         self.integrate_plugin_optimization_methods()
 
+    def _reset_plugin_menu(self, plugin_menu: QMenu) -> None:
+        """Empty the Plugin menu and re-add its fixed header."""
+        plugin_menu.clear()
+        manage_action = QAction("Plugin Manager...", self._im.host)
+        manage_action.triggered.connect(lambda: self._show_plugin_manager(plugin_menu))
+        plugin_menu.addAction(manage_action)
+        plugin_menu.addSeparator()
+
     def rebuild_plugin_menus(self) -> None:
         """Fully rebuild all plugin-managed UI after an install/uninstall.
 
@@ -124,7 +137,12 @@ class PluginMenuManager:
         ``PluginManager.discover_plugins`` has already been called and the
         registries are fresh.  It cleans the existing tagged actions and
         re-populates every integration point: menus, toolbars, export,
-        file-openers, analysis tools, and 3D styles.
+        file-openers, analysis tools, legacy run() entries, and 3D styles.
+
+        The Plugin menu is emptied and rebuilt rather than topped up, so a
+        reload lands the context-injected entries above the folder-derived ones
+        exactly as a fresh launch does. Appending to the surviving (untagged)
+        folder entries instead used to flip the two groups on every reload.
         """
 
         def _clean_menu(menu: QMenu) -> None:
@@ -132,7 +150,11 @@ class PluginMenuManager:
                 submenu = action.menu()
                 if submenu is not None:
                     _clean_menu(submenu)
-                    if not any(not a.isSeparator() for a in submenu.actions()):
+                    # Only drop submenus the plugin system created. Native
+                    # submenus that happen to be empty are not ours to remove.
+                    if action.data() == self._PLUGIN_ACTION_TAG and not any(
+                        not a.isSeparator() for a in submenu.actions()
+                    ):
                         menu.removeAction(action)
                 elif action.data() == self._PLUGIN_ACTION_TAG:
                     self._remove_action(menu, action)
@@ -143,24 +165,21 @@ class PluginMenuManager:
         except Exception:
             logging.warning("Plugin rebuild: menu cleanup error", exc_info=True)
 
-        # Drop tagged (plugin-created) top-level menus the clean pass emptied
-        try:
-            menu_bar = self._im.host.menuBar()
-            for top_action in list(menu_bar.actions()):
-                if top_action.data() != self._PLUGIN_ACTION_TAG:
-                    continue
-                submenu = top_action.menu()
-                if submenu is None or not any(
-                    not a.isSeparator() for a in submenu.actions()
-                ):
-                    menu_bar.removeAction(top_action)
-        except Exception:
-            logging.warning("Plugin rebuild: menubar cleanup error", exc_info=True)
+        self._clear_plugin_menubar_entries()
 
-        self._im.plugin_menubar_separator_added = False
+        plugin_menu = getattr(self._im, "plugin_menu", None)
+        if plugin_menu is not None:
+            self._reset_plugin_menu(plugin_menu)
+
+        def _rebuild_legacy_actions() -> None:
+            if plugin_menu is not None:
+                self._add_legacy_plugin_actions(
+                    plugin_menu, self._im.host.plugin_manager.plugins
+                )
 
         for method, label in [
             (self.add_registered_plugin_actions, "menu actions"),
+            (_rebuild_legacy_actions, "legacy plugin actions"),
             (self.add_plugin_toolbar_actions, "toolbar actions"),
             (self.integrate_plugin_export_actions, "export actions"),
             (self.integrate_plugin_file_openers, "file openers"),
@@ -172,6 +191,90 @@ class PluginMenuManager:
                 method()
             except Exception:
                 logging.warning("Plugin rebuild: %s error", label, exc_info=True)
+
+    def _clear_plugin_menubar_entries(self) -> None:
+        """Drop emptied plugin-created top-level menus and the menubar divider.
+
+        Both clear paths need this. ``_get_plugin_target_menus`` walks *into*
+        the menus on the bar but never the bar itself, so without this pass an
+        uninstalled plugin's own top-level menu survives as an empty stub and
+        the divider in front of it is never reclaimed. Resetting the flag lets
+        the following populate pass re-add that divider.
+        """
+        try:
+            menu_bar = self._im.host.menuBar()
+            for top_action in list(menu_bar.actions()):
+                if top_action.data() != self._PLUGIN_ACTION_TAG:
+                    continue
+                submenu = top_action.menu()
+                if submenu is None or not any(
+                    not a.isSeparator() for a in submenu.actions()
+                ):
+                    menu_bar.removeAction(top_action)
+        except Exception:
+            logging.warning("Plugin menubar cleanup error", exc_info=True)
+
+        self._im.plugin_menubar_separator_added = False
+
+    def _ensure_plugin_separator(self, menu: QMenu) -> None:
+        """Add a tagged divider before the first plugin entry appended to *menu*.
+
+        The divider must land where the plugin content actually starts. For a
+        nested path like ``Tools/Sub/Item`` that is the *parent* menu, just
+        before ``Sub`` is created -- checking the freshly made (and therefore
+        empty) leaf instead placed no divider at all, and the next sibling
+        entry then saw an untagged submenu as the last action and inserted the
+        divider after the plugin submenu, splitting the plugin group instead of
+        separating it from the native entries.
+        """
+        actions = menu.actions()
+        if (
+            actions
+            and not actions[-1].isSeparator()
+            and actions[-1].data() != self._PLUGIN_ACTION_TAG
+        ):
+            sep = menu.addSeparator()
+            if sep is not None:
+                sep.setData(self._PLUGIN_ACTION_TAG)
+
+    @classmethod
+    def _is_manager_companion(
+        cls,
+        top_level_title: str,
+        parts: List[str],
+        plugin_name: Optional[str],
+        label: str,
+    ) -> bool:
+        """Return True for a plugin that belongs beside the Plugin Manager.
+
+        The Plugin Installer extends the Plugin Manager rather than acting on a
+        molecule, so it reads as part of the menu's header pair instead of as
+        one more installed plugin. Matched by name (its own PLUGIN_NAME, or the
+        label it registered) so the app needs no hard dependency on it.
+        """
+        if top_level_title != cls._PLUGIN_MENU_TITLE or len(parts) != 2:
+            return False
+        candidates = (plugin_name or "", label)
+        return any(
+            c.strip().rstrip(".").casefold() in cls._MANAGER_COMPANIONS
+            for c in candidates
+        )
+
+    @staticmethod
+    def _trim_trailing_separator(menu: QMenu) -> None:
+        """Drop a divider left dangling at the end of *menu*."""
+        actions = menu.actions()
+        if actions and actions[-1].isSeparator():
+            menu.removeAction(actions[-1])
+
+    @staticmethod
+    def _add_beside_plugin_manager(menu: QMenu, action: QAction) -> None:
+        """Add *action* to the menu's header group, above the first divider."""
+        anchor = next((a for a in menu.actions() if a.isSeparator()), None)
+        if anchor is None:
+            menu.addAction(action)
+        else:
+            menu.insertAction(anchor, action)
 
     def add_registered_plugin_actions(self) -> None:
         """Add menu actions explicitly registered by V3/V4 plugins."""
@@ -211,25 +314,33 @@ class PluginMenuManager:
                     ),
                     None,
                 )
-                current_menu = sub if sub else current_menu.addMenu(part)
+                if sub is not None:
+                    # Descending into an existing submenu appends nothing to
+                    # the parent, so no divider is due here.
+                    current_menu = sub
+                    continue
+                self._ensure_plugin_separator(current_menu)
+                current_menu = current_menu.addMenu(part)
+                current_menu.menuAction().setData(self._PLUGIN_ACTION_TAG)
 
-            actions = current_menu.actions()
-            if (
-                actions
-                and not actions[-1].isSeparator()
-                and actions[-1].data() != self._PLUGIN_ACTION_TAG
-            ):
-                sep = current_menu.addSeparator()
-                sep.setData(self._PLUGIN_ACTION_TAG)
+            label = text or parts[-1]
+            pinned = self._is_manager_companion(
+                top_level_title, parts, action_def.get("plugin"), label
+            )
+            if not pinned:
+                self._ensure_plugin_separator(current_menu)
 
-            action = QAction(text or parts[-1], self._im.host)
+            action = QAction(label, self._im.host)
             action.triggered.connect(
                 self._make_safe_callback(callback, action_def.get("plugin", "Plugin"))
             )
             if action_def.get("shortcut"):
                 action.setShortcut(QKeySequence(action_def["shortcut"]))
             action.setData(self._PLUGIN_ACTION_TAG)
-            current_menu.addAction(action)
+            if pinned:
+                self._add_beside_plugin_manager(current_menu, action)
+            else:
+                current_menu.addAction(action)
 
     def add_plugin_toolbar_actions(self) -> None:
         """Populate the plugin toolbar from registered toolbar actions."""
@@ -271,8 +382,13 @@ class PluginMenuManager:
         dlg.exec()
         self.update_plugin_menu(plugin_menu)
 
-    def _clear_all_plugin_actions(self, plugin_menu: QMenu) -> None:
-        """Remove all tagged plugin actions from every menu and the export button."""
+    def _clear_all_plugin_actions(self) -> None:
+        """Remove all tagged plugin actions from every menu and the export button.
+
+        The Plugin menu itself is not emptied here — ``_reset_plugin_menu``
+        owns that, so both the update and the rebuild path clear it the same
+        way.
+        """
 
         def clear_menu(menu: Any) -> None:
             if not menu:
@@ -283,9 +399,9 @@ class PluginMenuManager:
                 elif act.menu():
                     clear_menu(act.menu())
 
-        plugin_menu.clear()
         for menu in self._get_plugin_target_menus():
             clear_menu(menu)
+        self._clear_plugin_menubar_entries()
 
     def update_style_menu_with_plugins(self) -> None:
         """Append custom 3D styles registered by plugins to the style menu."""
@@ -329,15 +445,36 @@ class PluginMenuManager:
         root = []
         for p in plugins:
             if hasattr(p["module"], "run"):
-                cat = p.get("category", p.get("rel_folder", "")).strip()
+                cat = str(p.get("category") or "").strip()
                 if cat:
                     categorized.setdefault(cat, []).append(p)
                 else:
                     root.append(p)
 
+        # This is the last step of Plugin-menu construction on both the update
+        # and the rebuild path, so it also drops the header divider when there
+        # turns out to be nothing under it -- an install of only the Plugin
+        # Installer would otherwise end on a dangling divider.
+        if not categorized and not root:
+            self._trim_trailing_separator(plugin_menu)
+            return
+
+        # Divide the folder-derived entries below from the context-injected
+        # ones ("Plugin/XXX" paths) that add_registered_plugin_actions already
+        # placed above: two different organizing schemes should not read as one
+        # list. Deferred until we know there is content, so an app with only
+        # context-injected plugins gets no dangling trailing divider.
+        existing = plugin_menu.actions()
+        if existing and not existing[-1].isSeparator():
+            plugin_menu.addSeparator()
+
         for cat in sorted(categorized.keys()):
             current_parent: Any = plugin_menu
-            for part in cat.split(os.sep):
+            # A folder category arrives with os.sep; a root plugin's own
+            # PLUGIN_CATEGORY is hand-written and usually uses "/".
+            for part in cat.replace("/", os.sep).split(os.sep):
+                if not part:
+                    continue
                 sub = next(
                     (
                         a.menu()

--- a/moleditpy/src/moleditpy/ui/plugin_menu_manager.py
+++ b/moleditpy/src/moleditpy/ui/plugin_menu_manager.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 import logging
 import os
-from typing import Any, Callable, Dict, List, TYPE_CHECKING
+from typing import Any, Callable, Dict, List, Optional, TYPE_CHECKING
 
 from PyQt6.QtGui import QAction, QIcon, QKeySequence
 from PyQt6.QtWidgets import QFileDialog, QMenu, QMessageBox
@@ -48,6 +48,8 @@ class PluginMenuManager:
 
     def __init__(self, init_manager: MainInitManager) -> None:
         self._im = init_manager
+        # Built once and re-added on every reset; see _reset_plugin_menu.
+        self._manage_action: Optional[QAction] = None
 
     def _make_safe_callback(self, callback: Callable, plugin_name: str) -> Callable:
         """Wrap a plugin callback so exceptions don't propagate into Qt's signal machinery."""
@@ -122,10 +124,29 @@ class PluginMenuManager:
         self.integrate_plugin_optimization_methods()
 
     def _reset_plugin_menu(self, plugin_menu: QMenu) -> None:
-        """Empty the Plugin menu and re-add its fixed header."""
+        """Empty the Plugin menu and re-add its fixed header.
+
+        Menu entries are parented to the host, not to the menu, so ``clear()``
+        only detaches them — without retiring the outgoing ones every rebuild
+        strands another set on the main window for the life of the process.
+
+        The manager entry is kept and re-added rather than rebuilt: a rebuild
+        can start from inside its own ``triggered`` handler (Plugin Manager ▸
+        Reload), and that handler is still on the stack, so this is the one
+        action that must not be deleted here.
+        """
+        manage_action = self._manage_action
+        self._retire_menu_tree(plugin_menu, manage_action)
         plugin_menu.clear()
-        manage_action = QAction("Plugin Manager...", self._im.host)
-        manage_action.triggered.connect(lambda: self._show_plugin_manager(plugin_menu))
+
+        if manage_action is None:
+            # Bound to the menu it was first built for, which in the app is
+            # always MainInitManager.plugin_menu.
+            manage_action = QAction("Plugin Manager...", self._im.host)
+            manage_action.triggered.connect(
+                lambda: self._show_plugin_manager(plugin_menu)
+            )
+            self._manage_action = manage_action
         plugin_menu.addAction(manage_action)
         plugin_menu.addSeparator()
 
@@ -144,23 +165,9 @@ class PluginMenuManager:
         folder entries instead used to flip the two groups on every reload.
         """
 
-        def _clean_menu(menu: QMenu) -> None:
-            for action in list(menu.actions()):
-                submenu = action.menu()
-                if submenu is not None:
-                    _clean_menu(submenu)
-                    # Only drop submenus the plugin system created. Native
-                    # submenus that happen to be empty are not ours to remove.
-                    if action.data() == self._PLUGIN_ACTION_TAG and not any(
-                        not a.isSeparator() for a in submenu.actions()
-                    ):
-                        menu.removeAction(action)
-                elif action.data() == self._PLUGIN_ACTION_TAG:
-                    self._remove_action(menu, action)
-
         try:
             for menu in self._get_plugin_target_menus():
-                _clean_menu(menu)
+                self._strip_plugin_actions(menu)
         except Exception:
             logging.warning("Plugin rebuild: menu cleanup error", exc_info=True)
 
@@ -190,6 +197,51 @@ class PluginMenuManager:
                 method()
             except Exception:
                 logging.warning("Plugin rebuild: %s error", label, exc_info=True)
+
+    def _retire_menu_tree(self, menu: QMenu, keep: Optional[QAction]) -> None:
+        """Destroy a menu subtree that ``clear()`` would only detach.
+
+        ``clear()`` deletes the actions a menu owns, but plugin entries are
+        parented to the host and submenus are child widgets of the menu, so
+        both outlive it — a submenu's menuAction going away does not take the
+        QMenu with it. Retiring the tree explicitly keeps a reload from
+        stranding another copy of every folder submenu and its entries.
+
+        *keep* is spared: it is the manager entry, which may be the handler
+        the current rebuild was started from.
+        """
+        for action in menu.actions():
+            submenu = action.menu()
+            if submenu is not None:
+                self._retire_menu_tree(submenu, keep)
+                submenu.deleteLater()
+            elif action is not keep:
+                action.deleteLater()
+
+    def _strip_plugin_actions(self, menu: QMenu) -> None:
+        """Remove every tagged action from *menu* and its submenus.
+
+        Recurses before removing, so a plugin-created submenu is emptied
+        first and only then dropped — and destroyed with it. Detaching a
+        submenu without destroying it leaves the QMenu alive as a child of
+        its former parent, and the next populate pass, no longer finding it
+        among the parent's actions, builds another: one stranded menu per
+        rebuild for the life of the process.
+
+        Native submenus that happen to be empty are not ours to remove, hence
+        the tag check.
+        """
+        for action in list(menu.actions()):
+            submenu = action.menu()
+            if submenu is not None:
+                self._strip_plugin_actions(submenu)
+                if action.data() == self._PLUGIN_ACTION_TAG and not any(
+                    not a.isSeparator() for a in submenu.actions()
+                ):
+                    menu.removeAction(action)
+                    submenu.deleteLater()
+            elif action.data() == self._PLUGIN_ACTION_TAG:
+                self._remove_action(menu, action)
 
     def _clear_plugin_menubar_entries(self) -> None:
         """Drop emptied plugin-created top-level menus and the menubar divider.
@@ -380,18 +432,9 @@ class PluginMenuManager:
         owns that, so both the update and the rebuild path clear it the same
         way.
         """
-
-        def clear_menu(menu: Any) -> None:
-            if not menu:
-                return
-            for act in list(menu.actions()):
-                if act.data() == self._PLUGIN_ACTION_TAG:
-                    self._remove_action(menu, act)
-                elif act.menu():
-                    clear_menu(act.menu())
-
         for menu in self._get_plugin_target_menus():
-            clear_menu(menu)
+            if menu:
+                self._strip_plugin_actions(menu)
         self._clear_plugin_menubar_entries()
 
     def update_style_menu_with_plugins(self) -> None:

--- a/moleditpy/src/moleditpy/ui/plugin_menu_manager.py
+++ b/moleditpy/src/moleditpy/ui/plugin_menu_manager.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 import logging
 import os
-from typing import Any, Callable, Dict, List, Optional, TYPE_CHECKING
+from typing import Any, Callable, Dict, List, TYPE_CHECKING
 
 from PyQt6.QtGui import QAction, QIcon, QKeySequence
 from PyQt6.QtWidgets import QFileDialog, QMenu, QMessageBox
@@ -41,11 +41,10 @@ class PluginMenuManager:
     # Title of the menu that hosts "Plugin/<path>" registrations.
     _PLUGIN_MENU_TITLE = "Plugin"
 
-    # Plugins that manage the plugin system itself. When installed, these sit
-    # with "Plugin Manager..." above the first divider instead of down among
-    # the plugins they install. Compared casefolded, with trailing dots
-    # stripped, against PLUGIN_NAME and the registered label.
-    _MANAGER_COMPANIONS = frozenset({"plugin installer"})
+    # Value of add_menu_action(pin=...) requesting the header slot: placed with
+    # "Plugin Manager..." above the first divider, for plugins that manage the
+    # plugin system itself rather than acting on a molecule.
+    _PIN_HEADER = "header"
 
     def __init__(self, init_manager: MainInitManager) -> None:
         self._im = init_manager
@@ -238,26 +237,20 @@ class PluginMenuManager:
                 sep.setData(self._PLUGIN_ACTION_TAG)
 
     @classmethod
-    def _is_manager_companion(
-        cls,
-        top_level_title: str,
-        parts: List[str],
-        plugin_name: Optional[str],
-        label: str,
+    def _wants_header_slot(
+        cls, top_level_title: str, parts: List[str], action_def: Dict[str, Any]
     ) -> bool:
-        """Return True for a plugin that belongs beside the Plugin Manager.
+        """Return True for an entry that asked to sit beside the Plugin Manager.
 
-        The Plugin Installer extends the Plugin Manager rather than acting on a
-        molecule, so it reads as part of the menu's header pair instead of as
-        one more installed plugin. Matched by name (its own PLUGIN_NAME, or the
-        label it registered) so the app needs no hard dependency on it.
+        A plugin that manages the plugin system itself — the Plugin Installer —
+        reads as part of the menu's header pair rather than as one more
+        installed plugin, and says so with ``pin="header"``. The app therefore
+        needs to know no plugin by name.
         """
-        if top_level_title != cls._PLUGIN_MENU_TITLE or len(parts) != 2:
-            return False
-        candidates = (plugin_name or "", label)
-        return any(
-            c.strip().rstrip(".").casefold() in cls._MANAGER_COMPANIONS
-            for c in candidates
+        return (
+            top_level_title == cls._PLUGIN_MENU_TITLE
+            and len(parts) == 2
+            and action_def.get("pin") == cls._PIN_HEADER
         )
 
     @staticmethod
@@ -324,9 +317,7 @@ class PluginMenuManager:
                 current_menu.menuAction().setData(self._PLUGIN_ACTION_TAG)
 
             label = text or parts[-1]
-            pinned = self._is_manager_companion(
-                top_level_title, parts, action_def.get("plugin"), label
-            )
+            pinned = self._wants_header_slot(top_level_title, parts, action_def)
             if not pinned:
                 self._ensure_plugin_separator(current_menu)
 

--- a/moleditpy/src/moleditpy/ui/template_preview_item.py
+++ b/moleditpy/src/moleditpy/ui/template_preview_item.py
@@ -78,9 +78,6 @@ class TemplatePreviewItem(QGraphicsItem):
         self.prepareGeometryChange()
         self.is_chain = False
         self.mark_first_atom = False
-        self.editor_drawn_bonds = {
-            frozenset(pair) for pair in (editor_drawn_bonds or ())
-        }
 
         n = len(points)
         if bonds_info is None:
@@ -89,6 +86,10 @@ class TemplatePreviewItem(QGraphicsItem):
                 for i in range(n)
             ]
         self._rebuild_ghost(points, bonds_info, [{"symbol": "C"} for _ in points])
+        # After the rebuild, which clears whatever the last preview recorded
+        self.editor_drawn_bonds = {
+            frozenset(pair) for pair in (editor_drawn_bonds or ())
+        }
         self.update()
 
     def set_chain_geometry(
@@ -147,6 +148,9 @@ class TemplatePreviewItem(QGraphicsItem):
         atoms_data: list[dict[str, Any]],
     ) -> None:
         """Rebuild the preview as real atom/bond items so it renders like the result."""
+        # Every preview kind lands here, so this is the one place that can keep
+        # a user template from inheriting the pairs a fused ring recorded
+        self.editor_drawn_bonds = set()
         self.ghost_scene.host = self.scene()
         if not points:
             self._clear_ghost()

--- a/moleditpy/src/moleditpy/ui/template_preview_item.py
+++ b/moleditpy/src/moleditpy/ui/template_preview_item.py
@@ -54,6 +54,7 @@ class TemplatePreviewItem(QGraphicsItem):
         self.ghost_atoms: List[AtomItem] = []
         self.ghost_bonds: List[BondItem] = []
         self.existing_indices: Set[int] = set()
+        self.editor_drawn_bonds: Set[frozenset] = set()
         self.existing_h_counts: Dict[int, int] = {}
         self.replaced_label_path = QPainterPath()
         self.mark_first_atom = False
@@ -66,15 +67,20 @@ class TemplatePreviewItem(QGraphicsItem):
         points: list[QPointF],
         is_aromatic: bool = False,
         bonds_info: Optional[list[Any]] = None,
+        editor_drawn_bonds: Optional[list[Any]] = None,
     ) -> None:
         """Set polygon points for a standard ring template preview.
 
         ``bonds_info`` carries the orders the placement will use; without it the
-        ring falls back to a plain alternation.
+        ring falls back to a plain alternation. ``editor_drawn_bonds`` lists the
+        vertex pairs the editor already draws, which the ghost must leave alone.
         """
         self.prepareGeometryChange()
         self.is_chain = False
         self.mark_first_atom = False
+        self.editor_drawn_bonds = {
+            frozenset(pair) for pair in (editor_drawn_bonds or ())
+        }
 
         n = len(points)
         if bonds_info is None:
@@ -130,6 +136,7 @@ class TemplatePreviewItem(QGraphicsItem):
         """Drop the ghost molecule and everything derived from the editor scene."""
         self._clear_ghost_items()
         self.existing_indices = set()
+        self.editor_drawn_bonds = set()
         self.existing_h_counts = {}
         self.replaced_label_path = QPainterPath()
 
@@ -362,6 +369,11 @@ class TemplatePreviewItem(QGraphicsItem):
         painter.save()
         painter.setOpacity(GHOST_OPACITY)
         for bond in self.ghost_bonds:
+            pair = frozenset((bond.atom1.atom_id, bond.atom2.atom_id))
+            if pair in self.editor_drawn_bonds:
+                # Placement leaves this bond alone and the editor already draws
+                # it; a ghost copy on top of a real double bond reads as a triple
+                continue
             painter.save()
             painter.translate(bond.pos())
             bond.paint(painter, option)  # type: ignore[arg-type]

--- a/tests/assertion_catalog.md
+++ b/tests/assertion_catalog.md
@@ -7061,27 +7061,27 @@ _Test Plugin3DController.set_bond_color._
 ### TestPluginInterface.test_add_plugin_menu
 _add_plugin_menu prepends 'Plugin/' to the path._
 
-- mock_manager.register_menu_action.assert_called_once_with('TestPlugin', 'Plugin/Utility/My Tool...', callback, None, None, None)
+- mock_manager.register_menu_action.assert_called_once_with('TestPlugin', 'Plugin/Utility/My Tool...', callback, None, None, None, None)
 
 ### TestPluginInterface.test_add_plugin_menu_strips_leading_slash
 _add_plugin_menu strips a leading slash from the path._
 
-- mock_manager.register_menu_action.assert_called_once_with('TestPlugin', 'Plugin/Analysis/Viewer', callback, None, None, None)
+- mock_manager.register_menu_action.assert_called_once_with('TestPlugin', 'Plugin/Analysis/Viewer', callback, None, None, None, None)
 
 ### TestPluginInterface.test_add_plugin_menu_with_text_and_shortcut
 _add_plugin_menu passes optional text/icon/shortcut through._
 
-- mock_manager.register_menu_action.assert_called_once_with('TestPlugin', 'Plugin/File/Export...', callback, 'Export', None, 'Ctrl+E')
+- mock_manager.register_menu_action.assert_called_once_with('TestPlugin', 'Plugin/File/Export...', callback, 'Export', None, 'Ctrl+E', None)
 
 ### TestPluginInterface.test_register_menu_action_new_style
 _register_menu_action (new style: path, callback) delegates correctly._
 
-- mock_manager.register_menu_action.assert_called_once_with('TestPlugin', 'File/Open', callback, None, None, None)
+- mock_manager.register_menu_action.assert_called_once_with('TestPlugin', 'File/Open', callback, None, None, None, None)
 
 ### TestPluginInterface.test_register_menu_action_old_style
 _register_menu_action (old style: path, text, callback) delegates correctly._
 
-- mock_manager.register_menu_action.assert_called_once_with('TestPlugin', 'File/Import', callback, 'Import PubChem...', None, None)
+- mock_manager.register_menu_action.assert_called_once_with('TestPlugin', 'File/Import', callback, 'Import PubChem...', None, None, None)
 
 ### TestPluginInterface.test_get_setting_returns_default_when_missing
 _get_setting returns the default if the key is absent._
@@ -7935,40 +7935,45 @@ _Without context-injected entries the header divider is enough._
 
 - assert _shape(plugin_menu) == ['Plugin Manager...', 'sep', 'Folder/']
 
-### TestPluginInstallerPinning.test_installer_sits_directly_below_the_manager
-_The installer joins the header pair with no divider between them._
+### TestHeaderPin.test_pinned_entry_sits_directly_below_the_manager
+_The entry joins the header pair with no divider between them._
 
 - assert _shape(plugin_menu) == ['Plugin Manager...', 'Plugin Installer...', 'sep', 'Folder/']
 
-### TestPluginInstallerPinning.test_installer_stays_above_other_injected_plugins
+### TestHeaderPin.test_pinned_entry_stays_above_other_injected_plugins
 _Ordinary context-injected entries stay below the divider._
 
 - assert _shape(plugin_menu) == ['Plugin Manager...', 'Plugin Installer...', 'sep', 'Injected']
 
-### TestPluginInstallerPinning.test_registration_order_does_not_matter
-_Registering the installer first gives the same layout._
+### TestHeaderPin.test_registration_order_does_not_matter
+_Registering the pinned entry first gives the same layout._
 
 - assert _shape(plugin_menu) == ['Plugin Manager...', 'Plugin Installer...', 'sep', 'Injected']
 
-### TestPluginInstallerPinning.test_installer_alone_leaves_no_dangling_divider
+### TestHeaderPin.test_pinned_entry_alone_leaves_no_dangling_divider
 _With nothing under it, the header divider is dropped._
 
 - assert _shape(plugin_menu) == ['Plugin Manager...', 'Plugin Installer...']
 
-### TestPluginInstallerPinning.test_matched_case_insensitively_by_label
-_A differently-cased PLUGIN_NAME or label still pins._
+### TestHeaderPin.test_the_name_alone_does_not_pin
+_Placement is granted on request only — the app knows no plugin names._
 
-- assert _shape(plugin_menu) == ['Plugin Manager...', 'Plugin installer']
+- assert _shape(plugin_menu) == ['Plugin Manager...', 'sep', 'Plugin Installer...']
 
-### TestPluginInstallerPinning.test_unrelated_plugin_is_not_pinned
-_A plugin merely mentioning install is left below the divider._
+### TestHeaderPin.test_unknown_pin_value_is_ignored
+_An unrecognised pin leaves the entry in the ordinary group._
 
-- assert _shape(plugin_menu) == ['Plugin Manager...', 'sep', 'Install Helper']
+- assert _shape(plugin_menu) == ['Plugin Manager...', 'sep', 'Plugin Installer...']
 
-### TestPluginInstallerPinning.test_nested_installer_path_is_not_pinned
-_Only a direct Plugin/<entry> registration is pinned._
+### TestHeaderPin.test_pin_needs_a_direct_plugin_path
+_pin="header" on a nested path is ignored._
 
 - assert _shape(plugin_menu) == ['Plugin Manager...', 'sep', 'Tools/']
+
+### TestHeaderPin.test_pin_outside_the_plugin_menu_is_ignored
+_A pin request only means anything inside the Plugin menu._
+
+- assert _shape(tools) == ['Native A', 'sep', 'Pinned']
 
 ## tests/unit/test_project_io.py
 

--- a/tests/assertion_catalog.md
+++ b/tests/assertion_catalog.md
@@ -3394,6 +3394,12 @@ _clear_all(skip_check=True) returns True and shows the cleared status message._
 - assert result is True
 - manager.host.statusBar().showMessage.assert_called_with('Cleared all data.')
 
+### TestEditActionsExtended.test_clear_all_restores_launch_zoom
+_clear_all resets the 2D view to the default zoom, not the identity transform._
+
+- manager.host.view_3d_manager.reset_zoom.assert_called_once()
+- manager.host.init_manager.view_2d.resetTransform.assert_not_called()
+
 ### TestEditActionsExtended.test_cut_selection
 _cut_selection copies then deletes the selected items._
 
@@ -7429,6 +7435,16 @@ __load_single_plugin converts a PLUGIN_VERSION tuple to a dotted string._
 
 - assert pm.plugins[0]['version'] == '3.1.4'
 
+### TestPluginManagerExtended.test_folder_overrides_declared_category
+_The containing folder wins over a plugin's own PLUGIN_CATEGORY._
+
+- assert plugin['category'] == 'Tools'
+
+### TestPluginManagerExtended.test_declared_category_applies_at_plugin_root
+_PLUGIN_CATEGORY still applies when the file sits at the plugins root._
+
+- assert plugin['category'] == 'AuthorChoice'
+
 ### TestPluginManagerExtended.test_run_plugin_exceptions
 _run_plugin shows a critical dialog when the plugin run() raises._
 
@@ -7801,10 +7817,12 @@ _integrate_plugin_file_openers adds a separator and action for each file opener.
 - im.import_menu.addSeparator.assert_called_once()
 - im.import_menu.addAction.assert_called_once()
 
-### TestClearAllPluginActions.test_clears_plugin_menu
-__clear_all_plugin_actions clears the plugin menu._
+### TestClearAllPluginActions.test_reset_plugin_menu_clears_and_re_adds_the_header
+__reset_plugin_menu empties the Plugin menu and restores its header._
 
 - plugin_menu.clear.assert_called_once()
+- plugin_menu.addAction.assert_called_once()
+- plugin_menu.addSeparator.assert_called_once()
 
 ### TestClearAllPluginActions.test_removes_tagged_actions_from_all_menus
 __clear_all_plugin_actions removes all plugin_managed tagged actions from all menus._
@@ -7847,6 +7865,110 @@ _No description provided._
 _No description provided._
 
 - im.host.plugin_manager.run_plugin.assert_called_once_with(plugin['module'], im.host)
+
+### TestPluginSeparatorPlacement.test_divider_precedes_a_nested_plugin_submenu
+_A nested path puts the divider before the submenu, not after it._
+
+- assert kinds == ['Native A', 'Native B', 'sep', 'menu']
+
+### TestPluginSeparatorPlacement.test_no_extra_divider_between_plugin_siblings
+_An entry following a plugin submenu does not get its own divider._
+
+- assert kinds == ['Native A', 'Native B', 'sep', 'menu', 'Direct']
+
+### TestPluginSeparatorPlacement.test_plugin_created_submenu_is_tagged
+_Submenus built for a plugin path carry the plugin tag for cleanup._
+
+- assert sub_action.data() == TAG
+
+### TestPluginSeparatorPlacement.test_shared_submenu_gets_one_divider_and_no_duplicate
+_Two plugins under the same submenu reuse it without extra dividers._
+
+- assert len(submenus) == 1
+- assert [a.text() for a in submenus[0].actions()] == ['One', 'Two']
+- assert sum((1 for a in tools.actions() if a.isSeparator())) == 1
+
+### TestClearPluginMenubarEntries.test_clear_all_drops_stale_plugin_top_level_menu
+__clear_all_plugin_actions reclaims the menu bar, not just the menus._
+
+- assert titles == ['Tools']
+- assert not any((a.isSeparator() for a in bar.actions()))
+
+### TestClearPluginMenubarEntries.test_clear_all_resets_separator_flag
+_The flag is reset so the next populate pass re-adds the divider._
+
+- assert im.plugin_menubar_separator_added is False
+
+### TestClearPluginMenubarEntries.test_native_top_level_menu_is_never_removed
+_An untagged top-level menu survives even when it is empty._
+
+- assert [a.text() for a in bar.actions() if a.menu()] == ['Empty Native']
+
+### TestClearPluginMenubarEntries.test_rebuild_uses_the_same_menubar_cleanup
+_rebuild_plugin_menus drops the stale top-level menu too._
+
+- assert [a.text() for a in bar.actions() if a.menu()] == ['Tools']
+- assert im.plugin_menubar_separator_added is False
+
+### TestPluginMenuComposition.test_update_puts_context_entries_above_folder_ones
+_A fresh build lists context-injected entries, a divider, then folders._
+
+- assert _shape(plugin_menu) == ['Plugin Manager...', 'sep', 'Injected', 'sep', 'Folder/']
+
+### TestPluginMenuComposition.test_rebuild_preserves_that_order
+_A reload must not flip the two groups._
+
+- assert _shape(plugin_menu) == ['Plugin Manager...', 'sep', 'Injected', 'sep', 'Folder/']
+
+### TestPluginMenuComposition.test_repeated_rebuilds_are_stable
+_Reloading twice yields the same menu, with no accumulation._
+
+- assert _shape(plugin_menu) == first
+
+### TestPluginMenuComposition.test_no_trailing_divider_without_folder_plugins
+_With only context-injected entries the menu ends on a real entry._
+
+- assert _shape(plugin_menu) == ['Plugin Manager...', 'sep', 'Injected']
+
+### TestPluginMenuComposition.test_folder_plugins_alone_get_no_leading_divider
+_Without context-injected entries the header divider is enough._
+
+- assert _shape(plugin_menu) == ['Plugin Manager...', 'sep', 'Folder/']
+
+### TestPluginInstallerPinning.test_installer_sits_directly_below_the_manager
+_The installer joins the header pair with no divider between them._
+
+- assert _shape(plugin_menu) == ['Plugin Manager...', 'Plugin Installer...', 'sep', 'Folder/']
+
+### TestPluginInstallerPinning.test_installer_stays_above_other_injected_plugins
+_Ordinary context-injected entries stay below the divider._
+
+- assert _shape(plugin_menu) == ['Plugin Manager...', 'Plugin Installer...', 'sep', 'Injected']
+
+### TestPluginInstallerPinning.test_registration_order_does_not_matter
+_Registering the installer first gives the same layout._
+
+- assert _shape(plugin_menu) == ['Plugin Manager...', 'Plugin Installer...', 'sep', 'Injected']
+
+### TestPluginInstallerPinning.test_installer_alone_leaves_no_dangling_divider
+_With nothing under it, the header divider is dropped._
+
+- assert _shape(plugin_menu) == ['Plugin Manager...', 'Plugin Installer...']
+
+### TestPluginInstallerPinning.test_matched_case_insensitively_by_label
+_A differently-cased PLUGIN_NAME or label still pins._
+
+- assert _shape(plugin_menu) == ['Plugin Manager...', 'Plugin installer']
+
+### TestPluginInstallerPinning.test_unrelated_plugin_is_not_pinned
+_A plugin merely mentioning install is left below the divider._
+
+- assert _shape(plugin_menu) == ['Plugin Manager...', 'sep', 'Install Helper']
+
+### TestPluginInstallerPinning.test_nested_installer_path_is_not_pinned
+_Only a direct Plugin/<entry> registration is pinned._
+
+- assert _shape(plugin_menu) == ['Plugin Manager...', 'sep', 'Tools/']
 
 ## tests/unit/test_project_io.py
 

--- a/tests/assertion_catalog.md
+++ b/tests/assertion_catalog.md
@@ -11723,6 +11723,12 @@ _The fallback must not fire where a full Kekulé ring is still valid._
 - assert len(added) == 4
 - assert new_doubles > 0
 
+### test_fusing_onto_a_crowded_bond_stays_valid
+_An upgrade must fit too, not merely avoid a neighbouring double._
+
+- assert not overloaded
+- assert scene.find_bond_between(first, second).order == 1
+
 ## tests/integration/test_headless_install.py
 
 ### test_headless_install_success
@@ -11970,6 +11976,13 @@ _The ghost leaves a bond it will not change to the editor._
 - assert len(shared_pairs) == 1
 - assert shared_pairs <= preview.editor_drawn_bonds
 - assert with_ghost == without_ghost
+
+### test_user_template_ghost_ignores_a_previous_fusion
+_Switching template kinds must not carry the fused pairs across._
+
+- assert scene.template_preview.editor_drawn_bonds
+- assert scene.template_preview.editor_drawn_bonds == set()
+- assert not hidden
 
 ## tests/integration/test_trigger_conversion_plugin_wrap.py
 

--- a/tests/assertion_catalog.md
+++ b/tests/assertion_catalog.md
@@ -11936,6 +11936,26 @@ _A built-in ring template previews as a ghost ring, Kekulé bonds included._
 - assert [b.order for b in preview.ghost_bonds] == [2, 1, 2, 1, 2, 1]
 - assert all((b.is_in_ring for b in preview.ghost_bonds))
 
+### test_fusing_ghost_keeps_an_untouched_bond_order
+_Fusing onto a ring must not draw a double over a bond that stays single._
+
+- assert shared
+- assert shared == [order]
+
+### test_fusing_ghost_still_previews_an_allowed_overwrite
+_A lone single bond does get upgraded, and the ghost must say so._
+
+- assert _shared_ghost_orders(preview) == [2]
+- assert scene.find_bond_between(first, second).order == 2
+
+### test_fusing_ghost_does_not_redraw_an_unchanged_bond
+_The ghost leaves a bond it will not change to the editor._
+
+- assert preview.isVisible()
+- assert len(shared_pairs) == 1
+- assert shared_pairs <= preview.editor_drawn_bonds
+- assert with_ghost == without_ghost
+
 ## tests/integration/test_trigger_conversion_plugin_wrap.py
 
 ### TestTriggerConversionTempMode.test_temp_mode_stored_and_consumed

--- a/tests/assertion_catalog.md
+++ b/tests/assertion_catalog.md
@@ -7975,6 +7975,34 @@ _A pin request only means anything inside the Plugin menu._
 
 - assert _shape(tools) == ['Native A', 'sep', 'Pinned']
 
+### TestCleanupDoesNotStrandObjects.test_repeated_cycles_do_not_strand_submenus
+_A plugin submenu is destroyed with its entry, not merely detached._
+
+- assert [a.text() for a in tools.actions() if a.menu()] == ['Sub']
+- assert len(tools.findChildren(QMenu)) == 1
+
+### TestCleanupDoesNotStrandObjects.test_native_submenu_survives_cleanup
+_An empty native submenu is neither removed nor destroyed._
+
+- assert [a.text() for a in tools.actions() if a.menu()] == ['Native Sub']
+- assert native_sub.title() == 'Native Sub'
+
+### TestCleanupDoesNotStrandObjects.test_manager_entry_is_reused_across_resets
+_The manager entry survives a reset — it may be the running handler._
+
+- assert menu.actions()[0] is first
+- assert first.text() == 'Plugin Manager...'
+
+### TestCleanupDoesNotStrandObjects.test_reset_retires_the_outgoing_entries
+_Entries dropped by a reset are deleted, not left on the host._
+
+
+### TestCleanupDoesNotStrandObjects.test_plugin_menu_subtree_is_retired_on_reset
+_Rebuilding the Plugin menu destroys its old submenus._
+
+- assert _shape(plugin_menu) == ['Plugin Manager...', 'sep', 'Nested/', 'sep', 'Folder/']
+- assert counts == [2, 2, 2, 2]
+
 ## tests/unit/test_project_io.py
 
 ### test_save_project_no_data

--- a/tests/assertion_catalog.md
+++ b/tests/assertion_catalog.md
@@ -12138,7 +12138,6 @@ _2D->3D Conversion: Test for the conversion button._
 - assert len(window.state_manager.data.atoms) == 2
 - assert len(window.state_manager.data.bonds) == 1
 - assert convert_button.isEnabled()
-- assert window.view_3d_manager.current_mol is not None
 - assert window.init_manager.optimize_3d_button.isEnabled()
 - assert window.init_manager.export_button.isEnabled()
 - assert window.init_manager.analysis_action.isEnabled()
@@ -12148,7 +12147,6 @@ _3D Optimization: Test for the 3D optimization button._
 
 - assert window.view_3d_manager.current_mol is not None
 - assert window.init_manager.optimize_3d_button.isEnabled()
-- assert 'Optimization completed' in msg or 'optimization successful' in msg or 'Process completed' in msg
 
 ### test_change_3d_style
 _3D Style Change: Test for the style menu._

--- a/tests/assertion_catalog.md
+++ b/tests/assertion_catalog.md
@@ -11708,6 +11708,21 @@ _Test that mirror transformation inverts the chiral label in 3D._
 - assert new_label in labels
 - assert initial_label not in labels
 
+## tests/integration/test_fused_ring_valence.py
+
+### test_fusing_benzene_onto_naphthalene_stays_valid
+_No rim bond may give a carbon a fifth bond._
+
+- assert not overloaded
+- assert mol is not None
+- assert not Chem.DetectChemistryProblems(mol)
+
+### test_fusing_keeps_aromatic_ring_when_it_fits
+_The fallback must not fire where a full Kekulé ring is still valid._
+
+- assert len(added) == 4
+- assert new_doubles > 0
+
 ## tests/integration/test_headless_install.py
 
 ### test_headless_install_success

--- a/tests/coverage_report.md
+++ b/tests/coverage_report.md
@@ -1,6 +1,6 @@
 # MoleditPy Coverage Report
 
-- **Overall Project Coverage**: **89.89%**
+- **Overall Project Coverage**: **89.92%**
 
 ### Coverage Breakdown
 
@@ -49,7 +49,7 @@
 | moleditpy\src\moleditpy\ui\move_selected_atoms_dialog.py |    464 |     44 |   90.5% |
 | moleditpy\src\moleditpy\ui\periodic_table_dialog.py     |     37 |      2 |   94.6% |
 | moleditpy\src\moleditpy\ui\planarize_dialog.py          |    112 |      9 |   92.0% |
-| moleditpy\src\moleditpy\ui\plugin_menu_manager.py       |    287 |     30 |   89.5% |
+| moleditpy\src\moleditpy\ui\plugin_menu_manager.py       |    338 |     30 |   91.1% |
 | moleditpy\src\moleditpy\ui\preview_molecule.py          |    116 |     14 |   87.9% |
 | moleditpy\src\moleditpy\ui\settings_dialog.py           |    101 |      3 |   97.0% |
 | moleditpy\src\moleditpy\ui\string_importers.py          |    121 |      0 |  100.0% |
@@ -70,11 +70,11 @@
 | moleditpy\src\moleditpy\utils\sip_isdeleted_safe.py     |     19 |      0 |  100.0% |
 | moleditpy\src\moleditpy\utils\suppress_log.py           |     10 |      0 |  100.0% |
 | moleditpy\src\moleditpy\utils\system_utils.py           |     40 |      0 |  100.0% |
-| **TOTAL** | **17105** | **1730** | **89.89%** |
+| **TOTAL** | **17156** | **1730** | **89.92%** |
 
 ## Test Suite Status
-- **Total tests passed**: 2261 (1 skipped)
-- **Unit tests**: PASSED (2054 passed)
+- **Total tests passed**: 2284 (1 skipped)
+- **Unit tests**: PASSED (2077 passed)
 - **Integration tests**: PASSED (87 passed)
 - **E2E tests**: PASSED (34 passed, 1 skipped)
 - **GUI tests**: PASSED (86 passed)

--- a/tests/coverage_report.md
+++ b/tests/coverage_report.md
@@ -1,6 +1,6 @@
 # MoleditPy Coverage Report
 
-- **Overall Project Coverage**: **90.02%**
+- **Overall Project Coverage**: **90.04%**
 
 ### Coverage Breakdown
 
@@ -43,7 +43,7 @@
 | moleditpy\src\moleditpy\ui\main_window.py               |    195 |     13 |   93.3% |
 | moleditpy\src\moleditpy\ui\main_window_init.py          |   1103 |     86 |   92.2% |
 | moleditpy\src\moleditpy\ui\mirror_dialog.py             |     72 |      7 |   90.3% |
-| moleditpy\src\moleditpy\ui\molecular_scene_handler.py   |   1052 |    123 |   88.3% |
+| moleditpy\src\moleditpy\ui\molecular_scene_handler.py   |   1082 |    123 |   88.6% |
 | moleditpy\src\moleditpy\ui\molecule_scene.py            |    637 |     82 |   87.1% |
 | moleditpy\src\moleditpy\ui\move_group_dialog.py         |    386 |     41 |   89.4% |
 | moleditpy\src\moleditpy\ui\move_selected_atoms_dialog.py |    464 |     44 |   90.5% |
@@ -70,12 +70,12 @@
 | moleditpy\src\moleditpy\utils\sip_isdeleted_safe.py     |     19 |      0 |  100.0% |
 | moleditpy\src\moleditpy\utils\suppress_log.py           |     10 |      0 |  100.0% |
 | moleditpy\src\moleditpy\utils\system_utils.py           |     40 |      0 |  100.0% |
-| **TOTAL** | **17180** | **1714** | **90.02%** |
+| **TOTAL** | **17210** | **1714** | **90.04%** |
 
 ## Test Suite Status
-- **Total tests passed**: 2293 (1 skipped)
+- **Total tests passed**: 2304 (1 skipped)
 - **Unit tests**: PASSED (2083 passed)
-- **Integration tests**: PASSED (90 passed)
+- **Integration tests**: PASSED (101 passed)
 - **E2E tests**: PASSED (34 passed, 1 skipped)
 - **GUI tests**: PASSED (86 passed)
 

--- a/tests/coverage_report.md
+++ b/tests/coverage_report.md
@@ -1,6 +1,6 @@
 # MoleditPy Coverage Report
 
-- **Overall Project Coverage**: **90.00%**
+- **Overall Project Coverage**: **90.04%**
 
 ### Coverage Breakdown
 
@@ -50,11 +50,11 @@
 | moleditpy\src\moleditpy\ui\periodic_table_dialog.py     |     37 |      2 |   94.6% |
 | moleditpy\src\moleditpy\ui\planarize_dialog.py          |    112 |      9 |   92.0% |
 | moleditpy\src\moleditpy\ui\plugin_menu_manager.py       |    342 |     28 |   91.8% |
-| moleditpy\src\moleditpy\ui\preview_molecule.py          |    116 |     15 |   87.1% |
+| moleditpy\src\moleditpy\ui\preview_molecule.py          |    116 |     14 |   87.9% |
 | moleditpy\src\moleditpy\ui\settings_dialog.py           |    101 |      3 |   97.0% |
 | moleditpy\src\moleditpy\ui\string_importers.py          |    121 |      0 |  100.0% |
 | moleditpy\src\moleditpy\ui\template_preview_item.py     |    240 |      4 |   98.3% |
-| moleditpy\src\moleditpy\ui\template_preview_view.py     |     46 |     10 |   78.3% |
+| moleditpy\src\moleditpy\ui\template_preview_view.py     |     46 |      4 |   91.3% |
 | moleditpy\src\moleditpy\ui\translation_dialog.py        |    276 |     21 |   92.4% |
 | moleditpy\src\moleditpy\ui\ui_manager.py                |    398 |     38 |   90.5% |
 | moleditpy\src\moleditpy\ui\user_template_dialog.py      |    298 |     34 |   88.6% |
@@ -70,7 +70,7 @@
 | moleditpy\src\moleditpy\utils\sip_isdeleted_safe.py     |     19 |      0 |  100.0% |
 | moleditpy\src\moleditpy\utils\suppress_log.py           |     10 |      0 |  100.0% |
 | moleditpy\src\moleditpy\utils\system_utils.py           |     40 |      0 |  100.0% |
-| **TOTAL** | **17214** | **1721** | **90.00%** |
+| **TOTAL** | **17214** | **1714** | **90.04%** |
 
 ## Test Suite Status
 - **Total tests passed**: 2306 (1 skipped)

--- a/tests/coverage_report.md
+++ b/tests/coverage_report.md
@@ -1,6 +1,6 @@
 # MoleditPy Coverage Report
 
-- **Overall Project Coverage**: **90.04%**
+- **Overall Project Coverage**: **90.00%**
 
 ### Coverage Breakdown
 
@@ -43,18 +43,18 @@
 | moleditpy\src\moleditpy\ui\main_window.py               |    195 |     13 |   93.3% |
 | moleditpy\src\moleditpy\ui\main_window_init.py          |   1103 |     86 |   92.2% |
 | moleditpy\src\moleditpy\ui\mirror_dialog.py             |     72 |      7 |   90.3% |
-| moleditpy\src\moleditpy\ui\molecular_scene_handler.py   |   1082 |    123 |   88.6% |
+| moleditpy\src\moleditpy\ui\molecular_scene_handler.py   |   1085 |    123 |   88.7% |
 | moleditpy\src\moleditpy\ui\molecule_scene.py            |    637 |     82 |   87.1% |
 | moleditpy\src\moleditpy\ui\move_group_dialog.py         |    386 |     41 |   89.4% |
 | moleditpy\src\moleditpy\ui\move_selected_atoms_dialog.py |    464 |     44 |   90.5% |
 | moleditpy\src\moleditpy\ui\periodic_table_dialog.py     |     37 |      2 |   94.6% |
 | moleditpy\src\moleditpy\ui\planarize_dialog.py          |    112 |      9 |   92.0% |
 | moleditpy\src\moleditpy\ui\plugin_menu_manager.py       |    342 |     28 |   91.8% |
-| moleditpy\src\moleditpy\ui\preview_molecule.py          |    116 |     14 |   87.9% |
+| moleditpy\src\moleditpy\ui\preview_molecule.py          |    116 |     15 |   87.1% |
 | moleditpy\src\moleditpy\ui\settings_dialog.py           |    101 |      3 |   97.0% |
 | moleditpy\src\moleditpy\ui\string_importers.py          |    121 |      0 |  100.0% |
-| moleditpy\src\moleditpy\ui\template_preview_item.py     |    239 |      4 |   98.3% |
-| moleditpy\src\moleditpy\ui\template_preview_view.py     |     46 |      4 |   91.3% |
+| moleditpy\src\moleditpy\ui\template_preview_item.py     |    240 |      4 |   98.3% |
+| moleditpy\src\moleditpy\ui\template_preview_view.py     |     46 |     10 |   78.3% |
 | moleditpy\src\moleditpy\ui\translation_dialog.py        |    276 |     21 |   92.4% |
 | moleditpy\src\moleditpy\ui\ui_manager.py                |    398 |     38 |   90.5% |
 | moleditpy\src\moleditpy\ui\user_template_dialog.py      |    298 |     34 |   88.6% |
@@ -70,12 +70,12 @@
 | moleditpy\src\moleditpy\utils\sip_isdeleted_safe.py     |     19 |      0 |  100.0% |
 | moleditpy\src\moleditpy\utils\suppress_log.py           |     10 |      0 |  100.0% |
 | moleditpy\src\moleditpy\utils\system_utils.py           |     40 |      0 |  100.0% |
-| **TOTAL** | **17210** | **1714** | **90.04%** |
+| **TOTAL** | **17214** | **1721** | **90.00%** |
 
 ## Test Suite Status
-- **Total tests passed**: 2304 (1 skipped)
+- **Total tests passed**: 2306 (1 skipped)
 - **Unit tests**: PASSED (2083 passed)
-- **Integration tests**: PASSED (101 passed)
+- **Integration tests**: PASSED (103 passed)
 - **E2E tests**: PASSED (34 passed, 1 skipped)
 - **GUI tests**: PASSED (86 passed)
 

--- a/tests/coverage_report.md
+++ b/tests/coverage_report.md
@@ -1,6 +1,6 @@
 # MoleditPy Coverage Report
 
-- **Overall Project Coverage**: **89.92%**
+- **Overall Project Coverage**: **89.89%**
 
 ### Coverage Breakdown
 
@@ -23,7 +23,7 @@
 | moleditpy\src\moleditpy\ui\atom_item.py                 |    327 |     30 |   90.8% |
 | moleditpy\src\moleditpy\ui\atom_picking.py              |    167 |     13 |   92.2% |
 | moleditpy\src\moleditpy\ui\base_picking_dialog.py       |     81 |      4 |   95.1% |
-| moleditpy\src\moleditpy\ui\bond_item.py                 |    370 |     54 |   85.4% |
+| moleditpy\src\moleditpy\ui\bond_item.py                 |    370 |     53 |   85.7% |
 | moleditpy\src\moleditpy\ui\bond_length_dialog.py        |    260 |     18 |   93.1% |
 | moleditpy\src\moleditpy\ui\calculation_worker.py        |    583 |     90 |   84.6% |
 | moleditpy\src\moleditpy\ui\chain_mixin.py               |     97 |      2 |   97.9% |
@@ -43,18 +43,18 @@
 | moleditpy\src\moleditpy\ui\main_window.py               |    195 |     13 |   93.3% |
 | moleditpy\src\moleditpy\ui\main_window_init.py          |   1103 |     86 |   92.2% |
 | moleditpy\src\moleditpy\ui\mirror_dialog.py             |     72 |      7 |   90.3% |
-| moleditpy\src\moleditpy\ui\molecular_scene_handler.py   |   1038 |    135 |   87.0% |
+| moleditpy\src\moleditpy\ui\molecular_scene_handler.py   |   1038 |    134 |   87.1% |
 | moleditpy\src\moleditpy\ui\molecule_scene.py            |    637 |     82 |   87.1% |
 | moleditpy\src\moleditpy\ui\move_group_dialog.py         |    386 |     41 |   89.4% |
 | moleditpy\src\moleditpy\ui\move_selected_atoms_dialog.py |    464 |     44 |   90.5% |
 | moleditpy\src\moleditpy\ui\periodic_table_dialog.py     |     37 |      2 |   94.6% |
 | moleditpy\src\moleditpy\ui\planarize_dialog.py          |    112 |      9 |   92.0% |
-| moleditpy\src\moleditpy\ui\plugin_menu_manager.py       |    338 |     30 |   91.1% |
-| moleditpy\src\moleditpy\ui\preview_molecule.py          |    116 |     14 |   87.9% |
+| moleditpy\src\moleditpy\ui\plugin_menu_manager.py       |    335 |     30 |   91.0% |
+| moleditpy\src\moleditpy\ui\preview_molecule.py          |    116 |     15 |   87.1% |
 | moleditpy\src\moleditpy\ui\settings_dialog.py           |    101 |      3 |   97.0% |
 | moleditpy\src\moleditpy\ui\string_importers.py          |    121 |      0 |  100.0% |
 | moleditpy\src\moleditpy\ui\template_preview_item.py     |    233 |      5 |   97.9% |
-| moleditpy\src\moleditpy\ui\template_preview_view.py     |     46 |      4 |   91.3% |
+| moleditpy\src\moleditpy\ui\template_preview_view.py     |     46 |     10 |   78.3% |
 | moleditpy\src\moleditpy\ui\translation_dialog.py        |    276 |     21 |   92.4% |
 | moleditpy\src\moleditpy\ui\ui_manager.py                |    398 |     38 |   90.5% |
 | moleditpy\src\moleditpy\ui\user_template_dialog.py      |    298 |     34 |   88.6% |
@@ -70,11 +70,11 @@
 | moleditpy\src\moleditpy\utils\sip_isdeleted_safe.py     |     19 |      0 |  100.0% |
 | moleditpy\src\moleditpy\utils\suppress_log.py           |     10 |      0 |  100.0% |
 | moleditpy\src\moleditpy\utils\system_utils.py           |     40 |      0 |  100.0% |
-| **TOTAL** | **17156** | **1730** | **89.92%** |
+| **TOTAL** | **17153** | **1735** | **89.89%** |
 
 ## Test Suite Status
-- **Total tests passed**: 2284 (1 skipped)
-- **Unit tests**: PASSED (2077 passed)
+- **Total tests passed**: 2285 (1 skipped)
+- **Unit tests**: PASSED (2078 passed)
 - **Integration tests**: PASSED (87 passed)
 - **E2E tests**: PASSED (34 passed, 1 skipped)
 - **GUI tests**: PASSED (86 passed)

--- a/tests/coverage_report.md
+++ b/tests/coverage_report.md
@@ -1,6 +1,6 @@
 # MoleditPy Coverage Report
 
-- **Overall Project Coverage**: **89.89%**
+- **Overall Project Coverage**: **89.90%**
 
 ### Coverage Breakdown
 
@@ -49,7 +49,7 @@
 | moleditpy\src\moleditpy\ui\move_selected_atoms_dialog.py |    464 |     44 |   90.5% |
 | moleditpy\src\moleditpy\ui\periodic_table_dialog.py     |     37 |      2 |   94.6% |
 | moleditpy\src\moleditpy\ui\planarize_dialog.py          |    112 |      9 |   92.0% |
-| moleditpy\src\moleditpy\ui\plugin_menu_manager.py       |    335 |     30 |   91.0% |
+| moleditpy\src\moleditpy\ui\plugin_menu_manager.py       |    342 |     28 |   91.8% |
 | moleditpy\src\moleditpy\ui\preview_molecule.py          |    116 |     15 |   87.1% |
 | moleditpy\src\moleditpy\ui\settings_dialog.py           |    101 |      3 |   97.0% |
 | moleditpy\src\moleditpy\ui\string_importers.py          |    121 |      0 |  100.0% |
@@ -70,11 +70,11 @@
 | moleditpy\src\moleditpy\utils\sip_isdeleted_safe.py     |     19 |      0 |  100.0% |
 | moleditpy\src\moleditpy\utils\suppress_log.py           |     10 |      0 |  100.0% |
 | moleditpy\src\moleditpy\utils\system_utils.py           |     40 |      0 |  100.0% |
-| **TOTAL** | **17153** | **1735** | **89.89%** |
+| **TOTAL** | **17160** | **1733** | **89.90%** |
 
 ## Test Suite Status
-- **Total tests passed**: 2285 (1 skipped)
-- **Unit tests**: PASSED (2078 passed)
+- **Total tests passed**: 2290 (1 skipped)
+- **Unit tests**: PASSED (2083 passed)
 - **Integration tests**: PASSED (87 passed)
 - **E2E tests**: PASSED (34 passed, 1 skipped)
 - **GUI tests**: PASSED (86 passed)

--- a/tests/coverage_report.md
+++ b/tests/coverage_report.md
@@ -1,6 +1,6 @@
 # MoleditPy Coverage Report
 
-- **Overall Project Coverage**: **89.90%**
+- **Overall Project Coverage**: **90.02%**
 
 ### Coverage Breakdown
 
@@ -43,18 +43,18 @@
 | moleditpy\src\moleditpy\ui\main_window.py               |    195 |     13 |   93.3% |
 | moleditpy\src\moleditpy\ui\main_window_init.py          |   1103 |     86 |   92.2% |
 | moleditpy\src\moleditpy\ui\mirror_dialog.py             |     72 |      7 |   90.3% |
-| moleditpy\src\moleditpy\ui\molecular_scene_handler.py   |   1038 |    134 |   87.1% |
+| moleditpy\src\moleditpy\ui\molecular_scene_handler.py   |   1052 |    123 |   88.3% |
 | moleditpy\src\moleditpy\ui\molecule_scene.py            |    637 |     82 |   87.1% |
 | moleditpy\src\moleditpy\ui\move_group_dialog.py         |    386 |     41 |   89.4% |
 | moleditpy\src\moleditpy\ui\move_selected_atoms_dialog.py |    464 |     44 |   90.5% |
 | moleditpy\src\moleditpy\ui\periodic_table_dialog.py     |     37 |      2 |   94.6% |
 | moleditpy\src\moleditpy\ui\planarize_dialog.py          |    112 |      9 |   92.0% |
 | moleditpy\src\moleditpy\ui\plugin_menu_manager.py       |    342 |     28 |   91.8% |
-| moleditpy\src\moleditpy\ui\preview_molecule.py          |    116 |     15 |   87.1% |
+| moleditpy\src\moleditpy\ui\preview_molecule.py          |    116 |     14 |   87.9% |
 | moleditpy\src\moleditpy\ui\settings_dialog.py           |    101 |      3 |   97.0% |
 | moleditpy\src\moleditpy\ui\string_importers.py          |    121 |      0 |  100.0% |
-| moleditpy\src\moleditpy\ui\template_preview_item.py     |    233 |      5 |   97.9% |
-| moleditpy\src\moleditpy\ui\template_preview_view.py     |     46 |     10 |   78.3% |
+| moleditpy\src\moleditpy\ui\template_preview_item.py     |    239 |      4 |   98.3% |
+| moleditpy\src\moleditpy\ui\template_preview_view.py     |     46 |      4 |   91.3% |
 | moleditpy\src\moleditpy\ui\translation_dialog.py        |    276 |     21 |   92.4% |
 | moleditpy\src\moleditpy\ui\ui_manager.py                |    398 |     38 |   90.5% |
 | moleditpy\src\moleditpy\ui\user_template_dialog.py      |    298 |     34 |   88.6% |
@@ -70,12 +70,12 @@
 | moleditpy\src\moleditpy\utils\sip_isdeleted_safe.py     |     19 |      0 |  100.0% |
 | moleditpy\src\moleditpy\utils\suppress_log.py           |     10 |      0 |  100.0% |
 | moleditpy\src\moleditpy\utils\system_utils.py           |     40 |      0 |  100.0% |
-| **TOTAL** | **17160** | **1733** | **89.90%** |
+| **TOTAL** | **17180** | **1714** | **90.02%** |
 
 ## Test Suite Status
-- **Total tests passed**: 2290 (1 skipped)
+- **Total tests passed**: 2293 (1 skipped)
 - **Unit tests**: PASSED (2083 passed)
-- **Integration tests**: PASSED (87 passed)
+- **Integration tests**: PASSED (90 passed)
 - **E2E tests**: PASSED (34 passed, 1 skipped)
 - **GUI tests**: PASSED (86 passed)
 

--- a/tests/gui/test_main_app.py
+++ b/tests/gui/test_main_app.py
@@ -352,10 +352,14 @@ def test_2d_to_3d_conversion(window, qtbot, monkeypatch):
     assert convert_button.isEnabled()
 
     qtbot.mouseClick(convert_button, Qt.MouseButton.LeftButton)
-    qtbot.wait(100)  # Wait for asynchronous processing
 
-    # 3. Verify current_mol is set (mocked in conftest.py)
-    assert window.view_3d_manager.current_mol is not None
+    # 3. Verify current_mol is set (mocked in conftest.py). Conversion runs on
+    # a worker thread, so poll for the result rather than betting on a fixed
+    # delay: under coverage the old wait(100) could expire first, leaving the
+    # status bar still on "Creating 3D structure...".
+    qtbot.waitUntil(
+        lambda: window.view_3d_manager.current_mol is not None, timeout=5000
+    )
 
     # Verify 3D features are enabled
     assert window.init_manager.optimize_3d_button.isEnabled()
@@ -385,16 +389,19 @@ def test_optimize_3d(window, qtbot, monkeypatch):
         traceback.print_exc()
 
     # 3. Click 3D optimization button
-    qtbot.mouseClick(window.init_manager.optimize_3d_button, Qt.MouseButton.LeftButton)
-    qtbot.wait(50)
+    def optimization_reported() -> bool:
+        msg = window.statusBar().currentMessage()
+        return (
+            "Optimization completed" in msg
+            or "optimization successful" in msg
+            or "Process completed" in msg
+        )
 
-    # 4. Verify success via status bar message
-    msg = window.statusBar().currentMessage()
-    assert (
-        "Optimization completed" in msg
-        or "optimization successful" in msg
-        or "Process completed" in msg
-    )
+    qtbot.mouseClick(window.init_manager.optimize_3d_button, Qt.MouseButton.LeftButton)
+
+    # 4. Verify success via status bar message. The optimization is handed to a
+    # worker thread, so wait on the message itself instead of a fixed delay.
+    qtbot.waitUntil(optimization_reported, timeout=5000)
 
 
 @pytest.mark.gui

--- a/tests/integration/test_fused_ring_valence.py
+++ b/tests/integration/test_fused_ring_valence.py
@@ -1,0 +1,136 @@
+"""Fusing a ring template must leave a molecule that is chemically possible."""
+
+import math
+
+import pytest
+from PyQt6.QtCore import QPointF
+from rdkit import Chem
+
+BOND_LEN = 75.0  # the app's default 2D bond length
+APOTHEM = BOND_LEN * math.sqrt(3) / 2.0
+START_ANGLE = math.radians(-120.0)  # matches the ring template's start angle
+STEP = math.radians(60.0)
+
+RING_A = (0.0, 0.0)
+RING_B = (112.5, -64.95)  # shares the a1-a2 edge with ring A
+
+# Naphthalene as a valid Kekulé structure
+NAPHTHALENE_BONDS = [
+    ("a5", "a0", 2),
+    ("a0", "a1", 1),
+    ("a1", "a2", 2),
+    ("a2", "a3", 1),
+    ("a3", "a4", 2),
+    ("a4", "a5", 1),
+    ("a1", "b0", 1),
+    ("b0", "b1", 2),
+    ("b1", "b2", 1),
+    ("b2", "b3", 2),
+    ("b3", "a2", 1),
+]
+# Every bond on the rim, with the ring centre it belongs to
+PERIPHERAL_BONDS = [
+    ("a5", "a0", RING_A),
+    ("a0", "a1", RING_A),
+    ("a2", "a3", RING_A),
+    ("a3", "a4", RING_A),
+    ("a4", "a5", RING_A),
+    ("a1", "b0", RING_B),
+    ("b0", "b1", RING_B),
+    ("b1", "b2", RING_B),
+    ("b2", "b3", RING_B),
+    ("b3", "a2", RING_B),
+]
+
+
+def _hex_points(centre):
+    cx, cy = centre
+    return [
+        QPointF(
+            cx + BOND_LEN * math.cos(START_ANGLE + i * STEP),
+            cy + BOND_LEN * math.sin(START_ANGLE + i * STEP),
+        )
+        for i in range(6)
+    ]
+
+
+def _build_naphthalene(scene):
+    ring_a, ring_b = _hex_points(RING_A), _hex_points(RING_B)
+    coords = {
+        "a0": ring_a[0],
+        "a1": ring_a[1],
+        "a2": ring_a[2],
+        "a3": ring_a[3],
+        "a4": ring_a[4],
+        "a5": ring_a[5],
+        "b0": ring_b[0],
+        "b1": ring_b[1],
+        "b2": ring_b[2],
+        "b3": ring_b[3],
+    }
+    atoms = {n: scene.atom_items[scene.create_atom("C", p)] for n, p in coords.items()}
+    for first, second, order in NAPHTHALENE_BONDS:
+        scene.create_bond(atoms[first], atoms[second], bond_order=order)
+    return atoms
+
+
+def _fuse_benzene_onto(scene, atoms, first, second, centre):
+    """Hover a benzene template over the given rim bond and place it."""
+    mid = (atoms[first].pos() + atoms[second].pos()) / 2.0
+    away = mid - QPointF(*centre)
+    length = math.hypot(away.x(), away.y()) or 1.0
+    scene.update_template_preview(
+        mid + QPointF(away.x() / length * APOTHEM, away.y() / length * APOTHEM)
+    )
+    context = scene.template_context
+    scene.add_molecule_fragment(
+        list(context["points"]),
+        list(context["bonds_info"]),
+        context.get("items") or [],
+    )
+
+
+@pytest.mark.parametrize("first,second,centre", PERIPHERAL_BONDS)
+def test_fusing_benzene_onto_naphthalene_stays_valid(window, first, second, centre):
+    """No rim bond may give a carbon a fifth bond.
+
+    A Kekulé ring always carries a double next to its fused bond, so fusing
+    onto a single bond whose atoms each already hold a double used to hand one
+    of them order 5. Those bonds are added single instead, which leaves the new
+    carbons as methylene.
+    """
+    scene = window.init_manager.scene
+    atoms = _build_naphthalene(scene)
+    window.ui_manager.set_mode("template_benzene")
+
+    _fuse_benzene_onto(scene, atoms, first, second, centre)
+
+    overloaded = {
+        atom_id: sum(b.order for b in item.bonds)
+        for atom_id, item in scene.atom_items.items()
+        if sum(b.order for b in item.bonds) > 4
+    }
+    assert not overloaded, f"hypervalent carbons after fusing on {first}-{second}"
+
+    mol = window.state_manager.data.to_rdkit_mol()
+    assert mol is not None, f"fusing on {first}-{second} produced no molecule"
+    assert not Chem.DetectChemistryProblems(mol)
+
+
+def test_fusing_keeps_aromatic_ring_when_it_fits(window):
+    """The fallback must not fire where a full Kekulé ring is still valid."""
+    scene = window.init_manager.scene
+    atoms = _build_naphthalene(scene)
+    window.ui_manager.set_mode("template_benzene")
+
+    # a5-a0 is a rim double bond: the template can alternate around it
+    _fuse_benzene_onto(scene, atoms, "a5", "a0", RING_A)
+
+    added = [
+        i for i in scene.atom_items if i not in {a.atom_id for a in atoms.values()}
+    ]
+    assert len(added) == 4, "fusing should add four new carbons"
+    new_doubles = sum(
+        1 for item in scene.atom_items.values() for b in item.bonds if b.order == 2
+    )
+    assert new_doubles > 0, "the fused ring lost all of its double bonds"

--- a/tests/integration/test_fused_ring_valence.py
+++ b/tests/integration/test_fused_ring_valence.py
@@ -134,3 +134,48 @@ def test_fusing_keeps_aromatic_ring_when_it_fits(window):
         1 for item in scene.atom_items.values() for b in item.bonds if b.order == 2
     )
     assert new_doubles > 0, "the fused ring lost all of its double bonds"
+
+
+def test_fusing_onto_a_crowded_bond_stays_valid(window):
+    """An upgrade must fit too, not merely avoid a neighbouring double.
+
+    x-a-b-y with a-w and b-z leaves a and b holding three single bonds each.
+    Re-ordering a-b to a double takes both to four, so the ring hanging off
+    them has nowhere to go; the upgrade has to be declined.
+    """
+    scene = window.init_manager.scene
+    ring = _hex_points(RING_A)
+    first = scene.atom_items[scene.create_atom("C", ring[0])]
+    second = scene.atom_items[scene.create_atom("C", ring[1])]
+    subs = [
+        scene.atom_items[scene.create_atom("C", ring[0] + QPointF(-BOND_LEN, 0))],
+        scene.atom_items[
+            scene.create_atom("C", ring[0] + QPointF(-BOND_LEN, BOND_LEN))
+        ],
+        scene.atom_items[scene.create_atom("C", ring[1] + QPointF(BOND_LEN, 0))],
+        scene.atom_items[scene.create_atom("C", ring[1] + QPointF(BOND_LEN, BOND_LEN))],
+    ]
+    scene.create_bond(first, second, bond_order=1)
+    scene.create_bond(first, subs[0], bond_order=1)
+    scene.create_bond(first, subs[1], bond_order=1)
+    scene.create_bond(second, subs[2], bond_order=1)
+    scene.create_bond(second, subs[3], bond_order=1)
+
+    window.ui_manager.set_mode("template_benzene")
+    scene.update_template_preview(QPointF(*RING_A))
+    context = scene.template_context
+    scene.add_molecule_fragment(
+        list(context["points"]),
+        list(context["bonds_info"]),
+        context.get("items") or [],
+    )
+
+    overloaded = {
+        atom_id: sum(b.order for b in item.bonds)
+        for atom_id, item in scene.atom_items.items()
+        if sum(b.order for b in item.bonds) > 4
+    }
+    assert not overloaded, "fusing onto a fully substituted bond overfilled an atom"
+    assert scene.find_bond_between(first, second).order == 1, (
+        "the shared bond had no room to become a double"
+    )

--- a/tests/integration/test_template_preview_in_editor.py
+++ b/tests/integration/test_template_preview_in_editor.py
@@ -386,3 +386,33 @@ def test_fusing_ghost_does_not_redraw_an_unchanged_bond(window):
     assert with_ghost == without_ghost, (
         f"ghost added {with_ghost - without_ghost} px over an unchanged bond"
     )
+
+
+def test_user_template_ghost_ignores_a_previous_fusion(window):
+    """Switching template kinds must not carry the fused pairs across.
+
+    The vertex pairs a fused ring records are indices, so they collide with a
+    user template's own vertices and would silently hide one of its bonds.
+    """
+    scene = window.init_manager.scene
+    points = _hex_points()
+    first = scene.atom_items[scene.create_atom("C", points[0])]
+    second = scene.atom_items[scene.create_atom("C", points[1])]
+    scene.create_bond(first, second, bond_order=2)
+
+    window.ui_manager.set_mode("template_benzene")
+    scene.update_template_preview(QPointF(0.0, 0.0))
+    assert scene.template_preview.editor_drawn_bonds, "expected a fused pair"
+
+    scene.user_template_data = PYRIDINE
+    window.ui_manager.set_mode("template_user_pyridine")
+    scene.update_template_preview(QPointF(600.0, 600.0))
+
+    assert scene.template_preview.editor_drawn_bonds == set()
+    hidden = [
+        (b.atom1.atom_id, b.atom2.atom_id)
+        for b in scene.template_preview.ghost_bonds
+        if frozenset((b.atom1.atom_id, b.atom2.atom_id))
+        in scene.template_preview.editor_drawn_bonds
+    ]
+    assert not hidden, f"user-template ghost bonds suppressed: {hidden}"

--- a/tests/integration/test_template_preview_in_editor.py
+++ b/tests/integration/test_template_preview_in_editor.py
@@ -1,5 +1,6 @@
 """The template ghost preview has to actually appear in the real 2D editor."""
 
+import math
 from unittest.mock import patch
 
 from PyQt6.QtCore import QPointF, QRectF
@@ -255,3 +256,133 @@ def test_ring_template_preview_appears(window):
     assert preview.isVisible()
     assert [b.order for b in preview.ghost_bonds] == [2, 1, 2, 1, 2, 1]
     assert all(b.is_in_ring for b in preview.ghost_bonds)
+
+
+# ---------------------------------------------------------------------------
+# Fusing: the ghost must show the order placement will leave on a shared bond
+# ---------------------------------------------------------------------------
+
+_HEX_SIDE = 75.0  # the app's default 2D bond length
+_HEX_START = math.radians(-120.0)  # matches the ring template's start angle
+_HEX_STEP = math.radians(60.0)
+_KEKULE = [(0, 1, 2), (1, 2, 1), (2, 3, 2), (3, 4, 1), (4, 5, 2), (5, 0, 1)]
+
+
+def _hex_points(centre=QPointF(0.0, 0.0)):
+    """The six vertices a benzene template lands on when centred at *centre*."""
+    return [
+        centre
+        + QPointF(
+            _HEX_SIDE * math.cos(_HEX_START + i * _HEX_STEP),
+            _HEX_SIDE * math.sin(_HEX_START + i * _HEX_STEP),
+        )
+        for i in range(6)
+    ]
+
+
+def _shared_ghost_orders(preview):
+    """Orders of ghost bonds whose two ends both sit on existing atoms."""
+    return [
+        bond.order
+        for bond in preview.ghost_bonds
+        if bond.atom1.atom_id in preview.existing_indices
+        and bond.atom2.atom_id in preview.existing_indices
+    ]
+
+
+def test_fusing_ghost_keeps_an_untouched_bond_order(window):
+    """Fusing onto a ring must not draw a double over a bond that stays single.
+
+    add_molecule_fragment refuses to re-order an existing bond whose atoms
+    already carry a double, so the alternation the rotation picks never reaches
+    the shared bond. The ghost used to draw it anyway, leaving a second line
+    along every single bond of the ring being fused to.
+    """
+    scene = window.init_manager.scene
+    points = _hex_points()
+    atoms = [scene.atom_items[scene.create_atom("C", p)] for p in points]
+    for i, j, order in _KEKULE:
+        scene.create_bond(atoms[i], atoms[j], bond_order=order)
+    window.ui_manager.set_mode("template_benzene")
+
+    apothem = _HEX_SIDE * math.sqrt(3) / 2.0
+    for i, j, order in _KEKULE:
+        mid = (points[i] + points[j]) / 2.0
+        length = math.hypot(mid.x(), mid.y()) or 1.0
+        scene.update_template_preview(
+            mid + QPointF(mid.x() / length * apothem, mid.y() / length * apothem)
+        )
+        preview = scene.template_preview
+
+        shared = _shared_ghost_orders(preview)
+        assert shared, f"nothing fused when hovering over bond ({i}, {j})"
+        assert shared == [order], (
+            f"ghost promises {shared} on bond ({i}, {j}), which stays {order}"
+        )
+
+
+def test_fusing_ghost_still_previews_an_allowed_overwrite(window):
+    """A lone single bond does get upgraded, and the ghost must say so."""
+    scene = window.init_manager.scene
+    points = _hex_points()
+    first = scene.atom_items[scene.create_atom("C", points[0])]
+    second = scene.atom_items[scene.create_atom("C", points[1])]
+    scene.create_bond(first, second, bond_order=1)
+    window.ui_manager.set_mode("template_benzene")
+
+    scene.update_template_preview(QPointF(0.0, 0.0))
+    preview = scene.template_preview
+    assert _shared_ghost_orders(preview) == [2]
+
+    context = scene.template_context
+    scene.add_molecule_fragment(
+        list(context["points"]),
+        list(context["bonds_info"]),
+        context.get("items") or [],
+    )
+
+    assert scene.find_bond_between(first, second).order == 2
+
+
+def test_fusing_ghost_does_not_redraw_an_unchanged_bond(window):
+    """The ghost leaves a bond it will not change to the editor.
+
+    Painting a ghost copy on top of the real bond doubles every line: over an
+    existing double bond the overlay reads as a triple.
+    """
+    scene = window.init_manager.scene
+    points = _hex_points()
+    atoms = [scene.atom_items[scene.create_atom("C", p)] for p in points]
+    for i, j, order in _KEKULE:
+        scene.create_bond(atoms[i], atoms[j], bond_order=order)
+    window.ui_manager.set_mode("template_benzene")
+
+    # Fuse onto bond (0, 1), which is a double and stays one
+    apothem = _HEX_SIDE * math.sqrt(3) / 2.0
+    mid = (points[0] + points[1]) / 2.0
+    length = math.hypot(mid.x(), mid.y()) or 1.0
+    scene.update_template_preview(
+        mid + QPointF(mid.x() / length * apothem, mid.y() / length * apothem)
+    )
+    preview = scene.template_preview
+    assert preview.isVisible()
+
+    # Ghost items are indexed by template vertex, not by editor atom id
+    shared_pairs = {
+        frozenset((b.atom1.atom_id, b.atom2.atom_id))
+        for b in preview.ghost_bonds
+        if b.atom1.atom_id in preview.existing_indices
+        and b.atom2.atom_id in preview.existing_indices
+    }
+    assert len(shared_pairs) == 1, "expected exactly one fused bond"
+    assert shared_pairs <= preview.editor_drawn_bonds
+
+    # A tight box on the shared bond must look the same with and without the ghost
+    region = QRectF(mid.x() - 12, mid.y() - 12, 24, 24)
+    with_ghost = _painted_pixels(scene, region)
+    preview.hide()
+    without_ghost = _painted_pixels(scene, region)
+
+    assert with_ghost == without_ghost, (
+        f"ghost added {with_ghost - without_ghost} px over an unchanged bond"
+    )

--- a/tests/unit/test_alt_template_bypass.py
+++ b/tests/unit/test_alt_template_bypass.py
@@ -27,6 +27,9 @@ class MockTemplateScene(TemplateMixin):
         self.find_atom_near_args.append((pos, tol))
         return None
 
+    def find_bond_between(self, atom1, atom2):
+        return None
+
     def items(self, *args):
         return self.items_returned
 

--- a/tests/unit/test_edit_actions.py
+++ b/tests/unit/test_edit_actions.py
@@ -414,6 +414,17 @@ class TestEditActionsExtended:
         assert result is True
         manager.host.statusBar().showMessage.assert_called_with("Cleared all data.")
 
+    def test_clear_all_restores_launch_zoom(self, manager):
+        """clear_all resets the 2D view to the default zoom, not the identity transform.
+
+        resetTransform() left the view at 100% while a freshly launched app
+        starts at 75%, so Clear All used to come back zoomed in.
+        """
+        manager.clear_all(skip_check=True)
+
+        manager.host.view_3d_manager.reset_zoom.assert_called_once()
+        manager.host.init_manager.view_2d.resetTransform.assert_not_called()
+
     def test_cut_selection(self, manager):
         """cut_selection copies then deletes the selected items."""
         manager.copy_selection = MagicMock()

--- a/tests/unit/test_plugin_interface.py
+++ b/tests/unit/test_plugin_interface.py
@@ -30,7 +30,13 @@ class TestPluginInterface:
                     "File/Test", cb, "Test Action", "icon.png", "Ctrl+T"
                 ),
                 lambda mgr, cb: mgr.register_menu_action.assert_called_once_with(
-                    "TestPlugin", "File/Test", cb, "Test Action", "icon.png", "Ctrl+T"
+                    "TestPlugin",
+                    "File/Test",
+                    cb,
+                    "Test Action",
+                    "icon.png",
+                    "Ctrl+T",
+                    None,
                 ),
             ),
             (
@@ -248,7 +254,7 @@ class TestPluginInterface:
         callback = MagicMock()
         ctx.add_plugin_menu("Utility/My Tool...", callback)
         mock_manager.register_menu_action.assert_called_once_with(
-            "TestPlugin", "Plugin/Utility/My Tool...", callback, None, None, None
+            "TestPlugin", "Plugin/Utility/My Tool...", callback, None, None, None, None
         )
 
     def test_add_plugin_menu_strips_leading_slash(self, mock_manager):
@@ -257,7 +263,7 @@ class TestPluginInterface:
         callback = MagicMock()
         ctx.add_plugin_menu("/Analysis/Viewer", callback)
         mock_manager.register_menu_action.assert_called_once_with(
-            "TestPlugin", "Plugin/Analysis/Viewer", callback, None, None, None
+            "TestPlugin", "Plugin/Analysis/Viewer", callback, None, None, None, None
         )
 
     def test_add_plugin_menu_with_text_and_shortcut(self, mock_manager):
@@ -268,7 +274,13 @@ class TestPluginInterface:
             "File/Export...", callback, text="Export", shortcut="Ctrl+E"
         )
         mock_manager.register_menu_action.assert_called_once_with(
-            "TestPlugin", "Plugin/File/Export...", callback, "Export", None, "Ctrl+E"
+            "TestPlugin",
+            "Plugin/File/Export...",
+            callback,
+            "Export",
+            None,
+            "Ctrl+E",
+            None,
         )
 
     def test_register_menu_action_new_style(self, mock_manager):
@@ -277,7 +289,7 @@ class TestPluginInterface:
         callback = MagicMock()
         ctx.register_menu_action("File/Open", callback)
         mock_manager.register_menu_action.assert_called_once_with(
-            "TestPlugin", "File/Open", callback, None, None, None
+            "TestPlugin", "File/Open", callback, None, None, None, None
         )
 
     def test_register_menu_action_old_style(self, mock_manager):
@@ -286,7 +298,7 @@ class TestPluginInterface:
         callback = MagicMock()
         ctx.register_menu_action("File/Import", "Import PubChem...", callback)
         mock_manager.register_menu_action.assert_called_once_with(
-            "TestPlugin", "File/Import", callback, "Import PubChem...", None, None
+            "TestPlugin", "File/Import", callback, "Import PubChem...", None, None, None
         )
 
     # ------------------------------------------------------------------

--- a/tests/unit/test_plugin_manager.py
+++ b/tests/unit/test_plugin_manager.py
@@ -646,6 +646,43 @@ except BaseException:
         pm._load_single_plugin("a.py", "VPlugin", "")
         assert pm.plugins[0]["version"] == "3.1.4"
 
+    def test_folder_overrides_declared_category(self, tmpdir):
+        """The containing folder wins over a plugin's own PLUGIN_CATEGORY.
+
+        Folder placement is the user's ordering decision, so a plugin filed
+        under a category folder stays there even if its source declares
+        something else.
+        """
+        pm = PluginManager()
+        root = tmpdir.mkdir("cat_plugins")
+        pm.plugin_dir = str(root)
+        root.mkdir("Tools").join("filed.py").write(
+            "PLUGIN_NAME = 'Filed'\n"
+            "PLUGIN_CATEGORY = 'AuthorChoice'\n"
+            "def run(mw):\n    pass\n"
+        )
+
+        pm.discover_plugins()
+
+        plugin = next(p for p in pm.plugins if p["name"] == "Filed")
+        assert plugin["category"] == "Tools"
+
+    def test_declared_category_applies_at_plugin_root(self, tmpdir):
+        """PLUGIN_CATEGORY still applies when the file sits at the plugins root."""
+        pm = PluginManager()
+        root = tmpdir.mkdir("root_plugins")
+        pm.plugin_dir = str(root)
+        root.join("loose.py").write(
+            "PLUGIN_NAME = 'Loose'\n"
+            "PLUGIN_CATEGORY = 'AuthorChoice'\n"
+            "def run(mw):\n    pass\n"
+        )
+
+        pm.discover_plugins()
+
+        plugin = next(p for p in pm.plugins if p["name"] == "Loose")
+        assert plugin["category"] == "AuthorChoice"
+
     @patch("moleditpy.plugins.plugin_manager.QMessageBox.critical")
     def test_run_plugin_exceptions(self, mock_crit):
         """run_plugin shows a critical dialog when the plugin run() raises."""

--- a/tests/unit/test_plugin_menu_manager.py
+++ b/tests/unit/test_plugin_menu_manager.py
@@ -959,7 +959,7 @@ class TestPluginMenuComposition:
 
 
 # ---------------------------------------------------------------------------
-# Plugin Installer — pinned beside the Plugin Manager
+# pin="header" — an entry placed beside the Plugin Manager on request
 # ---------------------------------------------------------------------------
 
 
@@ -970,17 +970,20 @@ def _v4_plugin(name):
     return p
 
 
-def _installer_entry(plugin="Plugin Installer", label="Plugin Installer..."):
+def _pinned_entry(label="Plugin Installer...", pin="header"):
+    """A direct Plugin/<entry> registration asking for the header slot."""
     entry = _entry("Plugin/" + label, label)
-    entry["plugin"] = plugin
+    entry["plugin"] = "Plugin Installer"
+    if pin is not None:
+        entry["pin"] = pin
     return entry
 
 
-class TestPluginInstallerPinning:
-    def test_installer_sits_directly_below_the_manager(self, im, pmm, app):
-        """The installer joins the header pair with no divider between them."""
+class TestHeaderPin:
+    def test_pinned_entry_sits_directly_below_the_manager(self, im, pmm, app):
+        """The entry joins the header pair with no divider between them."""
         _bar, plugin_menu = _menubar_with_plugin_menu(im)
-        im.host.plugin_manager.menu_actions = [_installer_entry()]
+        im.host.plugin_manager.menu_actions = [_pinned_entry()]
         im.host.plugin_manager.plugins = [_legacy_plugin("Filed", "Folder")]
 
         pmm.rebuild_plugin_menus()
@@ -992,12 +995,12 @@ class TestPluginInstallerPinning:
             "Folder/",
         ]
 
-    def test_installer_stays_above_other_injected_plugins(self, im, pmm, app):
+    def test_pinned_entry_stays_above_other_injected_plugins(self, im, pmm, app):
         """Ordinary context-injected entries stay below the divider."""
         _bar, plugin_menu = _menubar_with_plugin_menu(im)
         im.host.plugin_manager.menu_actions = [
             _entry("Plugin/Injected", "Injected"),
-            _installer_entry(),
+            _pinned_entry(),
         ]
         im.host.plugin_manager.plugins = [_v4_plugin("Modern")]
 
@@ -1011,10 +1014,10 @@ class TestPluginInstallerPinning:
         ]
 
     def test_registration_order_does_not_matter(self, im, pmm, app):
-        """Registering the installer first gives the same layout."""
+        """Registering the pinned entry first gives the same layout."""
         _bar, plugin_menu = _menubar_with_plugin_menu(im)
         im.host.plugin_manager.menu_actions = [
-            _installer_entry(),
+            _pinned_entry(),
             _entry("Plugin/Injected", "Injected"),
         ]
         im.host.plugin_manager.plugins = [_v4_plugin("Modern")]
@@ -1028,34 +1031,20 @@ class TestPluginInstallerPinning:
             "Injected",
         ]
 
-    def test_installer_alone_leaves_no_dangling_divider(self, im, pmm, app):
+    def test_pinned_entry_alone_leaves_no_dangling_divider(self, im, pmm, app):
         """With nothing under it, the header divider is dropped."""
         _bar, plugin_menu = _menubar_with_plugin_menu(im)
-        im.host.plugin_manager.menu_actions = [_installer_entry()]
+        im.host.plugin_manager.menu_actions = [_pinned_entry()]
         im.host.plugin_manager.plugins = [_v4_plugin("Modern")]
 
         pmm.rebuild_plugin_menus()
 
         assert _shape(plugin_menu) == ["Plugin Manager...", "Plugin Installer..."]
 
-    def test_matched_case_insensitively_by_label(self, im, pmm, app):
-        """A differently-cased PLUGIN_NAME or label still pins."""
+    def test_the_name_alone_does_not_pin(self, im, pmm, app):
+        """Placement is granted on request only — the app knows no plugin names."""
         _bar, plugin_menu = _menubar_with_plugin_menu(im)
-        im.host.plugin_manager.menu_actions = [
-            _installer_entry(plugin="Some Author Bundle", label="Plugin installer")
-        ]
-        im.host.plugin_manager.plugins = [_v4_plugin("Modern")]
-
-        pmm.rebuild_plugin_menus()
-
-        assert _shape(plugin_menu) == ["Plugin Manager...", "Plugin installer"]
-
-    def test_unrelated_plugin_is_not_pinned(self, im, pmm, app):
-        """A plugin merely mentioning install is left below the divider."""
-        _bar, plugin_menu = _menubar_with_plugin_menu(im)
-        im.host.plugin_manager.menu_actions = [
-            _installer_entry(plugin="Installer Helper", label="Install Helper")
-        ]
+        im.host.plugin_manager.menu_actions = [_pinned_entry(pin=None)]
         im.host.plugin_manager.plugins = [_v4_plugin("Modern")]
 
         pmm.rebuild_plugin_menus()
@@ -1063,17 +1052,48 @@ class TestPluginInstallerPinning:
         assert _shape(plugin_menu) == [
             "Plugin Manager...",
             "sep",
-            "Install Helper",
+            "Plugin Installer...",
         ]
 
-    def test_nested_installer_path_is_not_pinned(self, im, pmm, app):
-        """Only a direct Plugin/<entry> registration is pinned."""
+    def test_unknown_pin_value_is_ignored(self, im, pmm, app):
+        """An unrecognised pin leaves the entry in the ordinary group."""
         _bar, plugin_menu = _menubar_with_plugin_menu(im)
-        entry = _entry("Plugin/Tools/Plugin Installer...", "Plugin Installer...")
-        entry["plugin"] = "Plugin Installer"
+        im.host.plugin_manager.menu_actions = [_pinned_entry(pin="footer")]
+        im.host.plugin_manager.plugins = [_v4_plugin("Modern")]
+
+        pmm.rebuild_plugin_menus()
+
+        assert _shape(plugin_menu) == [
+            "Plugin Manager...",
+            "sep",
+            "Plugin Installer...",
+        ]
+
+    def test_pin_needs_a_direct_plugin_path(self, im, pmm, app):
+        """pin="header" on a nested path is ignored."""
+        _bar, plugin_menu = _menubar_with_plugin_menu(im)
+        entry = _entry("Plugin/Tools/Installer", "Installer")
+        entry["pin"] = "header"
         im.host.plugin_manager.menu_actions = [entry]
         im.host.plugin_manager.plugins = [_v4_plugin("Modern")]
 
         pmm.rebuild_plugin_menus()
 
         assert _shape(plugin_menu) == ["Plugin Manager...", "sep", "Tools/"]
+
+    def test_pin_outside_the_plugin_menu_is_ignored(self, im, pmm, app):
+        """A pin request only means anything inside the Plugin menu."""
+        from PyQt6.QtWidgets import QMenuBar
+
+        bar = QMenuBar()
+        tools = bar.addMenu("Tools")
+        tools.addAction("Native A")
+        im.host.menuBar = MagicMock(return_value=bar)
+        del im.plugin_menu
+        entry = _entry("Tools/Pinned", "Pinned")
+        entry["pin"] = "header"
+        im.host.plugin_manager.menu_actions = [entry]
+
+        pmm.rebuild_plugin_menus()
+
+        assert _shape(tools) == ["Native A", "sep", "Pinned"]

--- a/tests/unit/test_plugin_menu_manager.py
+++ b/tests/unit/test_plugin_menu_manager.py
@@ -589,13 +589,16 @@ class TestIntegratePluginFileOpeners:
 
 
 class TestClearAllPluginActions:
-    def test_clears_plugin_menu(self, im, pmm):
-        """_clear_all_plugin_actions clears the plugin menu."""
+    def test_reset_plugin_menu_clears_and_re_adds_the_header(self, im, pmm):
+        """_reset_plugin_menu empties the Plugin menu and restores its header."""
         plugin_menu = MagicMock(spec=QMenu)
         plugin_menu.actions.return_value = []
-        im.host.menuBar.return_value.actions.return_value = []
-        pmm._clear_all_plugin_actions(plugin_menu)
+
+        pmm._reset_plugin_menu(plugin_menu)
+
         plugin_menu.clear.assert_called_once()
+        plugin_menu.addAction.assert_called_once()
+        plugin_menu.addSeparator.assert_called_once()
 
     def test_removes_tagged_actions_from_all_menus(self, im, pmm):
         """_clear_all_plugin_actions removes all plugin_managed tagged actions from all menus."""
@@ -615,10 +618,8 @@ class TestClearAllPluginActions:
         top_action.menu.return_value = top_menu
 
         im.host.menuBar.return_value.actions.return_value = [top_action]
-        plugin_menu = MagicMock(spec=QMenu)
-        plugin_menu.actions.return_value = []
 
-        pmm._clear_all_plugin_actions(plugin_menu)
+        pmm._clear_all_plugin_actions()
 
         sub_menu.removeAction.assert_called_with(tagged)
 
@@ -692,3 +693,387 @@ class TestAddLegacyPluginActions:
         im.host.plugin_manager.run_plugin.assert_called_once_with(
             plugin["module"], im.host
         )
+
+
+# ---------------------------------------------------------------------------
+# add_registered_plugin_actions — divider placement in tree-structured menus
+# ---------------------------------------------------------------------------
+
+TAG = PluginMenuManager._PLUGIN_ACTION_TAG
+
+
+def _menubar_with_tools(im, app):
+    """Give *im* a real menu bar holding a native 'Tools' menu with two entries."""
+    from PyQt6.QtWidgets import QMenuBar
+
+    bar = QMenuBar()
+    tools = bar.addMenu("Tools")
+    tools.addAction("Native A")
+    tools.addAction("Native B")
+    im.host.menuBar = MagicMock(return_value=bar)
+    return bar, tools
+
+
+def _entry(path, text):
+    return {
+        "plugin": "P",
+        "path": path,
+        "callback": lambda: None,
+        "text": text,
+        "icon": None,
+        "shortcut": None,
+    }
+
+
+class TestPluginSeparatorPlacement:
+    def test_divider_precedes_a_nested_plugin_submenu(self, im, pmm, app):
+        """A nested path puts the divider before the submenu, not after it.
+
+        The divider used to be checked against the freshly created (empty) leaf
+        submenu, so no divider was added at all and the plugin submenu sat
+        flush against the native entries.
+        """
+        _bar, tools = _menubar_with_tools(im, app)
+        im.host.plugin_manager.menu_actions = [_entry("Tools/Sub/Item", "Item")]
+
+        pmm.add_registered_plugin_actions()
+
+        kinds = [
+            "sep" if a.isSeparator() else ("menu" if a.menu() else a.text())
+            for a in tools.actions()
+        ]
+        assert kinds == ["Native A", "Native B", "sep", "menu"]
+
+    def test_no_extra_divider_between_plugin_siblings(self, im, pmm, app):
+        """An entry following a plugin submenu does not get its own divider.
+
+        The submenu action is tagged, so the dedupe check recognises it as
+        plugin-owned instead of mistaking it for a native entry.
+        """
+        _bar, tools = _menubar_with_tools(im, app)
+        im.host.plugin_manager.menu_actions = [
+            _entry("Tools/Sub/Item", "Item"),
+            _entry("Tools/Direct", "Direct"),
+        ]
+
+        pmm.add_registered_plugin_actions()
+
+        kinds = [
+            "sep" if a.isSeparator() else ("menu" if a.menu() else a.text())
+            for a in tools.actions()
+        ]
+        assert kinds == ["Native A", "Native B", "sep", "menu", "Direct"]
+
+    def test_plugin_created_submenu_is_tagged(self, im, pmm, app):
+        """Submenus built for a plugin path carry the plugin tag for cleanup."""
+        _bar, tools = _menubar_with_tools(im, app)
+        im.host.plugin_manager.menu_actions = [_entry("Tools/Sub/Item", "Item")]
+
+        pmm.add_registered_plugin_actions()
+
+        sub_action = next(a for a in tools.actions() if a.menu())
+        assert sub_action.data() == TAG
+
+    def test_shared_submenu_gets_one_divider_and_no_duplicate(self, im, pmm, app):
+        """Two plugins under the same submenu reuse it without extra dividers."""
+        _bar, tools = _menubar_with_tools(im, app)
+        im.host.plugin_manager.menu_actions = [
+            _entry("Tools/Sub/One", "One"),
+            _entry("Tools/Sub/Two", "Two"),
+        ]
+
+        pmm.add_registered_plugin_actions()
+
+        submenus = [a.menu() for a in tools.actions() if a.menu()]
+        assert len(submenus) == 1
+        assert [a.text() for a in submenus[0].actions()] == ["One", "Two"]
+        assert sum(1 for a in tools.actions() if a.isSeparator()) == 1
+
+
+# ---------------------------------------------------------------------------
+# Menu-bar cleanup — shared by both clear paths
+# ---------------------------------------------------------------------------
+
+
+def _menubar_with_plugin_top_level(im):
+    """Build a bar holding a native menu plus a tagged divider and plugin menu."""
+    from PyQt6.QtWidgets import QMenuBar
+
+    bar = QMenuBar()
+    bar.addMenu("Tools").addAction("Native A")
+
+    sep = bar.addSeparator()
+    sep.setData(TAG)
+
+    plugin_top = bar.addMenu("MyPlugin")
+    plugin_top.menuAction().setData(TAG)
+    entry = plugin_top.addAction("Gone")
+    entry.setData(TAG)
+
+    im.host.menuBar = MagicMock(return_value=bar)
+    im.plugin_menubar_separator_added = True
+    return bar
+
+
+class TestClearPluginMenubarEntries:
+    def test_clear_all_drops_stale_plugin_top_level_menu(self, im, pmm, app):
+        """_clear_all_plugin_actions reclaims the menu bar, not just the menus.
+
+        _get_plugin_target_menus walks into the bar's menus but never the bar
+        itself, so an uninstalled plugin's own top-level menu used to survive
+        as an empty stub with an orphaned divider in front of it.
+        """
+        bar = _menubar_with_plugin_top_level(im)
+
+        pmm._clear_all_plugin_actions()
+
+        titles = [a.text() for a in bar.actions() if a.menu()]
+        assert titles == ["Tools"]
+        assert not any(a.isSeparator() for a in bar.actions())
+
+    def test_clear_all_resets_separator_flag(self, im, pmm, app):
+        """The flag is reset so the next populate pass re-adds the divider."""
+        _menubar_with_plugin_top_level(im)
+
+        pmm._clear_all_plugin_actions()
+
+        assert im.plugin_menubar_separator_added is False
+
+    def test_native_top_level_menu_is_never_removed(self, im, pmm, app):
+        """An untagged top-level menu survives even when it is empty."""
+        from PyQt6.QtWidgets import QMenuBar
+
+        bar = QMenuBar()
+        bar.addMenu("Empty Native")
+        im.host.menuBar = MagicMock(return_value=bar)
+
+        pmm._clear_all_plugin_actions()
+
+        assert [a.text() for a in bar.actions() if a.menu()] == ["Empty Native"]
+
+    def test_rebuild_uses_the_same_menubar_cleanup(self, im, pmm, app):
+        """rebuild_plugin_menus drops the stale top-level menu too."""
+        bar = _menubar_with_plugin_top_level(im)
+
+        pmm.rebuild_plugin_menus()
+
+        assert [a.text() for a in bar.actions() if a.menu()] == ["Tools"]
+        assert im.plugin_menubar_separator_added is False
+
+
+# ---------------------------------------------------------------------------
+# Plugin menu composition — context-injected vs folder-derived groups
+# ---------------------------------------------------------------------------
+
+
+def _menubar_with_plugin_menu(im):
+    """Give *im* a real menu bar whose only menu is the Plugin menu."""
+    from PyQt6.QtWidgets import QMenuBar
+
+    bar = QMenuBar()
+    plugin_menu = bar.addMenu("&Plugin")
+    im.host.menuBar = MagicMock(return_value=bar)
+    im.plugin_menu = plugin_menu
+    return bar, plugin_menu
+
+
+def _shape(menu):
+    """Describe a menu as a list of 'sep' / submenu titles / action labels."""
+    return [
+        "sep" if a.isSeparator() else (a.menu().title() + "/" if a.menu() else a.text())
+        for a in menu.actions()
+    ]
+
+
+class TestPluginMenuComposition:
+    def test_update_puts_context_entries_above_folder_ones(self, im, pmm, app):
+        """A fresh build lists context-injected entries, a divider, then folders."""
+        _bar, plugin_menu = _menubar_with_plugin_menu(im)
+        im.host.plugin_manager.menu_actions = [_entry("Plugin/Injected", "Injected")]
+        im.host.plugin_manager.discover_plugins.return_value = [
+            _legacy_plugin("Filed", "Folder")
+        ]
+
+        pmm.update_plugin_menu(plugin_menu)
+
+        assert _shape(plugin_menu) == [
+            "Plugin Manager...",
+            "sep",
+            "Injected",
+            "sep",
+            "Folder/",
+        ]
+
+    def test_rebuild_preserves_that_order(self, im, pmm, app):
+        """A reload must not flip the two groups.
+
+        rebuild_plugin_menus used to strip only the tagged (context-injected)
+        entries and append the fresh ones after the surviving folder entries,
+        so every reload swapped the order.
+        """
+        _bar, plugin_menu = _menubar_with_plugin_menu(im)
+        im.host.plugin_manager.menu_actions = [_entry("Plugin/Injected", "Injected")]
+        im.host.plugin_manager.plugins = [_legacy_plugin("Filed", "Folder")]
+
+        pmm.rebuild_plugin_menus()
+
+        assert _shape(plugin_menu) == [
+            "Plugin Manager...",
+            "sep",
+            "Injected",
+            "sep",
+            "Folder/",
+        ]
+
+    def test_repeated_rebuilds_are_stable(self, im, pmm, app):
+        """Reloading twice yields the same menu, with no accumulation."""
+        _bar, plugin_menu = _menubar_with_plugin_menu(im)
+        im.host.plugin_manager.menu_actions = [_entry("Plugin/Injected", "Injected")]
+        im.host.plugin_manager.plugins = [_legacy_plugin("Filed", "Folder")]
+
+        pmm.rebuild_plugin_menus()
+        first = _shape(plugin_menu)
+        pmm.rebuild_plugin_menus()
+
+        assert _shape(plugin_menu) == first
+
+    def test_no_trailing_divider_without_folder_plugins(self, im, pmm, app):
+        """With only context-injected entries the menu ends on a real entry."""
+        _bar, plugin_menu = _menubar_with_plugin_menu(im)
+        im.host.plugin_manager.menu_actions = [_entry("Plugin/Injected", "Injected")]
+        im.host.plugin_manager.plugins = [_v4_plugin("Modern")]
+
+        pmm.rebuild_plugin_menus()
+
+        assert _shape(plugin_menu) == ["Plugin Manager...", "sep", "Injected"]
+
+    def test_folder_plugins_alone_get_no_leading_divider(self, im, pmm, app):
+        """Without context-injected entries the header divider is enough."""
+        _bar, plugin_menu = _menubar_with_plugin_menu(im)
+        im.host.plugin_manager.menu_actions = []
+        im.host.plugin_manager.plugins = [_legacy_plugin("Filed", "Folder")]
+
+        pmm.rebuild_plugin_menus()
+
+        assert _shape(plugin_menu) == ["Plugin Manager...", "sep", "Folder/"]
+
+
+# ---------------------------------------------------------------------------
+# Plugin Installer — pinned beside the Plugin Manager
+# ---------------------------------------------------------------------------
+
+
+def _v4_plugin(name):
+    """A discovered initialize()-style plugin: present, but with no run()."""
+    p = _legacy_plugin(name)
+    del p["module"].run
+    return p
+
+
+def _installer_entry(plugin="Plugin Installer", label="Plugin Installer..."):
+    entry = _entry("Plugin/" + label, label)
+    entry["plugin"] = plugin
+    return entry
+
+
+class TestPluginInstallerPinning:
+    def test_installer_sits_directly_below_the_manager(self, im, pmm, app):
+        """The installer joins the header pair with no divider between them."""
+        _bar, plugin_menu = _menubar_with_plugin_menu(im)
+        im.host.plugin_manager.menu_actions = [_installer_entry()]
+        im.host.plugin_manager.plugins = [_legacy_plugin("Filed", "Folder")]
+
+        pmm.rebuild_plugin_menus()
+
+        assert _shape(plugin_menu) == [
+            "Plugin Manager...",
+            "Plugin Installer...",
+            "sep",
+            "Folder/",
+        ]
+
+    def test_installer_stays_above_other_injected_plugins(self, im, pmm, app):
+        """Ordinary context-injected entries stay below the divider."""
+        _bar, plugin_menu = _menubar_with_plugin_menu(im)
+        im.host.plugin_manager.menu_actions = [
+            _entry("Plugin/Injected", "Injected"),
+            _installer_entry(),
+        ]
+        im.host.plugin_manager.plugins = [_v4_plugin("Modern")]
+
+        pmm.rebuild_plugin_menus()
+
+        assert _shape(plugin_menu) == [
+            "Plugin Manager...",
+            "Plugin Installer...",
+            "sep",
+            "Injected",
+        ]
+
+    def test_registration_order_does_not_matter(self, im, pmm, app):
+        """Registering the installer first gives the same layout."""
+        _bar, plugin_menu = _menubar_with_plugin_menu(im)
+        im.host.plugin_manager.menu_actions = [
+            _installer_entry(),
+            _entry("Plugin/Injected", "Injected"),
+        ]
+        im.host.plugin_manager.plugins = [_v4_plugin("Modern")]
+
+        pmm.rebuild_plugin_menus()
+
+        assert _shape(plugin_menu) == [
+            "Plugin Manager...",
+            "Plugin Installer...",
+            "sep",
+            "Injected",
+        ]
+
+    def test_installer_alone_leaves_no_dangling_divider(self, im, pmm, app):
+        """With nothing under it, the header divider is dropped."""
+        _bar, plugin_menu = _menubar_with_plugin_menu(im)
+        im.host.plugin_manager.menu_actions = [_installer_entry()]
+        im.host.plugin_manager.plugins = [_v4_plugin("Modern")]
+
+        pmm.rebuild_plugin_menus()
+
+        assert _shape(plugin_menu) == ["Plugin Manager...", "Plugin Installer..."]
+
+    def test_matched_case_insensitively_by_label(self, im, pmm, app):
+        """A differently-cased PLUGIN_NAME or label still pins."""
+        _bar, plugin_menu = _menubar_with_plugin_menu(im)
+        im.host.plugin_manager.menu_actions = [
+            _installer_entry(plugin="Some Author Bundle", label="Plugin installer")
+        ]
+        im.host.plugin_manager.plugins = [_v4_plugin("Modern")]
+
+        pmm.rebuild_plugin_menus()
+
+        assert _shape(plugin_menu) == ["Plugin Manager...", "Plugin installer"]
+
+    def test_unrelated_plugin_is_not_pinned(self, im, pmm, app):
+        """A plugin merely mentioning install is left below the divider."""
+        _bar, plugin_menu = _menubar_with_plugin_menu(im)
+        im.host.plugin_manager.menu_actions = [
+            _installer_entry(plugin="Installer Helper", label="Install Helper")
+        ]
+        im.host.plugin_manager.plugins = [_v4_plugin("Modern")]
+
+        pmm.rebuild_plugin_menus()
+
+        assert _shape(plugin_menu) == [
+            "Plugin Manager...",
+            "sep",
+            "Install Helper",
+        ]
+
+    def test_nested_installer_path_is_not_pinned(self, im, pmm, app):
+        """Only a direct Plugin/<entry> registration is pinned."""
+        _bar, plugin_menu = _menubar_with_plugin_menu(im)
+        entry = _entry("Plugin/Tools/Plugin Installer...", "Plugin Installer...")
+        entry["plugin"] = "Plugin Installer"
+        im.host.plugin_manager.menu_actions = [entry]
+        im.host.plugin_manager.plugins = [_v4_plugin("Modern")]
+
+        pmm.rebuild_plugin_menus()
+
+        assert _shape(plugin_menu) == ["Plugin Manager...", "sep", "Tools/"]

--- a/tests/unit/test_plugin_menu_manager.py
+++ b/tests/unit/test_plugin_menu_manager.py
@@ -1097,3 +1097,107 @@ class TestHeaderPin:
         pmm.rebuild_plugin_menus()
 
         assert _shape(tools) == ["Native A", "sep", "Pinned"]
+
+
+# ---------------------------------------------------------------------------
+# Cleanup must retire what it detaches, not just unhook it
+# ---------------------------------------------------------------------------
+
+
+def _drain_deferred_deletes(app):
+    """Run the event-loop turn that deleteLater() waits for."""
+    from PyQt6.QtCore import QCoreApplication, QEvent
+
+    app.processEvents()
+    QCoreApplication.sendPostedEvents(None, QEvent.Type.DeferredDelete)
+
+
+class TestCleanupDoesNotStrandObjects:
+    def test_repeated_cycles_do_not_strand_submenus(self, im, pmm, app):
+        """A plugin submenu is destroyed with its entry, not merely detached.
+
+        Tagging plugin-created submenus made the clear pass remove them
+        without recursing, leaving each one alive as a child of its former
+        parent while the next pass built a replacement — one stranded QMenu
+        per Plugin Manager cycle.
+        """
+        _bar, tools = _menubar_with_tools(im, app)
+        im.host.plugin_manager.menu_actions = [_entry("Tools/Sub/Item", "Item")]
+
+        for _ in range(4):
+            pmm.add_registered_plugin_actions()
+            pmm._clear_all_plugin_actions()
+            _drain_deferred_deletes(app)
+        pmm.add_registered_plugin_actions()
+        _drain_deferred_deletes(app)
+
+        assert [a.text() for a in tools.actions() if a.menu()] == ["Sub"]
+        assert len(tools.findChildren(QMenu)) == 1
+
+    def test_native_submenu_survives_cleanup(self, im, pmm, app):
+        """An empty native submenu is neither removed nor destroyed."""
+        _bar, tools = _menubar_with_tools(im, app)
+        native_sub = tools.addMenu("Native Sub")
+
+        pmm._clear_all_plugin_actions()
+        _drain_deferred_deletes(app)
+
+        assert [a.text() for a in tools.actions() if a.menu()] == ["Native Sub"]
+        assert native_sub.title() == "Native Sub"  # not deleted
+
+    def test_manager_entry_is_reused_across_resets(self, im, pmm, app):
+        """The manager entry survives a reset — it may be the running handler.
+
+        A rebuild can start from inside its own triggered handler (Plugin
+        Manager > Reload), so this is the one entry the reset must not delete.
+        """
+        menu = QMenu()
+
+        pmm._reset_plugin_menu(menu)
+        first = menu.actions()[0]
+        pmm._reset_plugin_menu(menu)
+
+        assert menu.actions()[0] is first
+        assert first.text() == "Plugin Manager..."
+
+    def test_reset_retires_the_outgoing_entries(self, im, pmm, app):
+        """Entries dropped by a reset are deleted, not left on the host."""
+        menu = QMenu()
+        pmm._reset_plugin_menu(menu)
+        stale = QAction("Stale", None)
+        menu.addAction(stale)
+
+        pmm._reset_plugin_menu(menu)
+        _drain_deferred_deletes(app)
+
+        with pytest.raises(RuntimeError):
+            stale.text()
+
+    def test_plugin_menu_subtree_is_retired_on_reset(self, im, pmm, app):
+        """Rebuilding the Plugin menu destroys its old submenus.
+
+        clear() deletes the actions a menu owns, but a submenu is a child
+        widget: dropping its menuAction leaves the QMenu behind, so every
+        reload used to strand another copy of each folder submenu.
+        """
+        _bar, plugin_menu = _menubar_with_plugin_menu(im)
+        im.host.plugin_manager.menu_actions = [_entry("Plugin/Nested/Item", "Item")]
+        im.host.plugin_manager.plugins = [_legacy_plugin("Filed", "Folder")]
+        im.host.plugin_manager.discover_plugins = MagicMock(
+            return_value=im.host.plugin_manager.plugins
+        )
+
+        counts = []
+        for _ in range(4):
+            pmm.update_plugin_menu(plugin_menu)
+            _drain_deferred_deletes(app)
+            counts.append(len(plugin_menu.findChildren(QMenu)))
+
+        assert _shape(plugin_menu) == [
+            "Plugin Manager...",
+            "sep",
+            "Nested/",
+            "sep",
+            "Folder/",
+        ]
+        assert counts == [2, 2, 2, 2], f"submenus stranded across reloads: {counts}"

--- a/tests/unit/test_template_fusing_preview.py
+++ b/tests/unit/test_template_fusing_preview.py
@@ -65,6 +65,9 @@ def test_update_template_preview_snaps_points_for_fusing(qapp):
 
     snapped_atom = MagicMock(spec=AtomItem)
     snapped_atom.pos.return_value = QPointF(0.0, 0.0)
+    snapped_atom.bonds = []  # spec=AtomItem misses instance attributes
+    snapped_atom.symbol = "C"
+    snapped_atom.charge = 0
     scene.items_returned = [snapped_atom]
 
     # Place an existing atom in the scene at (10.5, 0.5), which is close to point 1 (10.0, 0.0)


### PR DESCRIPTION
## Summary

<!-- What does this PR do? List the key changes in 2–4 bullet points. -->

Two independent areas, both found by using the app: the **Plugin menu** and the **2D template ghost**.

**Plugin menu**

- **Dividers landed in the wrong menu for nested paths.** The native/plugin divider was checked against the *deepest* menu in the path, which for `Tools/Sub/Item` was the freshly created (empty) leaf — so no divider appeared, and the next sibling entry then saw an untagged submenu as the last action and inserted the divider *after* the plugin submenu, splitting the plugin group instead of separating it from the native entries.
- **Reload flipped the menu.** `rebuild_plugin_menus` stripped only tagged actions, so untagged folder-derived entries survived and the re-added context-injected ones landed *after* them — turning `context > folder` into `folder > context` on every reload. Legacy `run()` entries were missing from the rebuild path entirely, so a reload never picked up a newly installed folder plugin.
- **New `pin="header"` on `add_menu_action`.** A plugin that manages the plugin system itself (the Plugin Installer) can ask to sit beside `Plugin Manager...` above the first divider. Granted only for a direct `Plugin/<entry>` path; other values are ignored, so unknown ones stay forward compatible.
- **Folder placement beats `PLUGIN_CATEGORY`.** Where the user filed a plugin is their decision; the declared category now applies only at the plugins root.
- **Cleanup retired nothing.** Menu entries are parented to the host and submenus are child widgets, so removal only detached them — measured 2 stranded `QMenu`s and 3 `QAction`s per Plugin Manager cycle.

**2D template ghost** — the preview disagreed with what placement would actually do:

- fusing benzene onto an existing ring drew a **phantom double** along every single bond it touched, because the rotation prefers safe connections over matching existing orders and placement then declines to apply it;
- even with the right order the ghost painted its own copy *over* the real bond, so fusing onto an existing double **read as a triple**;
- fusing onto naphthalene produced **hypervalent carbons** on 5 of its 10 rim bonds — a Kekulé ring always carries a double next to its fused bond, so fusing onto a single bond whose atoms each already hold a double hands one of them a fifth bond. Those bonds are added single instead, leaving the new carbons as methylene.

Resulting Plugin menu, identical on a fresh launch and after a reload:

```
Plugin Manager...
Plugin Installer...     ← pin="header"
─────────────
Injected                ← context.add_menu_action("Plugin/XXX")
─────────────
Folder ▸                ← folder-derived run() plugins
```

Also here: **Clear All** called `resetTransform()` (100%) while a fresh launch starts at 75%, so it came back zoomed in; both plugin clear paths now reclaim the menu bar, where an uninstalled plugin's top-level menu used to survive as an empty stub; and two GUI tests now wait on the 3D worker instead of a fixed delay.

## Type of change

<!-- Check all that apply. -->

- [x] Bug fix
- [x] New feature
- [x] Refactor / code cleanup
- [x] Documentation
- [x] Tests
- [ ] CI / build

## Related issues

<!-- Link any related issues, e.g. Closes #123 -->

None. Paired with HiroYokoyama/moleditpy-plugins@5091f5b, which makes the Plugin Installer request the header slot.

## Test plan

<!-- How did you verify the change works? -->

- [x] Ran `python tests/run_all_tests.py` — all pass (2306 passed, 1 skipped)
- [ ] Manually tested in the GUI with the check list
- [x] Added new unit tests

37 new tests. Every fix was verified by reverting it and confirming the matching tests fail.

| Area | Tests |
|---|---|
| Divider placement in nested menus | `TestPluginSeparatorPlacement` (4) |
| Menu-bar reclamation | `TestClearPluginMenubarEntries` (4) |
| Group order and divider | `TestPluginMenuComposition` (5) |
| `pin="header"` | `TestHeaderPin` (8) |
| Cleanup retiring its objects | `TestCleanupDoesNotStrandObjects` (5) |
| Category priority | 2 in `test_plugin_manager.py` |
| Ghost vs placement | 4 in `test_template_preview_in_editor.py` |
| Fused-ring valence | 12 in `test_fused_ring_valence.py` |
| Clear All zoom | `test_clear_all_restores_launch_zoom` |

Menu behaviour is pinned against real `QMenu`/`QMenuBar` objects rather than mocks, and the ghost-overlap test is behavioural — it renders a box on the shared bond and asserts the pixel count is unchanged with the ghost shown and hidden. The object-stranding tests drain `DeferredDelete` so `deleteLater` is actually observed.

Coverage 89.89% → 90.00%. `mypy` clean (69 files), `ruff check` clean, pylint 9.38/10 (unchanged).

Not verified in the GUI. Both areas are visual, so a manual pass over the Plugin menu and over benzene fusing would be worth doing before release.

## Checklist

- [x] `python -m flake8 moleditpy/src/ --select=F` returns 0 issues
- [x] No bare `except:` clauses added (use `except Exception as e:` and log the error)
- [x] No new unused imports or variables
- [x] Plugin API changes are backwards-compatible (or documented in Summary)

`PluginContext` gains an optional `pin` on `add_menu_action` / `add_plugin_menu`; existing calls are unaffected, and `register_menu_action` takes it last with a default so a V3-era caller reaching `PluginManager` directly keeps working. Two author-visible changes are documented in `PLUGIN_DEVELOPMENT_MANUAL_V4.md`:

- a `PLUGIN_CATEGORY` declared by a plugin filed inside a category folder no longer overrides that folder;
- passing `pin` to a MoleditPy older than 4.8.1 raises `TypeError` out of `initialize()`, which drops the plugin entirely rather than just misplacing it. The manual carries the try/except guard plugins need.

### Reviewer notes

- `add_molecule_fragment` no longer decides keep-or-overwrite in its bond loop; `_plan_template_bonds` owns that and the loop applies the plan. This is more than a spot fix, but the duplicated decision was exactly why the preview and the placement could disagree. `_should_overwrite_benzene_bond` is now policy input to the planner rather than a second decision point.
- One hypervalence case (fusing onto a bond whose atoms already carry three single bonds) also fails on `main`; it is fixed here rather than left, since the planner had to handle it anyway.
- Tagged plugin entries removed by `_strip_plugin_actions` are still only detached, as before. A plugin action can start a rebuild from its own handler — the Plugin Installer does — and deleting a signal's sender while it is on the stack is not safe. Stranding per cycle drops from 2 `QMenu`s + 3 `QAction`s to 0 and 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
